### PR TITLE
feat(landing): modernize below-hero — hover depth, ticket motif, video facade, warm dark surfaces, footer, nav fixes

### DIFF
--- a/apps/caramel-app/next.config.mjs
+++ b/apps/caramel-app/next.config.mjs
@@ -57,6 +57,15 @@ const nextConfig = {
                 port: '',
                 pathname: '/s2/favicons/**',
             },
+            // YouTube video thumbnails, used by the click-to-load video facade
+            // in WhyNot.tsx so no YouTube iframe (and no YouTube cookie) loads
+            // until the visitor actually asks for the video.
+            {
+                protocol: 'https',
+                hostname: 'i.ytimg.com',
+                port: '',
+                pathname: '/vi/**',
+            },
         ],
     },
     async headers() {

--- a/apps/caramel-app/src/components/FeaturesSection.tsx
+++ b/apps/caramel-app/src/components/FeaturesSection.tsx
@@ -144,102 +144,111 @@ export default function FeaturesSection() {
                                     stiffness: 100,
                                     damping: 15,
                                 }}
-                                whileHover={{
-                                    scale: 1.02,
-                                    y: -5,
-                                    boxShadow:
-                                        '0 20px 40px rgba(234,105,37,0.15)',
-                                    transition: { duration: 0.2 },
-                                }}
-                                className="group relative overflow-hidden rounded-2xl border border-caramel/20 bg-gradient-to-br from-caramel/5 via-orange-50/30 to-caramel/5 p-8 shadow-md transition-colors duration-300 hover:border-caramel/40 dark:border-caramel/30 dark:from-caramel/10 dark:via-orange-900/20 dark:to-caramel/10 dark:hover:border-caramel/50 sm:p-6"
                             >
-                                {/* Animated Background Pattern */}
-                                <div
-                                    aria-hidden="true"
-                                    className="absolute inset-0 opacity-5"
-                                >
-                                    <motion.div
-                                        className="h-full w-full"
-                                        style={{
-                                            backgroundImage: `
+                                {/* The entrance animation and the card chrome
+                                    are deliberately on separate elements:
+                                    framer leaves an inline `transform: none` on
+                                    anything it animates, which would outrank
+                                    the hover-lift class. */}
+                                <div className="group relative h-full overflow-hidden rounded-2xl border border-caramel/20 bg-gradient-to-br from-caramel/5 via-orange-50/30 to-caramel/5 p-8 shadow-md transition-all duration-300 hover:-translate-y-1 hover:border-caramel/60 hover:shadow-[0_12px_32px_-8px_rgba(234,105,37,0.35)] dark:border-caramel/30 dark:from-caramel/10 dark:via-orange-900/20 dark:to-caramel/10 sm:p-6">
+                                    {/* Animated Background Pattern */}
+                                    <div
+                                        aria-hidden="true"
+                                        className="absolute inset-0 opacity-5"
+                                    >
+                                        <motion.div
+                                            className="h-full w-full"
+                                            style={{
+                                                backgroundImage: `
                                                 linear-gradient(90deg, #ea6925 1px, transparent 1px),
                                                 linear-gradient(#ea6925 1px, transparent 1px)
                                             `,
-                                            backgroundSize: '20px 20px',
-                                        }}
-                                        animate={
-                                            reduceMotion
-                                                ? undefined
-                                                : {
-                                                      backgroundPosition: [
-                                                          '0px 0px',
-                                                          '20px 20px',
-                                                          '0px 0px',
-                                                      ],
-                                                  }
-                                        }
-                                        transition={{
-                                            duration: 8,
-                                            repeat: Infinity,
-                                            ease: 'linear',
-                                            repeatType: 'loop',
-                                        }}
-                                    />
-                                </div>
-
-                                <div className="relative z-10 text-center">
-                                    {/* Large icon - hidden on lg and down */}
-                                    <motion.div
-                                        aria-hidden="true"
-                                        className="mx-auto mb-6 text-6xl text-caramel transition-transform duration-300 xl:block lg:hidden"
-                                        animate={
-                                            reduceMotion
-                                                ? undefined
-                                                : {
-                                                      rotate: [0, 2, -2, 0],
-                                                      scale: [1, 1.02, 1],
-                                                  }
-                                        }
-                                        transition={{
-                                            duration: 4,
-                                            repeat: Infinity,
-                                            ease: 'easeInOut',
-                                            repeatType: 'loop',
-                                        }}
-                                        whileHover={{ scale: 1.1 }}
-                                    >
-                                        {feat.icon}
-                                    </motion.div>
-
-                                    {/* Mobile layout - icon + title in one row */}
-                                    <div className="hidden text-left lg:block">
-                                        <div className="mb-3 flex items-center">
-                                            <span
-                                                aria-hidden="true"
-                                                className="mr-3 flex-shrink-0 text-2xl text-caramel"
-                                            >
-                                                {feat.icon}
-                                            </span>
-                                            <h3 className="text-2xl font-bold tracking-tight text-gray-800 dark:text-white sm:text-xl">
-                                                {feat.title}
-                                            </h3>
-                                        </div>
-                                        <p className="ml-11 text-base leading-relaxed text-gray-600 dark:text-gray-400 sm:text-sm">
-                                            {feat.desc}
-                                        </p>
+                                                backgroundSize: '20px 20px',
+                                            }}
+                                            animate={
+                                                reduceMotion
+                                                    ? undefined
+                                                    : {
+                                                          backgroundPosition: [
+                                                              '0px 0px',
+                                                              '20px 20px',
+                                                              '0px 0px',
+                                                          ],
+                                                      }
+                                            }
+                                            transition={{
+                                                duration: 8,
+                                                repeat: Infinity,
+                                                ease: 'linear',
+                                                repeatType: 'loop',
+                                            }}
+                                        />
                                     </div>
 
-                                    {/* Desktop layout - original centered layout */}
-                                    <div className="xl:block lg:hidden">
-                                        <h3 className="mb-4 text-3xl font-bold tracking-tight text-gray-800 dark:text-white sm:text-2xl">
-                                            {feat.title}
-                                        </h3>
-                                        <p className="mb-4 text-lg leading-relaxed text-gray-600 dark:text-gray-400 sm:text-base">
-                                            {feat.desc}
-                                        </p>
-                                        <p className="text-sm leading-relaxed text-gray-500 dark:text-gray-400 sm:text-xs">
-                                            {feat.detail}
-                                        </p>
+                                    <div className="relative z-10 text-center">
+                                        {/* Large icon - hidden on lg and down. The
+                                        card-hover scale lives on this wrapper
+                                        because the inner element's ambient
+                                        framer animation owns its inline
+                                        transform; nesting lets both compose. */}
+                                        <div
+                                            aria-hidden="true"
+                                            className="mx-auto mb-6 text-6xl text-caramel transition-transform duration-300 group-hover:scale-110 xl:block lg:hidden"
+                                        >
+                                            <motion.div
+                                                animate={
+                                                    reduceMotion
+                                                        ? undefined
+                                                        : {
+                                                              rotate: [
+                                                                  0, 2, -2, 0,
+                                                              ],
+                                                              scale: [
+                                                                  1, 1.02, 1,
+                                                              ],
+                                                          }
+                                                }
+                                                transition={{
+                                                    duration: 4,
+                                                    repeat: Infinity,
+                                                    ease: 'easeInOut',
+                                                    repeatType: 'loop',
+                                                }}
+                                            >
+                                                {feat.icon}
+                                            </motion.div>
+                                        </div>
+
+                                        {/* Mobile layout - icon + title in one row */}
+                                        <div className="hidden text-left lg:block">
+                                            <div className="mb-3 flex items-center">
+                                                <span
+                                                    aria-hidden="true"
+                                                    className="mr-3 flex-shrink-0 text-2xl text-caramel transition-transform duration-300 group-hover:scale-110"
+                                                >
+                                                    {feat.icon}
+                                                </span>
+                                                <h3 className="text-2xl font-bold tracking-tight text-gray-800 dark:text-white sm:text-xl">
+                                                    {feat.title}
+                                                </h3>
+                                            </div>
+                                            <p className="ml-11 text-base leading-relaxed text-gray-600 dark:text-gray-400 sm:text-sm">
+                                                {feat.desc}
+                                            </p>
+                                        </div>
+
+                                        {/* Desktop layout - original centered layout */}
+                                        <div className="xl:block lg:hidden">
+                                            <h3 className="mb-4 text-3xl font-bold tracking-tight text-gray-800 dark:text-white sm:text-2xl">
+                                                {feat.title}
+                                            </h3>
+                                            <p className="mb-4 text-lg leading-relaxed text-gray-600 dark:text-gray-400 sm:text-base">
+                                                {feat.desc}
+                                            </p>
+                                            <p className="text-sm leading-relaxed text-gray-500 dark:text-gray-400 sm:text-xs">
+                                                {feat.detail}
+                                            </p>
+                                        </div>
                                     </div>
                                 </div>
                             </motion.div>
@@ -265,77 +274,97 @@ export default function FeaturesSection() {
                         </p>
                     </div>
 
-                    <div className="mx-auto max-w-4xl space-y-4">
-                        {comparisonItems.map((item, index) => (
-                            <motion.div
-                                key={item.title}
-                                initial={
-                                    reduceMotion
-                                        ? { opacity: 0 }
-                                        : { opacity: 0, y: 10 }
-                                }
-                                whileInView={{ opacity: 1, y: 0 }}
-                                viewport={{
-                                    once: true,
-                                    margin: '0px 0px -60px 0px',
-                                }}
-                                transition={{
-                                    duration: 0.4,
-                                    delay: index * 0.08,
-                                    ease: 'easeOut',
-                                }}
-                                className="overflow-hidden rounded-xl border border-gray-100 bg-white shadow-sm transition-all duration-300 ease-caramel hover:border-caramel/30 hover:shadow-caramel-sm dark:border-caramel/30 dark:bg-darkerBg dark:hover:border-caramel/50"
-                            >
-                                <div className="grid grid-cols-2 lg:grid-cols-2 sm:grid-cols-1">
-                                    {/* Others */}
-                                    <div className="flex items-center space-x-4 p-6">
-                                        <div className="flex-shrink-0">
-                                            <HiXCircle
-                                                aria-hidden="true"
-                                                className="h-8 w-8 text-red-500"
-                                            />
-                                        </div>
-                                        <div className="flex-1">
-                                            <h4 className="mb-1 text-sm font-medium uppercase tracking-wide text-gray-600 dark:text-gray-400">
-                                                Other Extensions
-                                            </h4>
-                                            <p className="font-medium text-gray-900 dark:text-white">
+                    <div className="mx-auto max-w-4xl">
+                        {/* ONE column header for the whole table. The per-row
+                            "Other Extensions" / "Caramel" labels are gone — the
+                            columns are labelled once and the rows just compare.
+                            Padding here mirrors the row cells' so the two
+                            column edges line up. */}
+                        <div className="mb-4 grid grid-cols-2">
+                            <div className="px-6 text-sm font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400 sm:px-4">
+                                Other Extensions
+                            </div>
+                            <div className="px-6 text-sm font-semibold uppercase tracking-wide text-caramel sm:px-4">
+                                Caramel
+                            </div>
+                        </div>
+
+                        <div className="space-y-4">
+                            {comparisonItems.map((item, index) => (
+                                <motion.div
+                                    key={item.title}
+                                    initial={
+                                        reduceMotion
+                                            ? { opacity: 0 }
+                                            : { opacity: 0, y: 10 }
+                                    }
+                                    whileInView={{ opacity: 1, y: 0 }}
+                                    viewport={{
+                                        once: true,
+                                        margin: '0px 0px -60px 0px',
+                                    }}
+                                    transition={{
+                                        duration: 0.4,
+                                        delay: index * 0.08,
+                                        ease: 'easeOut',
+                                    }}
+                                >
+                                    {/* Card chrome sits inside the motion
+                                        element for the same reason as the
+                                        feature cards: framer's inline
+                                        transform would beat the hover lift.
+                                        Stays two columns at every width — the
+                                        comparison only reads as a comparison
+                                        side by side, and the labels that used
+                                        to carry a stacked layout are gone. */}
+                                    <div className="grid grid-cols-2 overflow-hidden rounded-xl border border-gray-100 bg-white shadow-sm transition-all duration-300 ease-caramel hover:-translate-y-1 hover:border-caramel/60 hover:shadow-[0_12px_32px_-8px_rgba(234,105,37,0.35)] dark:border-caramel/30 dark:bg-darkSurface">
+                                        {/* Losing column — neutral card surface
+                                            (never darker than the page) and
+                                            muted so the eye lands on Caramel. */}
+                                        <div className="flex items-center space-x-4 p-6 opacity-50 sm:space-x-3 sm:p-4">
+                                            <div className="flex-shrink-0">
+                                                <HiXCircle
+                                                    aria-hidden="true"
+                                                    className="h-8 w-8 rounded-full bg-gray-400/20 text-gray-500 dark:bg-white/10 dark:text-gray-400"
+                                                />
+                                            </div>
+                                            <p className="flex-1 font-medium text-gray-900 dark:text-white">
                                                 {item.other}
                                             </p>
                                         </div>
-                                    </div>
 
-                                    {/* Caramel */}
-                                    <div className="flex items-center space-x-4 border-l border-caramel/20 bg-gradient-to-br from-caramel/5 via-orange-50/30 to-caramel/5 p-6 dark:from-caramel/10 dark:via-orange-900/20 dark:to-caramel/10 sm:border-l-0 sm:border-t">
-                                        <div className="flex-shrink-0">
-                                            <HiCheckCircle
-                                                aria-hidden="true"
-                                                className="h-8 w-8 text-caramel"
-                                            />
-                                        </div>
-                                        <div className="flex-1">
-                                            <h4 className="mb-1 text-sm font-medium uppercase tracking-wide text-caramel">
-                                                Caramel
-                                            </h4>
-                                            <p className="font-medium text-gray-900 dark:text-white">
+                                        {/* Winning column — tinted and ringed
+                                            at full strength. The ring is inset
+                                            so the card's overflow-hidden can't
+                                            clip it. */}
+                                        <div className="flex items-center space-x-4 bg-caramel/[0.08] p-6 ring-1 ring-inset ring-caramel/40 sm:space-x-3 sm:p-4">
+                                            <div className="flex-shrink-0">
+                                                <HiCheckCircle
+                                                    aria-hidden="true"
+                                                    className="h-8 w-8 text-caramel"
+                                                />
+                                            </div>
+                                            <p className="flex-1 font-medium text-gray-900 dark:text-white">
                                                 {item.caramel}
                                             </p>
                                         </div>
                                     </div>
-                                </div>
-                            </motion.div>
-                        ))}
+                                </motion.div>
+                            ))}
+                        </div>
                     </div>
                 </motion.div>
 
-                {/* Browser Support Section */}
+                {/* Browser Support Section. The transparent border is always
+                    present so the dark theme's caramel border doesn't change
+                    the slab's size. */}
                 <motion.div
                     id="install-extension"
                     initial={{ opacity: 0, y: 20 }}
                     whileInView={{ opacity: 1, y: 0 }}
                     viewport={{ once: true }}
                     transition={{ duration: 0.6, delay: 0.2, ease: 'easeOut' }}
-                    className="rounded-3xl bg-gradient-to-r from-caramel to-orange-600 p-12 text-center text-black shadow-lg lg:p-8"
+                    className="rounded-3xl border border-transparent bg-gradient-to-br from-caramel to-[#c9531a] p-12 text-center text-white shadow-lg ring-1 ring-inset ring-white/20 dark:border-caramel/30 dark:bg-caramel/[0.12] dark:bg-none dark:ring-0 lg:p-8"
                 >
                     <h3 className="mb-6 text-3xl font-extrabold tracking-tight lg:text-2xl">
                         Available on Your Favorite Browser!

--- a/apps/caramel-app/src/components/OpenSourceSection.tsx
+++ b/apps/caramel-app/src/components/OpenSourceSection.tsx
@@ -3,6 +3,7 @@
 import { useReducedMotion } from '@/lib/reducedMotion'
 import { motion } from 'framer-motion'
 import {
+    FaArrowRight,
     FaBan,
     FaBug,
     FaCode,
@@ -160,74 +161,77 @@ export default function OpenSourceSection() {
                                     stiffness: 100,
                                     damping: 15,
                                 }}
-                                whileHover={{
-                                    scale: 1.02,
-                                    y: -5,
-                                    boxShadow:
-                                        '0 20px 40px rgba(234,105,37,0.15)',
-                                    transition: { duration: 0.2 },
-                                }}
-                                className="group relative overflow-hidden rounded-3xl border border-caramel/20 bg-gradient-to-br from-caramel/5 via-orange-50/30 to-caramel/5 p-8 transition-colors duration-300 hover:border-caramel/40 dark:border-caramel/30 dark:from-caramel/10 dark:via-orange-900/20 dark:to-caramel/10 dark:hover:border-caramel/50 sm:p-6"
                             >
-                                <div
-                                    aria-hidden="true"
-                                    className="absolute inset-0 opacity-5"
-                                >
-                                    <motion.div
-                                        className="h-full w-full"
-                                        style={{
-                                            backgroundImage: `
+                                {/* A framer motion element writes its
+                                    transform inline — including `none` at rest
+                                    — so a Tailwind hover:-translate-y-1 placed
+                                    on it never applies. Every card here splits
+                                    the two: the motion element owns only the
+                                    entrance, a plain child owns the chrome and
+                                    the hover. Same reason the icon scale below
+                                    rides on its own inner span. */}
+                                <div className="group relative h-full overflow-hidden rounded-3xl border border-caramel/20 bg-gradient-to-br from-caramel/5 via-orange-50/30 to-caramel/5 p-8 transition-all duration-300 hover:-translate-y-1 hover:border-caramel/60 hover:shadow-[0_12px_32px_-8px_rgba(234,105,37,0.35)] dark:border-caramel/30 dark:from-caramel/10 dark:via-orange-900/20 dark:to-caramel/10 sm:p-6">
+                                    <div
+                                        aria-hidden="true"
+                                        className="absolute inset-0 opacity-5"
+                                    >
+                                        <motion.div
+                                            className="h-full w-full"
+                                            style={{
+                                                backgroundImage: `
                                                 linear-gradient(90deg, #ea6925 1px, transparent 1px),
                                                 linear-gradient(#ea6925 1px, transparent 1px)
                                             `,
-                                            backgroundSize: '20px 20px',
-                                        }}
-                                        animate={
-                                            reduceMotion
-                                                ? undefined
-                                                : {
-                                                      backgroundPosition: [
-                                                          '0px 0px',
-                                                          '20px 20px',
-                                                          '0px 0px',
-                                                      ],
-                                                  }
-                                        }
-                                        transition={{
-                                            duration: 8,
-                                            repeat: Infinity,
-                                            ease: 'linear',
-                                            repeatType: 'loop',
-                                        }}
-                                    />
-                                </div>
-                                <div className="relative z-10 text-center">
-                                    <motion.div
-                                        className="mx-auto mb-6 flex items-center justify-center text-6xl text-caramel transition-transform duration-300"
-                                        animate={
-                                            reduceMotion
-                                                ? undefined
-                                                : {
-                                                      rotate: [0, 2, -2, 0],
-                                                      scale: [1, 1.02, 1],
-                                                  }
-                                        }
-                                        transition={{
-                                            duration: 4,
-                                            repeat: Infinity,
-                                            ease: 'easeInOut',
-                                            repeatType: 'loop',
-                                        }}
-                                        whileHover={{ scale: 1.1 }}
-                                    >
-                                        {feature.icon}
-                                    </motion.div>
-                                    <h4 className="mb-4 text-2xl font-bold text-gray-800 dark:text-white sm:text-xl">
-                                        {feature.title}
-                                    </h4>
-                                    <p className="text-base leading-relaxed text-gray-600 dark:text-gray-400 sm:text-sm">
-                                        {feature.desc}
-                                    </p>
+                                                backgroundSize: '20px 20px',
+                                            }}
+                                            animate={
+                                                reduceMotion
+                                                    ? undefined
+                                                    : {
+                                                          backgroundPosition: [
+                                                              '0px 0px',
+                                                              '20px 20px',
+                                                              '0px 0px',
+                                                          ],
+                                                      }
+                                            }
+                                            transition={{
+                                                duration: 8,
+                                                repeat: Infinity,
+                                                ease: 'linear',
+                                                repeatType: 'loop',
+                                            }}
+                                        />
+                                    </div>
+                                    <div className="relative z-10 text-center">
+                                        <motion.div
+                                            className="mx-auto mb-6 flex items-center justify-center text-6xl text-caramel"
+                                            animate={
+                                                reduceMotion
+                                                    ? undefined
+                                                    : {
+                                                          rotate: [0, 2, -2, 0],
+                                                          scale: [1, 1.02, 1],
+                                                      }
+                                            }
+                                            transition={{
+                                                duration: 4,
+                                                repeat: Infinity,
+                                                ease: 'easeInOut',
+                                                repeatType: 'loop',
+                                            }}
+                                        >
+                                            <span className="block transition-transform duration-300 group-hover:scale-110">
+                                                {feature.icon}
+                                            </span>
+                                        </motion.div>
+                                        <h4 className="mb-4 text-2xl font-bold text-gray-800 dark:text-white sm:text-xl">
+                                            {feature.title}
+                                        </h4>
+                                        <p className="text-base leading-relaxed text-gray-600 dark:text-gray-400 sm:text-sm">
+                                            {feature.desc}
+                                        </p>
+                                    </div>
                                 </div>
                             </motion.div>
                         ))}
@@ -272,75 +276,77 @@ export default function OpenSourceSection() {
                                     stiffness: 100,
                                     damping: 15,
                                 }}
-                                whileHover={{
-                                    scale: 1.02,
-                                    y: -5,
-                                    boxShadow:
-                                        '0 20px 40px rgba(234,105,37,0.15)',
-                                    transition: { duration: 0.2 },
-                                }}
-                                className="group relative overflow-hidden rounded-3xl border border-caramel/20 bg-gradient-to-br from-caramel/5 via-orange-50/30 to-caramel/5 p-8 transition-colors duration-300 hover:border-caramel/40 dark:border-caramel/30 dark:from-caramel/10 dark:via-orange-900/20 dark:to-caramel/10 dark:hover:border-caramel/50 sm:p-6"
                             >
-                                <div
-                                    aria-hidden="true"
-                                    className="absolute inset-0 opacity-5"
-                                >
-                                    <motion.div
-                                        className="h-full w-full"
-                                        style={{
-                                            backgroundImage: `
+                                <div className="group relative h-full overflow-hidden rounded-3xl border border-caramel/20 bg-gradient-to-br from-caramel/5 via-orange-50/30 to-caramel/5 p-8 transition-all duration-300 hover:-translate-y-1 hover:border-caramel/60 hover:shadow-[0_12px_32px_-8px_rgba(234,105,37,0.35)] dark:border-caramel/30 dark:from-caramel/10 dark:via-orange-900/20 dark:to-caramel/10 sm:p-6">
+                                    <div
+                                        aria-hidden="true"
+                                        className="absolute inset-0 opacity-5"
+                                    >
+                                        <motion.div
+                                            className="h-full w-full"
+                                            style={{
+                                                backgroundImage: `
                                                 linear-gradient(90deg, #ea6925 1px, transparent 1px),
                                                 linear-gradient(#ea6925 1px, transparent 1px)
                                             `,
-                                            backgroundSize: '20px 20px',
-                                        }}
-                                        animate={
-                                            reduceMotion
-                                                ? undefined
-                                                : {
-                                                      backgroundPosition: [
-                                                          '0px 0px',
-                                                          '20px 20px',
-                                                          '0px 0px',
-                                                      ],
-                                                  }
-                                        }
-                                        transition={{
-                                            duration: 8,
-                                            repeat: Infinity,
-                                            ease: 'linear',
-                                            repeatType: 'loop',
-                                        }}
-                                    />
-                                </div>
-                                <div className="relative z-10 flex items-start gap-6 sm:flex-col sm:items-center sm:gap-4">
-                                    <motion.div
-                                        className="flex h-16 w-16 items-center justify-center rounded-2xl bg-caramel/10 text-2xl text-caramel transition-transform duration-300 dark:bg-caramel/20"
-                                        animate={
-                                            reduceMotion
-                                                ? undefined
-                                                : {
-                                                      rotate: [0, 2, -2, 0],
-                                                      scale: [1, 1.02, 1],
-                                                  }
-                                        }
-                                        transition={{
-                                            duration: 4,
-                                            repeat: Infinity,
-                                            ease: 'easeInOut',
-                                            repeatType: 'loop',
-                                        }}
-                                        whileHover={{ scale: 1.1 }}
-                                    >
-                                        {platform.icon}
-                                    </motion.div>
-                                    <div className="flex-1 sm:text-center">
-                                        <h3 className="mb-3 text-2xl font-bold text-gray-800 dark:text-white sm:text-xl">
-                                            {platform.name}
-                                        </h3>
-                                        <p className="text-base leading-relaxed text-gray-600 dark:text-gray-400 sm:text-sm">
-                                            {platform.desc}
-                                        </p>
+                                                backgroundSize: '20px 20px',
+                                            }}
+                                            animate={
+                                                reduceMotion
+                                                    ? undefined
+                                                    : {
+                                                          backgroundPosition: [
+                                                              '0px 0px',
+                                                              '20px 20px',
+                                                              '0px 0px',
+                                                          ],
+                                                      }
+                                            }
+                                            transition={{
+                                                duration: 8,
+                                                repeat: Infinity,
+                                                ease: 'linear',
+                                                repeatType: 'loop',
+                                            }}
+                                        />
+                                    </div>
+                                    <div className="relative z-10 flex items-start gap-6 sm:flex-col sm:items-center sm:gap-4">
+                                        <motion.div
+                                            className="flex h-16 w-16 items-center justify-center rounded-2xl bg-caramel/10 text-2xl text-caramel dark:bg-caramel/20"
+                                            animate={
+                                                reduceMotion
+                                                    ? undefined
+                                                    : {
+                                                          rotate: [0, 2, -2, 0],
+                                                          scale: [1, 1.02, 1],
+                                                      }
+                                            }
+                                            transition={{
+                                                duration: 4,
+                                                repeat: Infinity,
+                                                ease: 'easeInOut',
+                                                repeatType: 'loop',
+                                            }}
+                                        >
+                                            <span className="block transition-transform duration-300 group-hover:scale-110">
+                                                {platform.icon}
+                                            </span>
+                                        </motion.div>
+                                        <div className="flex-1 sm:text-center">
+                                            <h3 className="mb-3 text-2xl font-bold text-gray-800 dark:text-white sm:text-xl">
+                                                {platform.name}
+                                            </h3>
+                                            <p className="text-base leading-relaxed text-gray-600 dark:text-gray-400 sm:text-sm">
+                                                {platform.desc}
+                                            </p>
+                                            <span className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-caramel underline-offset-4 group-hover:underline">
+                                                Open {platform.name}
+                                                <FaArrowRight
+                                                    aria-hidden="true"
+                                                    className="transition-transform duration-300 group-hover:translate-x-1"
+                                                />
+                                            </span>
+                                        </div>
                                     </div>
                                 </div>
                             </motion.a>
@@ -383,88 +389,85 @@ export default function OpenSourceSection() {
                                     stiffness: 100,
                                     damping: 15,
                                 }}
-                                whileHover={{
-                                    scale: 1.02,
-                                    y: -5,
-                                    boxShadow:
-                                        '0 20px 40px rgba(234,105,37,0.15)',
-                                    transition: { duration: 0.2 },
-                                }}
-                                className="group relative overflow-hidden rounded-3xl border border-caramel/20 bg-gradient-to-br from-caramel/5 via-orange-50/30 to-caramel/5 p-8 transition-colors duration-300 hover:border-caramel/40 dark:border-caramel/30 dark:from-caramel/10 dark:via-orange-900/20 dark:to-caramel/10 dark:hover:border-caramel/50 sm:p-6"
                             >
-                                <div
-                                    aria-hidden="true"
-                                    className="absolute inset-0 opacity-5"
-                                >
-                                    <motion.div
-                                        className="h-full w-full"
-                                        style={{
-                                            backgroundImage: `
+                                <div className="group relative h-full overflow-hidden rounded-3xl border border-caramel/20 bg-gradient-to-br from-caramel/5 via-orange-50/30 to-caramel/5 p-8 transition-all duration-300 hover:-translate-y-1 hover:border-caramel/60 hover:shadow-[0_12px_32px_-8px_rgba(234,105,37,0.35)] dark:border-caramel/30 dark:from-caramel/10 dark:via-orange-900/20 dark:to-caramel/10 sm:p-6">
+                                    <div
+                                        aria-hidden="true"
+                                        className="absolute inset-0 opacity-5"
+                                    >
+                                        <motion.div
+                                            className="h-full w-full"
+                                            style={{
+                                                backgroundImage: `
                                                 linear-gradient(90deg, #ea6925 1px, transparent 1px),
                                                 linear-gradient(#ea6925 1px, transparent 1px)
                                             `,
-                                            backgroundSize: '20px 20px',
-                                        }}
-                                        animate={
-                                            reduceMotion
-                                                ? undefined
-                                                : {
-                                                      backgroundPosition: [
-                                                          '0px 0px',
-                                                          '20px 20px',
-                                                          '0px 0px',
-                                                      ],
-                                                  }
-                                        }
-                                        transition={{
-                                            duration: 8,
-                                            repeat: Infinity,
-                                            ease: 'linear',
-                                            repeatType: 'loop',
-                                        }}
-                                    />
-                                </div>
-                                <div className="relative z-10 flex items-start gap-6 sm:flex-col sm:items-center sm:gap-4">
-                                    <motion.div
-                                        className="text-4xl text-caramel transition-transform duration-300 sm:text-3xl"
-                                        animate={
-                                            reduceMotion
-                                                ? undefined
-                                                : {
-                                                      rotate: [0, 2, -2, 0],
-                                                      scale: [1, 1.02, 1],
-                                                  }
-                                        }
-                                        transition={{
-                                            duration: 4,
-                                            repeat: Infinity,
-                                            ease: 'easeInOut',
-                                            repeatType: 'loop',
-                                        }}
-                                        whileHover={{ scale: 1.1 }}
-                                    >
-                                        {contribution.icon}
-                                    </motion.div>
-                                    <div className="flex-1 sm:text-center">
-                                        <h4 className="mb-3 text-2xl font-bold text-gray-800 dark:text-white sm:text-xl">
-                                            {contribution.title}
-                                        </h4>
-                                        <p className="mb-6 text-base leading-relaxed text-gray-600 dark:text-gray-400 sm:text-sm">
-                                            {contribution.desc}
-                                        </p>
-                                        <motion.a
-                                            href={contribution.href}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            className="inline-flex items-center rounded-full bg-gradient-to-r from-caramel to-orange-600 px-6 py-3 text-sm font-semibold text-white shadow-md transition-all duration-200 hover:shadow-xl"
-                                            whileHover={{
-                                                scale: 1.05,
-                                                transition: { duration: 0.2 },
+                                                backgroundSize: '20px 20px',
                                             }}
-                                            whileTap={{ scale: 0.95 }}
+                                            animate={
+                                                reduceMotion
+                                                    ? undefined
+                                                    : {
+                                                          backgroundPosition: [
+                                                              '0px 0px',
+                                                              '20px 20px',
+                                                              '0px 0px',
+                                                          ],
+                                                      }
+                                            }
+                                            transition={{
+                                                duration: 8,
+                                                repeat: Infinity,
+                                                ease: 'linear',
+                                                repeatType: 'loop',
+                                            }}
+                                        />
+                                    </div>
+                                    <div className="relative z-10 flex items-start gap-6 sm:flex-col sm:items-center sm:gap-4">
+                                        <motion.div
+                                            className="text-4xl text-caramel sm:text-3xl"
+                                            animate={
+                                                reduceMotion
+                                                    ? undefined
+                                                    : {
+                                                          rotate: [0, 2, -2, 0],
+                                                          scale: [1, 1.02, 1],
+                                                      }
+                                            }
+                                            transition={{
+                                                duration: 4,
+                                                repeat: Infinity,
+                                                ease: 'easeInOut',
+                                                repeatType: 'loop',
+                                            }}
                                         >
-                                            {contribution.action}
-                                        </motion.a>
+                                            <span className="block transition-transform duration-300 group-hover:scale-110">
+                                                {contribution.icon}
+                                            </span>
+                                        </motion.div>
+                                        <div className="flex-1 sm:text-center">
+                                            <h4 className="mb-3 text-2xl font-bold text-gray-800 dark:text-white sm:text-xl">
+                                                {contribution.title}
+                                            </h4>
+                                            <p className="mb-6 text-base leading-relaxed text-gray-600 dark:text-gray-400 sm:text-sm">
+                                                {contribution.desc}
+                                            </p>
+                                            <motion.a
+                                                href={contribution.href}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                className="inline-flex items-center rounded-full bg-gradient-to-r from-caramel to-orange-600 px-6 py-3 text-sm font-semibold text-white shadow-md transition-all duration-200 hover:shadow-xl"
+                                                whileHover={{
+                                                    scale: 1.05,
+                                                    transition: {
+                                                        duration: 0.2,
+                                                    },
+                                                }}
+                                                whileTap={{ scale: 0.95 }}
+                                            >
+                                                {contribution.action}
+                                            </motion.a>
+                                        </div>
                                     </div>
                                 </div>
                             </motion.div>
@@ -478,12 +481,12 @@ export default function OpenSourceSection() {
                     whileInView={{ opacity: 1, y: 0 }}
                     viewport={{ once: true }}
                     transition={{ duration: 0.6, delay: 0.15, ease: 'easeOut' }}
-                    className="rounded-3xl bg-gradient-to-r from-caramel to-orange-600 p-12 text-center text-white shadow-2xl lg:p-8 sm:p-6"
+                    className="rounded-3xl bg-gradient-to-br from-caramel to-[#c9531a] p-12 text-center text-white shadow-2xl ring-1 ring-inset ring-white/20 dark:border dark:border-caramel/30 dark:bg-caramel/[0.12] dark:bg-none dark:ring-0 lg:p-8 sm:p-6"
                 >
-                    <h3 className="mb-6 text-3xl font-semibold tracking-tight lg:text-2xl">
+                    <h3 className="mb-6 text-3xl font-semibold tracking-tight text-white lg:text-2xl">
                         Ready to Make a Difference?
                     </h3>
-                    <p className="mx-auto mb-8 max-w-2xl text-lg leading-relaxed opacity-90">
+                    <p className="mx-auto mb-8 max-w-2xl text-lg leading-relaxed text-white/90">
                         Join our mission to create ethical, transparent, and
                         user-first shopping tools. Your contribution, no matter
                         how small, helps build a better internet for everyone.

--- a/apps/caramel-app/src/components/PricingSection.tsx
+++ b/apps/caramel-app/src/components/PricingSection.tsx
@@ -29,7 +29,7 @@ const stats = [
         icon: <FaGithub />,
     },
     {
-        title: '∞',
+        title: '5,000+',
         desc: 'Stores Supported',
         icon: <FaHeart />,
     },
@@ -98,7 +98,7 @@ export default function PricingSection() {
                     whileInView={{ opacity: 1, y: 0 }}
                     viewport={{ once: true }}
                     transition={{ duration: 0.6, delay: 0.2 }}
-                    className="mb-20 grid grid-cols-3 gap-8 lg:grid-cols-2 sm:grid-cols-1"
+                    className="mx-auto mb-20 grid max-w-4xl grid-cols-3 gap-6 lg:grid-cols-2 sm:grid-cols-1"
                 >
                     {stats.map((stat, index) => (
                         <motion.div
@@ -107,7 +107,7 @@ export default function PricingSection() {
                             whileInView={{ opacity: 1, y: 0 }}
                             viewport={{ once: true }}
                             transition={{ duration: 0.5, delay: 0.1 * index }}
-                            className="group relative overflow-hidden rounded-2xl border border-caramel/20 bg-gradient-to-br from-caramel/5 via-orange-50/30 to-caramel/5 p-8 text-center shadow-md transition-shadow duration-300 hover:shadow-lg dark:border-caramel/30 dark:from-caramel/10 dark:via-orange-900/20 dark:to-caramel/10 sm:p-6"
+                            className="group relative overflow-hidden rounded-2xl border border-caramel/20 bg-gradient-to-br from-caramel/5 via-orange-50/30 to-caramel/5 p-6 text-center shadow-md transition-shadow duration-300 hover:shadow-lg dark:border-caramel/30 dark:from-caramel/10 dark:via-orange-900/20 dark:to-caramel/10 sm:p-5"
                         >
                             {/* Animated Background Pattern */}
                             <div className="absolute inset-0 opacity-5">
@@ -137,10 +137,10 @@ export default function PricingSection() {
                             </div>
 
                             <div className="relative z-10">
-                                <motion.div className="mb-4 flex justify-center text-5xl text-caramel">
+                                <motion.div className="mb-3 flex justify-center text-4xl text-caramel">
                                     {stat.icon}
                                 </motion.div>
-                                <h3 className="mb-2 text-5xl font-bold text-gray-900 dark:text-white lg:text-4xl">
+                                <h3 className="mb-2 text-4xl font-bold text-gray-900 dark:text-white lg:text-3xl">
                                     {stat.title}
                                 </h3>
                                 <p className="text-gray-600 dark:text-gray-300">
@@ -188,11 +188,11 @@ export default function PricingSection() {
                         </div>
 
                         <div className="relative z-10">
-                            <div className="absolute right-0 top-0 rounded-bl-3xl bg-gradient-to-br from-caramel to-orange-600 px-8 py-3 text-sm font-bold text-white shadow-lg lg:px-6 lg:py-2.5 lg:text-sm sm:px-4 sm:py-2 sm:text-xs">
+                            <div className="absolute right-0 top-0 rounded-full bg-gradient-to-br from-caramel to-orange-600 px-5 py-2 text-xs font-bold tracking-[0.15em] text-white shadow-lg sm:px-4 sm:py-1.5 sm:text-[0.65rem]">
                                 ALWAYS FREE
                             </div>
 
-                            <div className="mb-10 border-b border-caramel/20 pb-10">
+                            <div className="pb-10">
                                 <h3 className="mb-4 text-4xl font-bold text-gray-900 dark:text-white lg:text-3xl sm:text-2xl">
                                     Free Forever Plan
                                 </h3>
@@ -202,7 +202,28 @@ export default function PricingSection() {
                                 </p>
                             </div>
 
-                            <div className="mb-10 grid grid-cols-2 gap-4 sm:grid-cols-1">
+                            {/* Coupon perforation: the tear line plus the two
+                                side notches. Full-bleed via negative margins
+                                (mirroring the card's own p-12/lg:p-8/sm:p-6) so
+                                each circle straddles a card edge and the card's
+                                overflow-hidden clips it into a bite. The notch
+                                fill must equal what sits behind the card: the
+                                page background (globals.css body = gray-50 /
+                                darkBg) under this section's caramel/5 wash. */}
+                            <div
+                                aria-hidden="true"
+                                className="relative -mx-12 lg:-mx-8 sm:-mx-6"
+                            >
+                                <div className="border-t-2 border-dashed border-caramel/30" />
+                                <div className="absolute left-0 top-1/2 h-10 w-10 -translate-x-1/2 -translate-y-1/2 rounded-full bg-gray-50 dark:bg-darkBg">
+                                    <div className="h-full w-full rounded-full bg-caramel/5" />
+                                </div>
+                                <div className="absolute right-0 top-1/2 h-10 w-10 -translate-y-1/2 translate-x-1/2 rounded-full bg-gray-50 dark:bg-darkBg">
+                                    <div className="h-full w-full rounded-full bg-caramel/5" />
+                                </div>
+                            </div>
+
+                            <div className="mb-10 mt-10 grid grid-cols-2 gap-4 sm:grid-cols-1">
                                 {features.map((feature, index) => (
                                     <motion.div
                                         key={feature}
@@ -234,6 +255,24 @@ export default function PricingSection() {
                                 <FaGithub className="text-2xl" />
                                 Get Started - It's Free
                             </motion.a>
+
+                            {/* Serial strip: the printed barcode + coupon code
+                                every real ticket carries. Decorative only. */}
+                            <div
+                                aria-hidden="true"
+                                className="mt-10 flex flex-col items-center gap-3"
+                            >
+                                <div
+                                    className="h-8 w-full max-w-xs opacity-20"
+                                    style={{
+                                        backgroundImage:
+                                            'repeating-linear-gradient(90deg, #ea6925 0 2px, transparent 2px 5px, #ea6925 5px 6px, transparent 6px 11px)',
+                                    }}
+                                />
+                                <p className="font-mono text-xs tracking-[0.35em] text-gray-500 dark:text-gray-400">
+                                    CARAMEL-FREE-FOREVER
+                                </p>
+                            </div>
                         </div>
                     </motion.div>
                 </motion.div>

--- a/apps/caramel-app/src/components/SectionDivider.tsx
+++ b/apps/caramel-app/src/components/SectionDivider.tsx
@@ -7,15 +7,24 @@ const dividerEase: [number, number, number, number] = [0.22, 1, 0.36, 1]
 
 interface SectionDividerProps {
     // Full Tailwind gradient class strings, passed as literals from the page so
-    // the JIT scanner still sees every colour used.
+    // the JIT scanner still sees every colour used. Since the tear line itself
+    // is now a fixed caramel dashed border, these two drive the SOFT layers
+    // under it — the per-divider colour the page varies stays visible as the
+    // warm haze that fades out toward each end.
     lineClassName: string
     glowClassName: string
 }
 
-// The hairline that wipes in between landing sections. Extracted from
-// app/page.tsx so that page can be a server component: framer-motion's
-// useReducedMotion is client-only, and the dividers were the only thing forcing
-// 'use client' on the whole route once useSearchParams moved out.
+// The perforated tear line that wipes in between landing sections: the same
+// coupon-ticket motif as the pricing card, so the landing page and /pricing
+// speak one visual language. Bounded to the sections' own max-w-7xl content
+// column (it used to run full-bleed and fade at the viewport edges) so the
+// dashes have two definite ends for the punch-hole notches to sit on.
+//
+// Extracted from app/page.tsx so that page can be a server component:
+// framer-motion's useReducedMotion is client-only, and the dividers were the
+// only thing forcing 'use client' on the whole route once useSearchParams
+// moved out.
 export default function SectionDivider({
     lineClassName,
     glowClassName,
@@ -23,16 +32,68 @@ export default function SectionDivider({
     const reduceMotion = useReducedMotion()
 
     return (
-        <motion.div
+        <div
             aria-hidden="true"
-            className="relative h-px"
-            initial={reduceMotion ? false : { scaleX: 0 }}
-            whileInView={{ scaleX: 1 }}
-            viewport={{ once: true, margin: '0px 0px -40px 0px' }}
-            transition={{ duration: 1.4, ease: dividerEase }}
+            className="mx-auto w-full max-w-7xl px-6 lg:px-8"
         >
-            <div className={`h-px ${lineClassName}`}></div>
-            <div className={`absolute inset-0 h-px ${glowClassName}`}></div>
-        </motion.div>
+            <div className="relative h-0.5">
+                {/* The line wipes; the notches must NOT, or scaleX would
+                    squash them into ellipses for the length of the wipe. */}
+                <motion.div
+                    className="absolute inset-0"
+                    initial={reduceMotion ? false : { scaleX: 0 }}
+                    whileInView={{ scaleX: 1 }}
+                    viewport={{ once: true, margin: '0px 0px -40px 0px' }}
+                    transition={{ duration: 1.4, ease: dividerEase }}
+                >
+                    <div
+                        className={`absolute inset-x-0 top-0 h-px blur-[1px] ${lineClassName}`}
+                    ></div>
+                    <div
+                        className={`absolute inset-x-0 top-0 h-px ${glowClassName}`}
+                    ></div>
+                    <div className="absolute inset-x-0 top-0 border-t-2 border-dashed border-caramel/25 dark:border-caramel/35"></div>
+                </motion.div>
+
+                {/* Punch holes at each end of the perforation. Filled with the
+                    page background (globals.css body = gray-50 / darkBg) so the
+                    dashes are genuinely interrupted rather than overlaid, with a
+                    caramel ring to read as a hole on a matching backdrop.
+
+                    The -translate centering MUST stay on these plain spans:
+                    framer writes inline `transform` on a motion element and
+                    resets it to `none` at rest, which beats Tailwind's
+                    transform-shorthand classes. Here that would not merely kill
+                    a hover — the translate is load-bearing positioning, so both
+                    holes would jump half their size off the line. The motion
+                    child therefore carries the fade and nothing else. */}
+                <span className="absolute left-0 top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2">
+                    <motion.span
+                        className="block h-full w-full rounded-full bg-gray-50 ring-1 ring-caramel/25 dark:bg-darkBg dark:ring-caramel/35"
+                        initial={reduceMotion ? false : { opacity: 0 }}
+                        whileInView={{ opacity: 1 }}
+                        viewport={{ once: true, margin: '0px 0px -40px 0px' }}
+                        transition={{
+                            duration: 0.5,
+                            delay: 0.9,
+                            ease: dividerEase,
+                        }}
+                    ></motion.span>
+                </span>
+                <span className="absolute right-0 top-1/2 h-3 w-3 -translate-y-1/2 translate-x-1/2">
+                    <motion.span
+                        className="block h-full w-full rounded-full bg-gray-50 ring-1 ring-caramel/25 dark:bg-darkBg dark:ring-caramel/35"
+                        initial={reduceMotion ? false : { opacity: 0 }}
+                        whileInView={{ opacity: 1 }}
+                        viewport={{ once: true, margin: '0px 0px -40px 0px' }}
+                        transition={{
+                            duration: 0.5,
+                            delay: 0.9,
+                            ease: dividerEase,
+                        }}
+                    ></motion.span>
+                </span>
+            </div>
+        </div>
     )
 }

--- a/apps/caramel-app/src/components/SupportedSection.tsx
+++ b/apps/caramel-app/src/components/SupportedSection.tsx
@@ -1,17 +1,34 @@
 'use client'
 
-import { ThemeContext } from '@/lib/contexts'
 import { useReducedMotion } from '@/lib/reducedMotion'
 import { motion } from 'framer-motion'
 import Image from 'next/image'
-import { useContext } from 'react'
+
+// The store scroller runs on CSS keyframes rather than a framer x-loop for one
+// reason: `animation-play-state: paused` (the hover pause) only acts on CSS
+// animations — framer drives transforms through WAAPI/JS, where the property is
+// inert, and toggling its `animate` prop instead makes the track slide back to
+// its start. Motion profile is a 1:1 port of the loop it replaces (translateX
+// 0 → -100% over 30s, linear, forever), so tooling that freezes animations for
+// screenshots still lands on the same first frame as before.
+const marqueeStyles = `
+@keyframes caramel-marquee {
+    from { transform: translateX(0); }
+    to { transform: translateX(-100%); }
+}
+.caramel-marquee-track {
+    animation: caramel-marquee 30s linear infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+    .caramel-marquee-track { animation: none; }
+}
+`
 
 const featuredStores = [
     {
         name: 'Amazon',
         desc: 'Worldʼs largest online retailer',
         image: '/amazon.png',
-        imageLight: '/amazon-light.png',
         category: 'marketplace',
     },
     {
@@ -59,7 +76,6 @@ const featuredStores = [
 ]
 
 export default function SupportedSection() {
-    const { isDarkMode } = useContext(ThemeContext)
     const reduceMotion = useReducedMotion()
 
     return (
@@ -109,39 +125,21 @@ export default function SupportedSection() {
                     transition={{ duration: 0.6, delay: 0.2, ease: 'easeOut' }}
                     className="mb-24"
                 >
-                    <div className="relative w-full overflow-hidden py-4">
-                        <motion.div
-                            className="flex gap-4"
-                            animate={
-                                reduceMotion
-                                    ? undefined
-                                    : { x: ['0%', '-100%'] }
-                            }
-                            transition={{
-                                x: {
-                                    repeat: Infinity,
-                                    repeatType: 'loop',
-                                    duration: 30,
-                                    ease: 'linear',
-                                },
-                            }}
-                        >
+                    <style>{marqueeStyles}</style>
+                    {/* py-6, not py-4: the cards' hover lift and warm shadow
+                        reach ~20px below the card and would otherwise be
+                        guillotined by this element's own overflow-hidden. */}
+                    <div className="relative w-full overflow-hidden py-6 [-webkit-mask-image:linear-gradient(to_right,transparent,black_6%,black_94%,transparent)] [mask-image:linear-gradient(to_right,transparent,black_6%,black_94%,transparent)]">
+                        <div className="caramel-marquee-track flex gap-4 hover:[animation-play-state:paused]">
                             {[...featuredStores, ...featuredStores].map(
                                 (store, index) => (
-                                    <motion.div
+                                    <div
                                         key={`${store.name}-${index}`}
                                         aria-hidden={
                                             index >= featuredStores.length ||
                                             undefined
                                         }
-                                        className="group relative min-w-[280px] flex-shrink-0 overflow-hidden rounded-3xl border border-caramel/20 bg-gradient-to-br from-caramel/5 via-orange-50/30 to-caramel/5 p-8 transition-colors duration-300 hover:border-caramel/40 dark:border-caramel/30 dark:from-caramel/10 dark:via-orange-900/20 dark:to-caramel/10 dark:hover:border-caramel/50 lg:min-w-[240px] sm:min-w-[200px] sm:p-6"
-                                        whileHover={{
-                                            scale: 1.02,
-                                            y: -3,
-                                            boxShadow:
-                                                '0 15px 30px rgba(234,105,37,0.12)',
-                                            transition: { duration: 0.2 },
-                                        }}
+                                        className="group relative min-w-[280px] flex-shrink-0 overflow-hidden rounded-3xl border border-caramel/20 bg-gradient-to-br from-caramel/5 via-orange-50/30 to-caramel/5 p-8 transition-all duration-300 hover:-translate-y-1 hover:border-caramel/60 hover:shadow-[0_12px_32px_-8px_rgba(234,105,37,0.35)] dark:border-caramel/30 dark:from-caramel/10 dark:via-orange-900/20 dark:to-caramel/10 lg:min-w-[240px] sm:min-w-[200px] sm:p-6"
                                     >
                                         <div
                                             aria-hidden="true"
@@ -177,7 +175,13 @@ export default function SupportedSection() {
                                             />
                                         </div>
                                         <div className="relative z-10 text-center">
-                                            <div className="relative mx-auto mb-6 flex h-20 w-20 items-center justify-center">
+                                            {/* The chip keeps brand logos on a
+                                                light plate in dark mode. They
+                                                used to be flattened to white
+                                                (`brightness-0 invert`), which
+                                                turned Target, Best Buy, eBay and
+                                                Walmart into identical blobs. */}
+                                            <div className="relative mx-auto mb-6 flex h-20 w-20 items-center justify-center transition-transform duration-300 group-hover:scale-110 dark:rounded-xl dark:bg-white/90 dark:p-2">
                                                 {/* eager on purpose: the marquee
                                                     translates the duplicated half
                                                     offscreen, so lazy copies never
@@ -193,18 +197,13 @@ export default function SupportedSection() {
                                                     load starves 2-core CI runners
                                                     and flakes the nav e2e suite. */}
                                                 <Image
-                                                    src={
-                                                        isDarkMode &&
-                                                        store.imageLight
-                                                            ? store.imageLight
-                                                            : store.image
-                                                    }
+                                                    src={store.image}
                                                     alt={`${store.name} logo`}
                                                     width={80}
                                                     height={80}
                                                     loading="eager"
                                                     unoptimized
-                                                    className={`object-contain ${isDarkMode ? 'brightness-0 invert' : ''}`}
+                                                    className="h-full w-full object-contain"
                                                 />
                                             </div>
                                             <h3 className="mb-3 text-2xl font-semibold text-gray-800 dark:text-white sm:text-xl">
@@ -214,10 +213,10 @@ export default function SupportedSection() {
                                                 {store.desc}
                                             </p>
                                         </div>
-                                    </motion.div>
+                                    </div>
                                 ),
                             )}
-                        </motion.div>
+                        </div>
                     </div>
                 </motion.div>
 
@@ -227,7 +226,7 @@ export default function SupportedSection() {
                     whileInView={{ opacity: 1, y: 0 }}
                     viewport={{ once: true }}
                     transition={{ duration: 0.6, delay: 0.15, ease: 'easeOut' }}
-                    className="rounded-3xl bg-gradient-to-r from-caramel to-orange-600 p-12 text-center text-white shadow-2xl lg:p-8 sm:p-6"
+                    className="rounded-3xl bg-gradient-to-br from-caramel to-[#c9531a] p-12 text-center text-white shadow-2xl ring-1 ring-inset ring-white/20 dark:border dark:border-caramel/30 dark:bg-caramel/[0.12] dark:bg-none dark:shadow-none dark:ring-0 lg:p-8 sm:p-6"
                 >
                     <h3 className="mb-6 text-3xl font-semibold tracking-tight lg:text-2xl">
                         Donʼt See Your Favorite Store?

--- a/apps/caramel-app/src/components/ThemeToggle.tsx
+++ b/apps/caramel-app/src/components/ThemeToggle.tsx
@@ -9,8 +9,11 @@ const ThemeToggle = ({ className }: ThemeToggleProps) => {
     const { isDarkMode, switchTheme } = useContext(ThemeContext)
 
     return (
+        /* No `id` here: the header renders two toggles (one inside the desktop
+           nav pill, one in the mobile row) and only ever shows one, but both
+           stay in the DOM — a hard-coded id would duplicate. Styling hooks off
+           the `theme-toggle` class instead. */
         <button
-            id="theme-toggle"
             className={`theme-toggle ${className || ''}`}
             title="Toggle light & dark"
             aria-label={isDarkMode ? 'dark' : 'light'}

--- a/apps/caramel-app/src/components/WhyNot.tsx
+++ b/apps/caramel-app/src/components/WhyNot.tsx
@@ -2,6 +2,7 @@
 
 import { useReducedMotion } from '@/lib/reducedMotion'
 import { motion } from 'framer-motion'
+import Image from 'next/image'
 import { useState } from 'react'
 import {
     FaExternalLinkAlt,
@@ -11,6 +12,12 @@ import {
     FaShieldAlt,
     FaTimesCircle,
 } from 'react-icons/fa'
+
+const VIDEO_ID = 'vc4yL3YTwWk'
+const VIDEO_TITLE = 'The Truth About Honey'
+// maxresdefault verified 200 (166 KB) for this video; i.ytimg.com is
+// allowlisted in next.config.mjs images.remotePatterns.
+const VIDEO_THUMBNAIL = `https://i.ytimg.com/vi/${VIDEO_ID}/maxresdefault.jpg`
 
 // This copy isn't rendered by the JSX below yet (F-009 oxlint sweep found
 // it while adding the gate — flagged as a new-finding candidate: either
@@ -143,25 +150,53 @@ export default function WhyNotHoneySection() {
                     >
                         <div className="relative aspect-video overflow-hidden rounded-2xl bg-black shadow-2xl">
                             {!videoLoaded && (
-                                <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-gray-900 to-black">
-                                    <motion.button
-                                        onClick={() => setVideoLoaded(true)}
-                                        className="flex items-center gap-4 rounded-full bg-red-600 px-8 py-4 font-semibold text-white shadow-lg transition-all duration-300 hover:bg-red-700"
-                                        whileHover={{ scale: 1.05 }}
-                                        whileTap={{ scale: 0.95 }}
-                                    >
-                                        <FaPlay
-                                            aria-hidden="true"
-                                            className="text-lg"
-                                        />
-                                        Watch: The Truth About Honey
-                                    </motion.button>
-                                </div>
+                                // Click-to-load facade: the YouTube iframe (and
+                                // its cookies) stay off the page until the
+                                // visitor asks for the video. The whole poster
+                                // is the button so the hit area matches what it
+                                // looks like.
+                                <motion.button
+                                    type="button"
+                                    onClick={() => setVideoLoaded(true)}
+                                    aria-label={`Play video: ${VIDEO_TITLE}`}
+                                    className="group absolute inset-0 block h-full w-full cursor-pointer"
+                                    whileHover="hover"
+                                    whileTap="tap"
+                                >
+                                    <Image
+                                        src={VIDEO_THUMBNAIL}
+                                        alt=""
+                                        fill
+                                        sizes="(max-width: 896px) 100vw, 896px"
+                                        className="object-cover"
+                                    />
+                                    <span
+                                        aria-hidden="true"
+                                        className="absolute inset-0 bg-darkerBg/55"
+                                    />
+                                    <span className="absolute inset-0 flex items-center justify-center">
+                                        <motion.span
+                                            variants={{
+                                                hover: { scale: 1.08 },
+                                                tap: { scale: 0.95 },
+                                            }}
+                                            className="flex h-20 w-20 items-center justify-center rounded-full bg-caramel shadow-lg shadow-black/40 sm:h-16 sm:w-16"
+                                        >
+                                            <FaPlay
+                                                aria-hidden="true"
+                                                className="ml-1 text-2xl text-white sm:text-xl"
+                                            />
+                                        </motion.span>
+                                    </span>
+                                    <span className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-darkerBg/85 to-transparent px-6 pb-4 pt-10 text-left text-sm font-semibold text-white sm:px-4 sm:text-xs">
+                                        {VIDEO_TITLE}
+                                    </span>
+                                </motion.button>
                             )}
                             {videoLoaded && (
                                 <iframe
-                                    src="https://www.youtube.com/embed/vc4yL3YTwWk?autoplay=1"
-                                    title="The Truth About Honey"
+                                    src={`https://www.youtube.com/embed/${VIDEO_ID}?autoplay=1`}
+                                    title={VIDEO_TITLE}
                                     className="h-full w-full"
                                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                                     allowFullScreen
@@ -169,7 +204,7 @@ export default function WhyNotHoneySection() {
                             )}
                         </div>
                         <motion.a
-                            href="https://www.youtube.com/watch?v=vc4yL3YTwWk"
+                            href={`https://www.youtube.com/watch?v=${VIDEO_ID}`}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="mt-4 inline-flex items-center gap-2 text-sm text-gray-600 transition-colors duration-200 hover:text-caramel dark:text-gray-400"
@@ -187,12 +222,12 @@ export default function WhyNotHoneySection() {
                     whileInView={{ opacity: 1, y: 0 }}
                     viewport={{ once: true }}
                     transition={{ duration: 0.6, delay: 0.15, ease: 'easeOut' }}
-                    className="rounded-3xl bg-gradient-to-r from-caramel to-orange-600 p-12 text-center text-white shadow-2xl lg:p-8 sm:p-6"
+                    className="rounded-3xl bg-gradient-to-br from-caramel to-[#c9531a] p-12 text-center text-white shadow-2xl ring-1 ring-inset ring-white/20 dark:border dark:border-caramel/30 dark:bg-caramel/[0.12] dark:bg-none dark:ring-0 lg:p-8 sm:p-6"
                 >
-                    <h3 className="mb-6 text-3xl font-semibold tracking-tight lg:text-2xl">
+                    <h3 className="mb-6 text-3xl font-semibold tracking-tight text-white lg:text-2xl">
                         Make the Switch to Caramel
                     </h3>
-                    <p className="mx-auto mb-8 max-w-3xl text-lg leading-relaxed opacity-90">
+                    <p className="mx-auto mb-8 max-w-3xl text-lg leading-relaxed text-white/90">
                         Join thousands of users whoʼve made the switch to
                         Caramel. Save money while supporting the creators you
                         love, all with complete transparency and privacy

--- a/apps/caramel-app/src/layouts/Footer/Footer.tsx
+++ b/apps/caramel-app/src/layouts/Footer/Footer.tsx
@@ -3,50 +3,122 @@
 import { motion } from 'framer-motion'
 import Image from 'next/image'
 import Link from 'next/link'
+import { FaDiscord, FaGithub } from 'react-icons/fa'
+import { RiInstagramFill } from 'react-icons/ri'
 
-const footerLinks = [
+/* Read once at module scope so the server render and the first client render
+   produce the same string. The only divergence possible is a page that is
+   server-rendered on Dec 31 and hydrated on Jan 1, which is acceptable. */
+const currentYear = new Date().getFullYear()
+
+const productLinks = [
     { name: 'Home', url: '/' },
-    { name: 'Coupons', url: '/coupons' },
     { name: 'Pricing', url: '/pricing' },
-    { name: 'Privacy', url: '/privacy' },
+    { name: 'Coupons', url: '/coupons' },
     { name: 'Supported Stores', url: '/supported-stores' },
+    { name: 'Sources', url: '/sources' },
 ]
 
-export default function Footer() {
-    const currentYear = new Date().getFullYear()
+const communityLinks = [
+    {
+        name: 'GitHub',
+        url: 'https://github.com/DevinoSolutions/caramel',
+        icon: <FaGithub aria-hidden="true" />,
+    },
+    {
+        name: 'Discord',
+        url: 'https://discord.com/invite/2vVVrQ5CEB',
+        icon: <FaDiscord aria-hidden="true" />,
+    },
+    {
+        name: 'Instagram',
+        url: 'https://www.instagram.com/grab.caramel/',
+        icon: <RiInstagramFill aria-hidden="true" />,
+    },
+]
 
+const legalLinks = [{ name: 'Privacy Policy', url: '/privacy' }]
+
+const headingClasses =
+    'text-sm font-semibold uppercase tracking-wider text-white dark:text-caramel'
+const linkClasses =
+    'rounded text-[15px] text-white transition-colors hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 dark:text-gray-300 dark:hover:text-white dark:focus-visible:ring-caramel/70'
+
+export default function Footer() {
     return (
-        <footer className="bg-caramel text-white">
-            <div className="container mx-auto px-6 pt-10">
+        <footer className="border-t-2 border-dashed border-white/40 bg-gradient-to-br from-caramel to-[#c9531a] text-white dark:border-caramel/40 dark:bg-darkSurface dark:bg-none">
+            <div className="container mx-auto px-6 pt-12">
                 <motion.div
                     initial={{ opacity: 0, y: 20 }}
                     whileInView={{ opacity: 1, y: 0 }}
                     transition={{ duration: 0.3 }}
                     viewport={{ once: true }}
-                    className="flex flex-col items-center gap-6 text-center"
+                    className="grid grid-cols-[1.6fr_1fr_1fr_1fr] gap-10 md:grid-cols-2 sm:grid-cols-1 sm:text-center"
                 >
-                    <Link
-                        href="/"
-                        className="rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
-                    >
-                        <Image
-                            src="/full-logo.png"
-                            alt="Caramel"
-                            width={140}
-                            height={45}
-                            className="brightness-0 invert"
-                        />
-                    </Link>
-                    <p className="max-w-md text-sm text-white/90">
-                        The open-source, privacy-first way to save at checkout.
-                    </p>
-                    <nav aria-label="Footer">
-                        <ul className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm font-medium">
-                            {footerLinks.map(link => (
+                    <div className="flex flex-col items-start gap-4 sm:items-center">
+                        <Link
+                            href="/"
+                            className="rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 dark:focus-visible:ring-caramel/70"
+                        >
+                            <Image
+                                src="/full-logo.png"
+                                alt="Caramel"
+                                width={140}
+                                height={45}
+                                className="brightness-0 invert"
+                            />
+                        </Link>
+                        <p className="max-w-xs text-[15px] text-white dark:text-gray-300">
+                            The open-source, privacy-first way to save at
+                            checkout.
+                        </p>
+                    </div>
+
+                    <nav aria-label="Product">
+                        <h2 className={headingClasses}>Product</h2>
+                        <ul className="mt-4 flex flex-col gap-2.5">
+                            {productLinks.map(link => (
                                 <li key={link.name}>
                                     <Link
                                         href={link.url}
-                                        className="rounded text-white/90 transition-colors hover:text-white hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+                                        className={linkClasses}
+                                    >
+                                        {link.name}
+                                    </Link>
+                                </li>
+                            ))}
+                        </ul>
+                    </nav>
+
+                    <nav aria-label="Community">
+                        <h2 className={headingClasses}>Community</h2>
+                        <ul className="mt-4 flex flex-col gap-2.5">
+                            {communityLinks.map(link => (
+                                <li key={link.name}>
+                                    <a
+                                        href={link.url}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className={`inline-flex items-center gap-2 ${linkClasses}`}
+                                    >
+                                        <span className="text-base">
+                                            {link.icon}
+                                        </span>
+                                        {link.name}
+                                    </a>
+                                </li>
+                            ))}
+                        </ul>
+                    </nav>
+
+                    <nav aria-label="Legal">
+                        <h2 className={headingClasses}>Legal</h2>
+                        <ul className="mt-4 flex flex-col gap-2.5">
+                            {legalLinks.map(link => (
+                                <li key={link.name}>
+                                    <Link
+                                        href={link.url}
+                                        className={linkClasses}
                                     >
                                         {link.name}
                                     </Link>
@@ -64,24 +136,22 @@ export default function Footer() {
                     whileInView={{ opacity: 1, y: 0 }}
                     transition={{ duration: 0.3 }}
                     viewport={{ once: true }}
-                    className="border-t border-white/20 pt-6 text-center"
+                    className="mt-6 flex items-center justify-between gap-4 border-t border-white/25 pt-6 dark:border-white/10 sm:flex-col sm:text-center"
                 >
-                    <div className="flex flex-col items-center gap-3">
-                        <p className="text-sm text-white">
-                            © {currentYear} Caramel. All Rights Reserved.
-                        </p>
-                        <div className="flex items-center gap-2">
-                            <span className="text-sm text-white">
-                                Powered by
-                            </span>
-                            <Image
-                                src="/devino.png"
-                                alt="Devino"
-                                width={60}
-                                height={20}
-                                className="inline-block"
-                            />
-                        </div>
+                    <p className="text-sm text-white dark:text-gray-300">
+                        © {currentYear} Caramel. All Rights Reserved.
+                    </p>
+                    <div className="flex items-center gap-2">
+                        <span className="text-sm text-white dark:text-gray-300">
+                            Powered by
+                        </span>
+                        <Image
+                            src="/devino.png"
+                            alt="Devino"
+                            width={60}
+                            height={20}
+                            className="inline-block"
+                        />
                     </div>
                 </motion.div>
             </div>

--- a/apps/caramel-app/src/layouts/Header/Header.tsx
+++ b/apps/caramel-app/src/layouts/Header/Header.tsx
@@ -16,6 +16,9 @@ interface HeaderProps {
 interface NavLink {
     name: string
     url: string
+    /* Full accessible name where the visible label is abbreviated to keep the
+       nav pill on one line. */
+    ariaLabel?: string
 }
 
 const links: NavLink[] = [
@@ -23,7 +26,7 @@ const links: NavLink[] = [
     { name: 'Coupons', url: '/coupons' },
     { name: 'Pricing', url: '/pricing' },
     { name: 'Privacy', url: '/privacy' },
-    { name: 'Supported Stores', url: '/supported-stores' },
+    { name: 'Stores', url: '/supported-stores', ariaLabel: 'Supported Stores' },
 ]
 
 const Link = motion.create(L)
@@ -93,8 +96,12 @@ export default function Header({ scrollRef }: HeaderProps) {
                     className="mb-auto mt-auto w-4/5 cursor-pointer sm:w-5/12"
                 />
             </Link>
+            {/* The pill holds five links, the auth block and the theme toggle in
+                one row between a fixed 237px logo gutter and a 32px right pad.
+                Everything is nowrap, so the gap/padding scale steps down at the
+                narrower desktop widths instead of breaking onto a second line. */}
             <motion.div
-                className={`mx-auto flex w-full items-center justify-center gap-8 rounded-[28px] bg-white py-[15px] shadow dark:bg-darkerBg lg:hidden`}
+                className={`mx-auto flex w-full items-center justify-center gap-5 rounded-[28px] bg-white py-[15px] shadow dark:bg-darkerBg 2xl:gap-4 xl:gap-2 lg:hidden`}
                 style={{
                     paddingLeft: 'calc(185px + 1.25rem + 32px)',
                     paddingRight: '32px',
@@ -107,15 +114,16 @@ export default function Header({ scrollRef }: HeaderProps) {
                         <Link
                             key={link.name}
                             href={link.url || ''}
+                            aria-label={link.ariaLabel}
                             aria-current={isActive ? 'page' : undefined}
-                            className={`px-[30px] py-2.5 hover:scale-105 ${isActive ? 'bg-caramel text-white shadow-sm' : 'text-caramel hover:bg-caramel/10'} inline-flex cursor-pointer items-center justify-center gap-2.5 rounded-3xl transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/60`}
+                            className={`whitespace-nowrap px-6 py-2.5 hover:scale-105 2xl:px-4 ${isActive ? 'bg-caramel text-white shadow-sm' : 'text-caramel hover:bg-caramel/10'} inline-flex cursor-pointer items-center justify-center gap-2.5 rounded-3xl transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/60 xl:px-3 xl:text-sm`}
                         >
                             {link.name}
                         </Link>
                     )
                 })}
                 {session?.user ? (
-                    <div ref={userMenuRef} className="relative ml-6">
+                    <div ref={userMenuRef} className="relative ml-2">
                         <button
                             onClick={() => setIsUserMenuOpen(!isUserMenuOpen)}
                             aria-haspopup="menu"
@@ -154,26 +162,29 @@ export default function Header({ scrollRef }: HeaderProps) {
                         </AnimatePresence>
                     </div>
                 ) : (
-                    <div className="ml-6 flex items-center gap-4">
+                    <div className="ml-2 flex items-center gap-3 xl:gap-2">
                         <Link
                             href="/login"
-                            className="inline-flex cursor-pointer items-center justify-center gap-2.5 rounded-3xl border border-caramel px-6 py-2.5 font-medium text-caramel transition hover:scale-105 hover:bg-caramel/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/60"
+                            className="inline-flex cursor-pointer items-center justify-center gap-2.5 whitespace-nowrap rounded-3xl border border-caramel px-6 py-2.5 font-medium text-caramel transition hover:scale-105 hover:bg-caramel/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/60 xl:px-3 xl:text-sm"
                         >
                             Login
                         </Link>
                         <Link
                             href="/signup"
-                            className="inline-flex cursor-pointer items-center justify-center gap-2.5 rounded-3xl bg-caramel px-6 py-2.5 font-medium text-white shadow-sm transition hover:scale-105 hover:bg-caramel/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/60 focus-visible:ring-offset-2"
+                            className="inline-flex cursor-pointer items-center justify-center gap-2.5 whitespace-nowrap rounded-3xl bg-caramel px-6 py-2.5 font-medium text-white shadow-sm transition hover:scale-105 hover:bg-caramel/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/60 focus-visible:ring-offset-2 xl:px-3 xl:text-sm"
                         >
                             Sign Up
                         </Link>
                     </div>
                 )}
+                <ThemeToggle className="shrink-0" />
             </motion.div>
-            <div className="flex items-center gap-2 lg:ml-6">
-                <ThemeToggle className="absolute -right-4 lg:relative lg:right-auto lg:ml-0" />
+            {/* Mobile-only companion to the in-pill toggle above: the pill is
+                hidden at <=1023px, so the toggle and the menu button live here. */}
+            <div className="hidden items-center gap-2 lg:ml-6 lg:flex">
+                <ThemeToggle />
                 <button
-                    className="hidden rounded-lg text-2xl text-caramel transition-colors hover:text-caramelLight focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/60 lg:block"
+                    className="rounded-lg text-2xl text-caramel transition-colors hover:text-caramelLight focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/60"
                     onClick={() => setIsMenuOpen(!isMenuOpen)}
                     aria-label={isMenuOpen ? 'Close menu' : 'Open menu'}
                     aria-expanded={isMenuOpen}
@@ -196,8 +207,9 @@ export default function Header({ scrollRef }: HeaderProps) {
                                     onClick={() => setIsMenuOpen(false)}
                                     key={link.name}
                                     href={link.url || ''}
+                                    aria-label={link.ariaLabel}
                                     aria-current={isActive ? 'page' : undefined}
-                                    className={`px-[30px] py-2.5 ${isActive ? 'bg-caramel text-white shadow-sm' : 'text-caramel hover:bg-caramel/10'} inline-flex cursor-pointer items-center justify-center gap-2.5 rounded-3xl transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/60`}
+                                    className={`px-[30px] py-2.5 ${isActive ? 'bg-caramel text-white shadow-sm' : 'text-caramel hover:bg-caramel/10'} inline-flex cursor-pointer items-center justify-center gap-2.5 whitespace-nowrap rounded-3xl transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/60`}
                                 >
                                     {link.name}
                                 </Link>

--- a/apps/caramel-app/src/styles/globals.css
+++ b/apps/caramel-app/src/styles/globals.css
@@ -193,6 +193,39 @@ body {
     border-radius: 360px;
 }
 
+/* WebKit paints its own background on autofilled inputs and ignores
+   `background-color` / `background-image` outright, so the near-black auth
+   cards flashed a bright lavender-white field the moment Chrome filled them.
+   The only lever that works is a huge inset box-shadow, which sits under the
+   text but over the UA layer. Colors mirror the auth inputs' own dark styling
+   (`dark:bg-darkBg` + `dark:text-gray-100` in the (auth) forms) so a filled
+   field is indistinguishable from a typed one.
+
+   Setting box-shadow also wipes Tailwind's `focus:ring-2 ring-caramel/30`, so
+   the :focus variant re-states that ring after the fill layer.
+
+   Light mode is left alone: Chrome's default fill (#e8f0fe) against the white
+   auth card still renders gray-900 text well above AA. */
+html.dark input:-webkit-autofill,
+html.dark input:-webkit-autofill:hover,
+html.dark input:-webkit-autofill:active,
+html.dark textarea:-webkit-autofill,
+html.dark select:-webkit-autofill {
+    box-shadow: inset 0 0 0 1000px #191a1c;
+    -webkit-text-fill-color: #f3f4f6;
+    caret-color: #f3f4f6;
+}
+
+html.dark input:-webkit-autofill:focus,
+html.dark textarea:-webkit-autofill:focus,
+html.dark select:-webkit-autofill:focus {
+    box-shadow:
+        inset 0 0 0 1000px #191a1c,
+        0 0 0 2px rgb(234 105 37 / 0.3);
+    -webkit-text-fill-color: #f3f4f6;
+    caret-color: #f3f4f6;
+}
+
 /* Landing refinement (additive): crafted keyboard focus ring in brand color.
    :focus-visible only — mouse/touch interactions are unaffected. */
 @layer base {


### PR DESCRIPTION
Implements the 11 highest-value wins from the design audit of dev.grabcaramel.com (both themes, below the hero). All changes verified in a real browser (light + dark) against a production build.

## What changed
- **Card hover depth (all ~56 landing cards):** the old hover was an invisible border-alpha change; cards now lift (-translate-y-1) with a caramel shadow, icons scale on hover. Cross-cutting fix baked in: framer-motion writes inline `transform` and resets it to 'none' at rest, which silently kills Tailwind-3 translate classes on any motion element — every card's hover chrome now lives on a plain inner div (motion element keeps only the entrance animation). Verified empirically via DOM probes.
- **Comparison table:** one two-column header instead of labels repeated on all 10 cells; losing column muted 50% on a warm surface (dark rows no longer read as holes); Caramel column ring+tint; red X → muted neutral.
- **Video facade:** real YouTube thumbnail (verified 200) + warm overlay + caramel play button + title caption, replacing the empty black box. Click-to-load privacy preserved; i.ytimg.com added to images.remotePatterns.
- **Marquee:** ported the framer x-loop to an identical CSS keyframe (30s linear infinite — animation-play-state can't pause WAAPI), edge mask fade so cards stop hard-cutting mid-word, pause on hover, reduced-motion via media query.
- **Orange slabs (4):** gradient + inner highlight in light; tinted caramel/12 bordered panels in dark (kills the glare blocks); near-black-on-orange headings → white.
- **Dark logo wall:** dropped the flat-white invert; logos keep brand colors on white chips in dark.
- **Footer:** one-row strip → 3 columns (Product/Community/Legal) with real URLs only, GitHub/Discord/Instagram icons, dashed perforation top edge; dark = darkSurface instead of glaring orange. Year moved to module scope (hydration-safe).
- **Header:** nav no longer wraps at 1440px ('Supported Stores' → 'Stores' visible label, accessible name preserved so e2e locators keep working; whitespace-nowrap; stepped gaps), theme toggle moved inside the nav pill (duplicate-id removed, mobile instance kept).
- **Dark autofill:** WebKit autofill no longer paints lavender-white inside dark auth cards (inset box-shadow hack, focus ring preserved).
- **Pricing:** the free plan is now a literal coupon ticket — side notches, dashed perforation, barcode + serial strip; badge pill-ified; stat tiles aligned to the card's width. SectionDivider restyled to the same ticket motif (dashed caramel + punched notches; no longer full-bleed — ends at the content column).
- **Claim consistency:** pricing stat '∞ Stores Supported' → '5,000+' matching the rest of the site. ('Chrome, Firefox, Edge, Safari' support line verified true — all four store listings live, HTTP 200.)

## Gates
tsc ✅ prettier ✅ oxlint ✅ eslint ✅ knip ✅ vitest 406/406 ✅ production build ✅ (public routes still Static). Hydration law held: no new client-only reads in render; useReducedMotion only via @/lib/reducedMotion.

Backlog (audit tier-3, not in this PR): open-source section restructure, /sources dark-panel warmth + chart tuning, auth-page brand panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)