### PR TITLE
fix(release): harden ASC version parsing + add workflow_dispatch [skip=chrome]

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -4,6 +4,21 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      skip_chrome:
+        description: 'Skip Chrome Web Store upload'
+        type: boolean
+        default: true
+      skip_apple:
+        description: 'Skip Apple App Store upload'
+        type: boolean
+        default: false
+      bump:
+        description: 'Version bump'
+        type: choice
+        options: [patch, minor, major]
+        default: patch
 
 env:
   SAFARI_BUNDLE_ID: ${{ vars.SAFARI_BUNDLE_ID }}
@@ -18,8 +33,8 @@ jobs:
     defaults:
       run:
         working-directory: ${{ env.WORKING_DIRECTORY }}
-    # only run when a PR into main is merged
-    if: github.event.pull_request.merged == true
+    # run on PR-into-main merges OR manual dispatch
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -52,7 +67,9 @@ jobs:
   publish_chrome:
     name: "🚀 Publish to Chrome Web Store"
     needs: package
-    if: ${{ !contains(github.event.pull_request.title, 'skip=chrome') }}
+    if: |
+      (github.event_name == 'workflow_dispatch' && inputs.skip_chrome != true) ||
+      (github.event_name == 'pull_request'      && !contains(github.event.pull_request.title, 'skip=chrome'))
     runs-on: ubuntu-latest
     steps:
       - name: Download artifact
@@ -74,7 +91,9 @@ jobs:
   publish_safari:
     name: "🚀 Publish to Apple App Store (Safari & iOS)"
     needs: package
-    if: ${{ !contains(github.event.pull_request.title, 'skip=apple') }}
+    if: |
+      (github.event_name == 'workflow_dispatch' && inputs.skip_apple != true) ||
+      (github.event_name == 'pull_request'      && !contains(github.event.pull_request.title, 'skip=apple'))
     runs-on: macos-latest
     env:
       ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
@@ -129,12 +148,18 @@ jobs:
           ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
           SAFARI_BUNDLE_ID:   ${{ env.SAFARI_BUNDLE_ID }}
           PR_TITLE:           ${{ github.event.pull_request.title }}
+          INPUT_BUMP:         ${{ inputs.bump }}
+          EVENT_NAME:         ${{ github.event_name }}
         run: |
-          bump="patch"
-          title=$(echo "$PR_TITLE" | tr '[:upper:]' '[:lower:]')
-          [[ "$title" == *feature* ]] && bump="minor"
-          [[ "$title" == *major*   ]] && bump="major"
-          [[ "$title" == *fix*     ]] && bump="patch"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            bump="${INPUT_BUMP:-patch}"
+          else
+            bump="patch"
+            title=$(echo "$PR_TITLE" | tr '[:upper:]' '[:lower:]')
+            [[ "$title" == *feature* ]] && bump="minor"
+            [[ "$title" == *major*   ]] && bump="major"
+            [[ "$title" == *fix*     ]] && bump="patch"
+          fi
 
           mkdir -p private_keys
           echo "$ASC_API_KEY_BASE64" | base64 --decode > private_keys/AuthKey_$ASC_KEY_ID.p8
@@ -143,15 +168,21 @@ jobs:
           export APPSTORE_CONNECT_API_KEY="$(cat private_keys/AuthKey_${ASC_KEY_ID}.p8)"
 
           # --limit 50 is the max the ASC API allows for sub-resources
+          # No "|| true" — a silent failure here previously shipped version "..1" build "1".
           asc testflight builds list \
             --filter-bundle-ids "$SAFARI_BUNDLE_ID" \
             --include-expired --limit 50 \
             --api-key-id "$ASC_KEY_ID" \
             --api-issuer "$ASC_ISSUER_ID" \
-            --json > builds.json || true
+            --json > builds.json
 
           echo "=== RAW builds.json ==="
           cat builds.json
+
+          if ! jq -e 'type == "array" and length > 0' builds.json >/dev/null; then
+            echo "ERROR: asc returned no TestFlight builds. Aborting to avoid uploading a malformed version."
+            exit 1
+          fi
 
           mac_entry=$(jq '[.[] | select(.platform=="MAC_OS")] | sort_by(.buildNumber | tonumber) | .[-1]' builds.json)
           ios_entry=$(jq '[.[] | select(.platform=="IOS")]   | sort_by(.buildNumber | tonumber) | .[-1]' builds.json)
@@ -169,13 +200,29 @@ jobs:
             exit 1
           fi
 
-          MACOS_CURRENT_VERSION=$( echo "$mac_entry" | jq -r '.version      // "1.0.0"' )
-          MACOS_CURRENT_BUILD=$( echo "$mac_entry" | jq -r '.buildNumber // "1"' )
-          IOS_CURRENT_VERSION=$( echo "$ios_entry" | jq -r '.version      // "1.0.0"' )
-          IOS_CURRENT_BUILD=$( echo "$ios_entry" | jq -r '.buildNumber // "1"' )
+          # jq's `// "default"` only fires on null — empty strings sneak past it.
+          # Treat null OR empty as missing, then validate format hard.
+          MACOS_CURRENT_VERSION=$( echo "$mac_entry" | jq -r '(.version      // "") | select(. != "") // "1.0.0"' )
+          MACOS_CURRENT_BUILD=$(  echo "$mac_entry" | jq -r '(.buildNumber // "") | select(. != "") // "0"' )
+          IOS_CURRENT_VERSION=$(  echo "$ios_entry" | jq -r '(.version      // "") | select(. != "") // "1.0.0"' )
+          IOS_CURRENT_BUILD=$(    echo "$ios_entry" | jq -r '(.buildNumber // "") | select(. != "") // "0"' )
 
           echo "macOS current: $MACOS_CURRENT_VERSION ($MACOS_CURRENT_BUILD)"
           echo "iOS   current: $IOS_CURRENT_VERSION ($IOS_CURRENT_BUILD)"
+
+          SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+$'
+          NUM_RE='^[0-9]+$'
+          for pair in "macOS:$MACOS_CURRENT_VERSION:$MACOS_CURRENT_BUILD" "iOS:$IOS_CURRENT_VERSION:$IOS_CURRENT_BUILD"; do
+            IFS=':' read -r plat ver bld <<< "$pair"
+            if ! [[ "$ver" =~ $SEMVER_RE ]]; then
+              echo "ERROR: $plat version '$ver' is not X.Y.Z. Aborting to avoid uploading a malformed CFBundleShortVersionString."
+              exit 1
+            fi
+            if ! [[ "$bld" =~ $NUM_RE ]]; then
+              echo "ERROR: $plat build number '$bld' is not numeric. Aborting."
+              exit 1
+            fi
+          done
 
           IFS='.' read -r major minor patch <<< "$MACOS_CURRENT_VERSION"
           case "$bump" in


### PR DESCRIPTION
Fixes the 'silent malformed version' bug from PR #104 release run, and adds a one-click manual trigger.

## Bug fixed
PR #104's Apple upload step said success but actually shipped MARKETING_VERSION=`..1` CURRENT_PROJECT_VERSION=`1` because:
- `asc testflight builds list ... || true` swallowed an empty/failed response
- jq's `// "1.0.0"` fallback only triggers on null, not empty string
- The 'type == null' guard didn't catch empty-string fields
- Bash arithmetic on empty values produced `..1` / `1`

App Store Connect rejected those uploads asynchronously, which is why no new build appeared in TestFlight.

## Changes
- Drop `|| true` on `asc` call — fail loudly
- Validate builds.json is a non-empty array before parsing
- Treat null OR empty as missing in jq fallbacks
- Hard regex validation: version must match `^[0-9]+\.[0-9]+\.[0-9]+$`, build must match `^[0-9]+$`, else abort
- Add `workflow_dispatch` trigger with inputs (skip_chrome default true, skip_apple default false, bump default patch) — one-click release from Actions tab

## Trigger
Merging this PR will fire the workflow with chrome skipped (Apple only).