### PR TITLE
feat(landing): hero stats as three same-size 3D coupon models

### DIFF
--- a/apps/caramel-app/src/components/HeroSection.tsx
+++ b/apps/caramel-app/src/components/HeroSection.tsx
@@ -17,6 +17,7 @@
 // scrolled out of view via an IntersectionObserver.
 
 import { ThemeContext } from '@/lib/contexts'
+import { formatStat, HERO_STATS, useCountUp } from '@/lib/heroStats'
 import { ticketNotchMask } from '@/lib/ticketMask'
 import { detectWebGL } from '@/lib/webglSupport'
 import { motion, useReducedMotion } from 'framer-motion'
@@ -68,103 +69,24 @@ function HeroTicketPoster(): React.JSX.Element {
     )
 }
 
-// The three hero stats, rendered as caramel coupon-ticket cards (shared
-// ticketNotchMask) at three deliberately different sizes and slight tilts so
-// they read as a scattered little stack under the 3D model. Each counts its
-// number up from 0 on first paint. This REPLACES the old inline stat row in
-// the left column.
-const STATS: {
-    value: number
-    suffix: string
-    label: string
-    format?: 'comma'
-    size: 'lg' | 'md' | 'sm'
-    tilt: string
-}[] = [
-    {
-        value: 5000,
-        suffix: '+',
-        label: 'Supported Stores',
-        format: 'comma',
-        size: 'lg',
-        tilt: '-rotate-3',
-    },
-    {
-        value: 100,
-        suffix: '%',
-        label: 'Open Source',
-        size: 'md',
-        tilt: 'rotate-2',
-    },
-    {
-        value: 0,
-        suffix: '%',
-        label: 'Data Selling',
-        size: 'sm',
-        tilt: '-rotate-2',
-    },
-]
-
-const STAT_SIZE: Record<
-    'lg' | 'md' | 'sm',
-    { pad: string; num: string; label: string }
-> = {
-    lg: { pad: 'px-6 py-5', num: 'text-4xl md:text-3xl', label: 'text-xs' },
-    md: {
-        pad: 'px-5 py-4',
-        num: 'text-3xl md:text-2xl',
-        label: 'text-[0.7rem]',
-    },
-    sm: {
-        pad: 'px-4 py-3.5',
-        num: 'text-2xl md:text-xl',
-        label: 'text-[0.65rem]',
-    },
-}
-
-// Count a value up from 0 to `target` with an easeOutCubic ramp, once `start`
-// flips true (first paint). reduced-motion / SSR shows the final value with no
-// animation. rAF math runs only in the effect, never during render.
-function useCountUp(target: number, start: boolean, reduce: boolean): number {
-    const [val, setVal] = useState(reduce ? target : 0)
-    useEffect(() => {
-        if (!start) return
-        if (reduce) {
-            setVal(target)
-            return
-        }
-        let raf = 0
-        const duration = 1200
-        const t0 = performance.now()
-        const tick = (now: number): void => {
-            const p = Math.min(1, (now - t0) / duration)
-            const eased = 1 - Math.pow(1 - p, 3)
-            setVal(target * eased)
-            if (p < 1) raf = requestAnimationFrame(tick)
-            else setVal(target)
-        }
-        raf = requestAnimationFrame(tick)
-        return () => cancelAnimationFrame(raf)
-    }, [target, start, reduce])
-    return val
-}
-
-function StatCoupon({
+// DOM fallback for the three hero stats, rendered as caramel coupon-ticket
+// cards (shared ticketNotchMask), ALL THE SAME SIZE, each counting its number
+// up from 0 on first paint. The primary presentation on desktop is now the 3D
+// stat coupons inside HeroTicketScene; these DOM cards are the stand-in shown
+// on mobile / reduced-motion / no-WebGL (and briefly under the canvas while its
+// chunk loads), sharing the same HERO_STATS data so the two never drift.
+function StatCard({
     stat,
     index,
     start,
     reduce,
 }: {
-    stat: (typeof STATS)[number]
+    stat: (typeof HERO_STATS)[number]
     index: number
     start: boolean
     reduce: boolean
 }): React.JSX.Element {
     const n = useCountUp(stat.value, start, reduce)
-    const rounded = Math.round(n)
-    const shown =
-        stat.format === 'comma' ? rounded.toLocaleString('en-US') : `${rounded}`
-    const size = STAT_SIZE[stat.size]
     return (
         <motion.div
             initial={
@@ -177,21 +99,39 @@ function StatCoupon({
                 ease: revealEase,
             }}
             whileHover={reduce ? undefined : { y: -4, scale: 1.03 }}
-            className={`relative ${stat.tilt} ${size.pad} rounded-2xl bg-gradient-to-br from-caramel to-orange-600 text-white shadow-caramel-lg`}
+            className="relative w-32 rounded-2xl bg-gradient-to-br from-caramel to-orange-600 px-5 py-4 text-white shadow-caramel-lg md:w-28"
             style={ticketNotchMask('0.55rem', '50%')}
         >
-            <div
-                className={`font-extrabold leading-none tracking-tight ${size.num}`}
-            >
-                {shown}
-                {stat.suffix}
+            <div className="text-3xl font-extrabold leading-none tracking-tight md:text-2xl">
+                {formatStat(n, stat)}
             </div>
-            <div
-                className={`mt-1.5 font-medium uppercase tracking-wide text-white/85 ${size.label}`}
-            >
+            <div className="mt-1.5 text-[0.7rem] font-medium uppercase tracking-wide text-white/85">
                 {stat.label}
             </div>
         </motion.div>
+    )
+}
+
+// A centered row of the three uniform stat cards (DOM fallback).
+function StatCards({
+    start,
+    reduce,
+}: {
+    start: boolean
+    reduce: boolean
+}): React.JSX.Element {
+    return (
+        <div className="flex flex-wrap items-stretch justify-center gap-3">
+            {HERO_STATS.map((stat, index) => (
+                <StatCard
+                    key={stat.label}
+                    stat={stat}
+                    index={index}
+                    start={start}
+                    reduce={reduce}
+                />
+            ))}
+        </div>
     )
 }
 
@@ -524,26 +464,37 @@ export default function HeroSection() {
                     </motion.div>
                 </div>
 
-                {/* RIGHT column: the interactive 3D coupon (desktop-only) with
-                    the three stat coupons beneath it. Below lg the parent goes
-                    single-column and the WebGL box is hidden (lg:hidden) so
-                    phones never mount three — but the stat coupons stay visible,
-                    reflowing under the copy (they carry the stats that used to
-                    live in the left column). */}
-                <div className="relative flex w-[45%] flex-col items-center gap-8 lg:w-full">
-                    {/* 3D model box: reserved up front; the live canvas
-                        cross-fades in over the poster, so there is zero CLS. */}
-                    <div className="relative h-[26rem] w-full lg:hidden">
+                {/* RIGHT column: on desktop, ONE interactive WebGL box holds
+                    the main 3D coupon AND the row of three same-size 3D stat
+                    coupons beneath it. A poster + the DOM stat cards cross-fade
+                    underneath until the canvas is ready — and stay as the
+                    permanent presentation for reduced-motion / no-WebGL desktop.
+                    Below lg the box is hidden (phones never mount three) and the
+                    DOM stat cards render in normal flow under the copy. */}
+                <div className="relative flex w-[45%] flex-col items-center lg:w-full">
+                    {/* DESKTOP 3D box: reserved up front; the live canvas
+                        cross-fades in over the fallback, so there is zero CLS. */}
+                    <div className="relative h-[34rem] w-full lg:hidden">
                         <div
-                            aria-hidden="true"
-                            className="absolute inset-0 transition-opacity duration-700 ease-out"
-                            style={{ opacity: canvasReady ? 0 : 1 }}
+                            className="absolute inset-0 flex flex-col justify-between transition-opacity duration-700 ease-out"
+                            style={{
+                                opacity: canvasReady ? 0 : 1,
+                                pointerEvents: canvasReady ? 'none' : undefined,
+                            }}
                         >
-                            <HeroTicketPoster />
+                            <div
+                                aria-hidden="true"
+                                className="relative h-[22rem] w-full"
+                            >
+                                <HeroTicketPoster />
+                            </div>
+                            <StatCards
+                                start={statsStarted}
+                                reduce={!!reduceMotion}
+                            />
                         </div>
                         {showCanvas && (
                             <div
-                                aria-hidden="true"
                                 className="absolute inset-0 transition-opacity duration-700 ease-out"
                                 style={{ opacity: canvasReady ? 1 : 0 }}
                             >
@@ -556,17 +507,13 @@ export default function HeroSection() {
                         )}
                     </div>
 
-                    {/* Stat coupons — three sizes, count up on load. */}
-                    <div className="flex flex-wrap items-end justify-center gap-3">
-                        {STATS.map((stat, index) => (
-                            <StatCoupon
-                                key={stat.label}
-                                stat={stat}
-                                index={index}
-                                start={statsStarted}
-                                reduce={!!reduceMotion}
-                            />
-                        ))}
+                    {/* MOBILE stats: the DOM stat cards in normal flow (the 3D
+                        box above is hidden below lg). */}
+                    <div className="hidden w-full lg:flex lg:justify-center">
+                        <StatCards
+                            start={statsStarted}
+                            reduce={!!reduceMotion}
+                        />
                     </div>
                 </div>
             </div>

--- a/apps/caramel-app/src/components/HeroTicketScene.tsx
+++ b/apps/caramel-app/src/components/HeroTicketScene.tsx
@@ -1,22 +1,33 @@
 'use client'
 
 // HeroTicketScene — the compact WebGL half of the split hero (right column,
-// desktop/lg+ only). Same ticket visual language as CouponVaultScene (it
-// shares the ./couponTicket3d geometry + palette) but deliberately LIGHT: a
-// single main ticket with springy mouse-parallax tilt + Float, a handful of
-// instanced droplets, low-count Sparkles, and a one-frame Lightformer
-// environment. No ContactShadows and no scroll dolly — the hero doesn't
-// scroll-drive. Loaded via next/dynamic ssr:false and only mounted after the
-// browser is idle + a real WebGL context + a lg+ viewport (HeroSection gates
-// all of that), so the `three` chunk never touches phones or first paint.
+// desktop/lg+ only). Same ticket visual language as the shared ./couponTicket3d
+// geometry + palette, deliberately LIGHT: one big main ticket with springy
+// mouse-parallax tilt + Float, PLUS a row of THREE same-size 3D stat coupons
+// beneath it (each a real ticket mesh whose number counts up on load via a drei
+// <Html> billboard label), a handful of instanced droplets, low-count Sparkles,
+// and a one-frame Lightformer environment. No ContactShadows and no scroll
+// dolly — the hero doesn't scroll-drive. Loaded via next/dynamic ssr:false and
+// only mounted after the browser is idle + a real WebGL context + a lg+ viewport
+// (HeroSection gates all of that), so the `three` chunk never touches phones or
+// first paint. Below lg / reduced-motion / no-WebGL the stats fall back to DOM
+// coupon cards in HeroSection (shared HERO_STATS data).
 //
 // Perf posture (brief "not heavy"): DPR clamped [1, 1.5]; frameloop gated by
 // the `active` prop (parent IntersectionObserver → 'never' when the hero is
-// scrolled out of view); the ticket geometry is built once (memoized) and is
-// the SAME codepath as the vault scene; droplets are ONE instanced mesh
-// (≤10); the environment + emblem ship no external asset / network fetch.
+// scrolled out of view); every ticket geometry is built once (memoized) and the
+// three stat coupons SHARE one geometry; droplets are ONE instanced mesh (≤10);
+// the environment + emblem ship no external asset / network fetch; the <Html>
+// labels are three small billboards, count-up runs only ~1.2s after mount.
 
-import { Environment, Float, Lightformer, Sparkles } from '@react-three/drei'
+import { formatStat, HERO_STATS, useCountUp } from '@/lib/heroStats'
+import {
+    Environment,
+    Float,
+    Html,
+    Lightformer,
+    Sparkles,
+} from '@react-three/drei'
 import { Canvas, useFrame, useThree } from '@react-three/fiber'
 import { useMemo, useRef } from 'react'
 import * as THREE from 'three'
@@ -42,6 +53,30 @@ const CARD = {
 }
 const CARD_FRONT = CARD.depth / 2 + CARD.bevel
 
+// The three stat coupons — deliberately ALL THE SAME SIZE (a uniform row reads
+// cleaner than mixed sizes). Shared geometry, laid out in a row below the main
+// ticket. Front-face Z (post-center) is depth/2 + bevel; the <Html> label sits
+// just proud of it.
+const STAT = {
+    w: 1.7,
+    h: 1.15,
+    cr: 0.15,
+    nr: 0.14,
+    ny: 0,
+    depth: 0.24,
+    bevel: 0.035,
+}
+const STAT_FRONT = STAT.depth / 2 + STAT.bevel
+const STAT_Y = -1.55
+const STAT_X = [-2.15, 0, 2.15]
+const MAIN_Y = 1.4
+
+// Content bounds of the main + stat group (world units, pre-fit) used to scale
+// the group so nothing clips the narrow hero column. Kept as consts so the fit
+// math stays readable.
+const CONTENT_HALF_W = 3.0
+const CONTENT_HALF_H = 2.4
+
 // A small drifting caramel field — one instanced mesh, ≤10 spheres.
 const DROPLET_COUNT = 10
 
@@ -62,7 +97,7 @@ const DROPLET_DATA: DropletDatum[] = Array.from(
     () => ({
         origin: new THREE.Vector3(
             (Math.random() - 0.5) * 7,
-            (Math.random() - 0.5) * 5,
+            (Math.random() - 0.5) * 6,
             (Math.random() - 0.5) * 4 - 1,
         ),
         speed: 0.2 + Math.random() * 0.5,
@@ -80,6 +115,32 @@ export interface HeroTicketSceneProps {
     // Fires once the GL context is created so the parent can cross-fade the
     // poster out from under the canvas.
     onReady?: () => void
+}
+
+// Shared caramel-glass material for every ticket (main + stats) so they read as
+// one family. Slightly tuned per theme.
+function TicketMaterial({ isDark }: { isDark: boolean }): React.JSX.Element {
+    return (
+        <meshPhysicalMaterial
+            color={isDark ? CARAMEL_DEEP : CARAMEL}
+            metalness={0.2}
+            roughness={0.1}
+            clearcoat={1}
+            clearcoatRoughness={0.06}
+            transmission={0.28}
+            thickness={1.4}
+            ior={1.45}
+            sheen={0.6}
+            sheenColor={CARAMEL_LIGHT}
+            sheenRoughness={0.4}
+            iridescence={0.18}
+            iridescenceIOR={1.3}
+            emissive={CARAMEL}
+            emissiveIntensity={isDark ? 0.3 : 0.12}
+            attenuationColor={CARAMEL_LIGHT}
+            attenuationDistance={2.2}
+        />
+    )
 }
 
 function HeroCard({ isDark }: { isDark: boolean }): React.JSX.Element {
@@ -124,25 +185,7 @@ function HeroCard({ isDark }: { isDark: boolean }): React.JSX.Element {
         <Float speed={2} rotationIntensity={0.25} floatIntensity={0.45}>
             <group ref={groupRef}>
                 <mesh geometry={geometry} castShadow receiveShadow>
-                    <meshPhysicalMaterial
-                        color={isDark ? CARAMEL_DEEP : CARAMEL}
-                        metalness={0.2}
-                        roughness={0.1}
-                        clearcoat={1}
-                        clearcoatRoughness={0.06}
-                        transmission={0.28}
-                        thickness={1.4}
-                        ior={1.45}
-                        sheen={0.6}
-                        sheenColor={CARAMEL_LIGHT}
-                        sheenRoughness={0.4}
-                        iridescence={0.18}
-                        iridescenceIOR={1.3}
-                        emissive={CARAMEL}
-                        emissiveIntensity={isDark ? 0.3 : 0.12}
-                        attenuationColor={CARAMEL_LIGHT}
-                        attenuationDistance={2.2}
-                    />
+                    <TicketMaterial isDark={isDark} />
                 </mesh>
                 <Perforation
                     width={CARD.w - CARD.nr * 2 - 0.1}
@@ -155,6 +198,91 @@ function HeroCard({ isDark }: { isDark: boolean }): React.JSX.Element {
                 <PercentEmblem isDark={isDark} frontZ={CARD_FRONT} />
             </group>
         </Float>
+    )
+}
+
+// One 3D stat coupon: a real caramel-glass ticket mesh (shared geometry) with a
+// billboarded <Html> label whose number counts up from 0 on mount. `center` +
+// no `transform` keeps the label upright and crisp even while the coupon floats.
+function StatCoupon3D({
+    geometry,
+    position,
+    stat,
+    isDark,
+}: {
+    geometry: THREE.ExtrudeGeometry
+    position: [number, number, number]
+    stat: (typeof HERO_STATS)[number]
+    isDark: boolean
+}): React.JSX.Element {
+    // The scene only ever mounts when motion is allowed (HeroSection gates it),
+    // so count-up always animates here — start=true, reduce=false.
+    const n = useCountUp(stat.value, true, false)
+    const shown = formatStat(n, stat)
+    return (
+        <Float speed={1.6} rotationIntensity={0.12} floatIntensity={0.3}>
+            <group position={position}>
+                <mesh geometry={geometry} castShadow receiveShadow>
+                    <TicketMaterial isDark={isDark} />
+                </mesh>
+                <Perforation
+                    width={STAT.w - STAT.nr * 2 - 0.06}
+                    y={STAT.ny}
+                    z={STAT_FRONT + 0.015}
+                    count={9}
+                    dash={0.05}
+                    color={isDark ? CARAMEL_LIGHT : '#fff2e6'}
+                />
+                {/* Fixed-size billboard label (no distanceFactor) so the text
+                    stays crisp and sized to sit ON the coupon face — the hero
+                    container is max-w capped, so the coupon's on-screen size is
+                    effectively constant across desktop widths. */}
+                <Html
+                    center
+                    position={[0, 0, STAT_FRONT + 0.04]}
+                    zIndexRange={[10, 0]}
+                >
+                    <div className="pointer-events-none w-24 select-none text-center leading-none text-white">
+                        <div className="text-2xl font-extrabold tracking-tight drop-shadow-[0_2px_5px_rgba(120,50,0,0.55)]">
+                            {shown}
+                        </div>
+                        <div className="mt-1.5 text-[0.55rem] font-semibold uppercase tracking-wide text-white/90 drop-shadow-[0_1px_2px_rgba(120,50,0,0.5)]">
+                            {stat.label}
+                        </div>
+                    </div>
+                </Html>
+            </group>
+        </Float>
+    )
+}
+
+function StatCoupons({ isDark }: { isDark: boolean }): React.JSX.Element {
+    // ONE geometry shared by all three coupons (they're the same size).
+    const geometry = useMemo(
+        () =>
+            makeTicketGeometry(
+                STAT.w,
+                STAT.h,
+                STAT.cr,
+                STAT.nr,
+                STAT.ny,
+                STAT.depth,
+                STAT.bevel,
+            ),
+        [],
+    )
+    return (
+        <>
+            {HERO_STATS.map((stat, i) => (
+                <StatCoupon3D
+                    key={stat.label}
+                    geometry={geometry}
+                    position={[STAT_X[i], STAT_Y, 0]}
+                    stat={stat}
+                    isDark={isDark}
+                />
+            ))}
+        </>
     )
 }
 
@@ -209,12 +337,19 @@ function Droplets({ isDark }: { isDark: boolean }): React.JSX.Element {
 }
 
 function SceneContents({ isDark }: { isDark: boolean }): React.JSX.Element {
-    // The vertical FOV keeps world height constant, so on the narrower hero
-    // column the 3.1u-wide card can overflow the horizontal frustum — scale the
-    // ticket group down to fit. Reactive to resize via R3F size state; no
-    // per-frame camera work (the hero never scroll-drives the camera).
+    // The vertical FOV keeps world height constant, so on the narrow hero column
+    // the main ticket + the stat-coupon row can overflow the frustum — scale the
+    // whole ticket group down to fit both dimensions (with a small margin).
+    // Reactive to resize via R3F size state; no per-frame camera work.
     const aspect = useThree(state => state.size.width / state.size.height)
-    const fit = Math.min(1, aspect / 0.85)
+    const dist = 7
+    const halfH = Math.tan((42 * Math.PI) / 180 / 2) * dist
+    const halfW = halfH * aspect
+    const fit = Math.min(
+        1,
+        (halfW * 0.94) / CONTENT_HALF_W,
+        (halfH * 0.94) / CONTENT_HALF_H,
+    )
 
     return (
         <>
@@ -232,13 +367,16 @@ function SceneContents({ isDark }: { isDark: boolean }): React.JSX.Element {
             />
 
             <group scale={fit}>
-                <HeroCard isDark={isDark} />
+                <group position={[0, MAIN_Y, 0]}>
+                    <HeroCard isDark={isDark} />
+                </group>
+                <StatCoupons isDark={isDark} />
             </group>
             <Droplets isDark={isDark} />
 
             <Sparkles
                 count={16}
-                scale={[7, 5, 4]}
+                scale={[7, 6, 4]}
                 size={2.2}
                 speed={0.3}
                 opacity={isDark ? 0.7 : 0.45}
@@ -283,7 +421,7 @@ export default function HeroTicketScene({
             className="h-full w-full"
             dpr={[1, 1.5]}
             frameloop={active ? 'always' : 'never'}
-            camera={{ position: [0, 0.2, 6.5], fov: 38 }}
+            camera={{ position: [0, 0, 7], fov: 42 }}
             gl={{
                 alpha: true,
                 antialias: true,

--- a/apps/caramel-app/src/lib/heroStats.ts
+++ b/apps/caramel-app/src/lib/heroStats.ts
@@ -1,0 +1,60 @@
+// heroStats — the three hero stats plus the count-up hook, shared by BOTH the
+// 3D stat coupons (HeroTicketScene, rendered in WebGL on desktop) and the DOM
+// stat-card fallback (HeroSection, shown on mobile / reduced-motion / no-WebGL)
+// so the numbers, labels and animation stay in ONE place. No `three` import
+// here — safe to pull into the main bundle via the DOM fallback.
+
+import { useEffect, useState } from 'react'
+
+export interface HeroStat {
+    value: number
+    suffix: string
+    label: string
+    format?: 'comma'
+}
+
+// Same size for all three (deliberate — a uniform row reads cleaner than mixed
+// sizes). Order = left→right / first→last.
+export const HERO_STATS: HeroStat[] = [
+    { value: 5000, suffix: '+', label: 'Supported Stores', format: 'comma' },
+    { value: 100, suffix: '%', label: 'Open Source' },
+    { value: 0, suffix: '%', label: 'Data Selling' },
+]
+
+export function formatStat(value: number, stat: HeroStat): string {
+    const rounded = Math.round(value)
+    const num =
+        stat.format === 'comma' ? rounded.toLocaleString('en-US') : `${rounded}`
+    return `${num}${stat.suffix}`
+}
+
+// Count a value up from 0 to `target` with an easeOutCubic ramp once `start`
+// flips true (first paint). reduced-motion / SSR shows the final value with no
+// animation. rAF math runs only inside the effect, never during render.
+export function useCountUp(
+    target: number,
+    start: boolean,
+    reduce: boolean,
+): number {
+    const [val, setVal] = useState(reduce ? target : 0)
+    useEffect(() => {
+        if (!start) return
+        if (reduce) {
+            setVal(target)
+            return
+        }
+        let raf = 0
+        const duration = 1200
+        const t0 = performance.now()
+        const tick = (now: number): void => {
+            const p = Math.min(1, (now - t0) / duration)
+            const eased = 1 - Math.pow(1 - p, 3)
+            setVal(target * eased)
+            if (p < 1) raf = requestAnimationFrame(tick)
+            else setVal(target)
+        }
+        raf = requestAnimationFrame(tick)
+        return () => cancelAnimationFrame(raf)
+    }, [target, start, reduce])
+    return val
+}


### PR DESCRIPTION
Reworks the three hero stats from DOM cards into **three same-size 3D coupon models** in the hero WebGL scene (feedback round 2).

## What changed
- **New `src/lib/heroStats.ts`** — single source of truth for the three stats (`HERO_STATS`), the `formatStat` helper, and the `useCountUp` hook. No `three` import, so it's safe in the main bundle. Consumed by both the 3D scene and the DOM fallback so the two never drift.
- **`HeroTicketScene.tsx`** — adds a row of three **same-size** 3D caramel-ticket coupons beneath the main model (shared geometry + material family), each with a billboarded drei `<Html>` label whose number counts up on mount. Group auto-fits the narrow hero column.
- **`HeroSection.tsx`** — the DOM stat cards are now uniform-size and serve as the fallback (mobile / reduced-motion / no-WebGL), cross-fading under the canvas on desktop.

## Verified (local, real browser)
- **Desktop light + dark**: main coupon + three same-size 3D stat coupons, labels fit on the coupon face, count-up runs, scene retints per theme.
- **Mobile (390px)**: no canvas mounts; DOM fallback shows the three uniform stat cards.
- Gates green: `tsc`, oxlint, eslint, prettier, knip, three-lazy-boundary test, full unit suite (406 tests).

Dev only — no prod changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)