### PR TITLE
feat(seo): server-render /sources and /supported-stores initial data

### DIFF
--- a/apps/caramel-app/e2e/pages.spec.ts
+++ b/apps/caramel-app/e2e/pages.spec.ts
@@ -122,6 +122,23 @@ test.describe('Supported Stores Page', () => {
         // The page should have a search or list of stores
         await expect(page.locator('body')).toContainText(/supported|stores/i)
     })
+
+    // Deployment-safe SSR/SEO gate (both e2e contexts — docs/testing.md
+    // two-context rule): fetch the RAW server HTML, no JS execution, exactly
+    // what a crawler gets. Before the SSR change the "Top Supported Websites"
+    // grid only appeared after a client fetch of /api/sites/top-sites, so the
+    // crawler HTML had no store content at all. The catalog is never
+    // legitimately empty in either context (see the coupon-card test above),
+    // so the top-sites heading must be present in the initial HTML.
+    test('server HTML contains the top supported websites (crawler view)', async ({
+        page,
+    }) => {
+        const res = await page.request.get('/supported-stores')
+        expect(res.ok()).toBe(true)
+        const html = await res.text()
+        expect(html).toContain('Is your favourite store supported?')
+        expect(html).toContain('Top Supported Websites')
+    })
 })
 
 test.describe('Sources Page', () => {
@@ -130,5 +147,37 @@ test.describe('Sources Page', () => {
 
         // The page should show coupon source information
         await expect(page.locator('body')).toContainText(/source/i)
+    })
+
+    // Deployment-safe SSR/SEO gate (both e2e contexts): raw server HTML must
+    // carry the sources table already resolved — the pre-SSR page served a
+    // "Loading..." placeholder row and fetched /api/sources client-side, so
+    // crawlers saw no data. "Loading..." only renders while a client refetch
+    // is in flight, never in the server HTML anymore.
+    test('server HTML contains the sources table (crawler view)', async ({
+        page,
+    }) => {
+        const res = await page.request.get('/sources')
+        expect(res.ok()).toBe(true)
+        const html = await res.text()
+        expect(html).toContain('Caramel coupon sources')
+        expect(html).not.toContain('Loading...')
+    })
+
+    // HERMETIC-ONLY (docs/testing.md two-context rule): asserts the SPECIFIC
+    // synthetic seed sources, which only exist in the fresh-seeded e2e-pr/
+    // local DB — the deployed dev site serves real pipeline sources instead.
+    // See prisma/migrations/20260714220157_catalog_seed/migration.sql.
+    test('server HTML renders the synthetic seed sources (hermetic DB only)', async ({
+        page,
+    }) => {
+        test.skip(
+            !process.env.DATABASE_URL,
+            'asserts synthetic catalog_seed sources rows — only present in the hermetic e2e-pr/local DB (docs/testing.md two-context rule)',
+        )
+        const res = await page.request.get('/sources')
+        const html = await res.text()
+        expect(html).toContain('Caramel Sample Feed A')
+        expect(html).toContain('Caramel Sample Feed B')
     })
 })

--- a/apps/caramel-app/src/app/(marketing)/sources/SourcesPageClient.tsx
+++ b/apps/caramel-app/src/app/(marketing)/sources/SourcesPageClient.tsx
@@ -2,8 +2,9 @@
 import Doodles from '@/components/Doodles'
 import { ThemeContext } from '@/lib/contexts'
 import { decryptJsonData } from '@/lib/securityHelpers/decryptJsonData'
+import type { SourceMetrics } from '@/lib/sourceMetrics'
 import { motion } from 'framer-motion'
-import { useContext, useEffect, useState } from 'react'
+import { useContext, useState } from 'react'
 import {
     Bar,
     CartesianGrid,
@@ -17,29 +18,27 @@ import {
 } from 'recharts'
 import { toast } from 'sonner'
 
-// numberOfCoupons/successRate are `number` — matches SourceMetrics in
-// app/api/sources/route.ts (the only producer of this shape). Previously
-// declared `string` here despite the server always sending numbers; the
-// mismatch was masked by `parseInt/parseFloat(x as any)`, which round-trips
-// an already-numeric value unchanged (String() then re-parse). Correcting
-// the type here removes the dead casts below with no behavior change.
-interface Source {
-    id: string
-    source: string
-    websites: string[]
-    numberOfCoupons: number
-    successRate: number
-}
+// The row shape is the shared SourceMetrics from lib/sourceMetrics.ts — the
+// ONE producer both the SSR page (initialSources prop) and the /api/sources
+// refetch below go through, so the two can never drift.
 
-export default function SourcesPageClient() {
-    const [sources, setSources] = useState<Source[]>([])
-    const [loading, setLoading] = useState(true)
+export default function SourcesPageClient({
+    initialSources,
+}: {
+    /** Server-rendered initial table (SEO) — same mapper as /api/sources. */
+    initialSources: SourceMetrics[]
+}) {
+    const [sources, setSources] = useState<SourceMetrics[]>(initialSources)
+    const [loading, setLoading] = useState(false)
     const [loadError, setLoadError] = useState(false)
     const [websitesInput, setWebsitesInput] = useState('')
     const [showModal, setShowModal] = useState(false)
     const [searchTerm, setSearchTerm] = useState('')
     const { isDarkMode } = useContext(ThemeContext)
 
+    // No mount-time fetch anymore: the server component already rendered the
+    // initial data into the HTML. This refetch runs only after submitting a
+    // new source, to refresh the table through the API.
     const fetchSources = async () => {
         setLoading(true)
         setLoadError(false)
@@ -47,7 +46,9 @@ export default function SourcesPageClient() {
             const res = await fetch('/api/sources')
             if (!res.ok) throw new Error(`HTTP ${res.status}`)
             const data = await res.json()
-            const plainObj = await decryptJsonData<{ data?: Source[] }>(data)
+            const plainObj = await decryptJsonData<{ data?: SourceMetrics[] }>(
+                data,
+            )
             setSources(Array.isArray(plainObj?.data) ? plainObj.data : [])
         } catch (error) {
             console.error('Error fetching sources:', error)
@@ -57,10 +58,6 @@ export default function SourcesPageClient() {
             setLoading(false)
         }
     }
-
-    useEffect(() => {
-        fetchSources()
-    }, [])
 
     const isValidUrl = (url: string): boolean => {
         try {
@@ -114,7 +111,7 @@ export default function SourcesPageClient() {
     }))
 
     return (
-        <main className="relative min-h-screen overflow-x-clip bg-gray-50 p-6 text-gray-800 dark:bg-transparent dark:text-gray-50">
+        <main className="relative min-h-screen overflow-x-clip bg-gray-50 p-6 text-gray-800 dark:bg-darkBg dark:text-gray-50">
             <Doodles />
             <motion.h1
                 className="mb-4 text-center text-4xl font-bold text-caramel"
@@ -129,7 +126,7 @@ export default function SourcesPageClient() {
                         role="dialog"
                         aria-modal="true"
                         aria-label="Submit a New Source"
-                        className="relative w-full max-w-md rounded-2xl bg-white p-6 shadow-xl dark:bg-darkerBg"
+                        className="relative w-full max-w-md rounded-2xl bg-white p-6 shadow-xl dark:border dark:border-caramel/30 dark:bg-darkSurface"
                         initial={{ opacity: 0, y: -20 }}
                         animate={{ opacity: 1, y: 0 }}
                     >
@@ -164,20 +161,20 @@ export default function SourcesPageClient() {
                                     onChange={e =>
                                         setWebsitesInput(e.target.value)
                                     }
-                                    className="mt-1 w-full rounded-lg border border-gray-300 p-2 text-black transition focus:border-caramel focus:outline-none focus:ring-2 focus:ring-caramel/40 dark:border-gray-700 dark:bg-darkBg dark:text-white dark:placeholder-gray-500"
+                                    className="mt-1 w-full rounded-lg border border-gray-300 p-2 text-black transition focus:border-caramel focus:outline-none focus:ring-2 focus:ring-caramel/40 dark:border-white/10 dark:bg-darkBg dark:text-white dark:placeholder-gray-500"
                                 />
                             </div>
                             <div className="flex justify-end space-x-2">
                                 <button
                                     type="button"
-                                    className="transform rounded-lg bg-gray-500 px-4 py-2 text-white transition hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-darkerBg"
+                                    className="transform rounded-lg bg-gray-500 px-4 py-2 text-white transition hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-darkSurface"
                                     onClick={() => setShowModal(false)}
                                 >
                                     Cancel
                                 </button>
                                 <button
                                     type="submit"
-                                    className="transform rounded-lg bg-caramel px-4 py-2 font-semibold text-white transition hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel focus-visible:ring-offset-2 dark:focus-visible:ring-offset-darkerBg"
+                                    className="transform rounded-lg bg-caramel px-4 py-2 font-semibold text-white transition hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel focus-visible:ring-offset-2 dark:focus-visible:ring-offset-darkSurface"
                                 >
                                     Submit
                                 </button>
@@ -206,11 +203,11 @@ export default function SourcesPageClient() {
                         aria-label="Search sources"
                         value={searchTerm}
                         onChange={e => setSearchTerm(e.target.value)}
-                        className="w-full rounded-lg border border-gray-300 bg-white p-2.5 text-black shadow-sm transition focus:border-caramel focus:outline-none focus:ring-2 focus:ring-caramel/40 dark:border-gray-700 dark:bg-darkerBg dark:text-white dark:placeholder-gray-500"
+                        className="w-full rounded-lg border border-gray-300 bg-white p-2.5 text-black shadow-sm transition focus:border-caramel focus:outline-none focus:ring-2 focus:ring-caramel/40 dark:border-white/10 dark:bg-darkSurface dark:text-white dark:placeholder-gray-500"
                     />
                 </div>
                 <div className="grid grid-cols-1 gap-6">
-                    <div className="overflow-x-auto rounded-xl border border-gray-100 bg-white p-6 shadow dark:border-gray-800 dark:bg-darkerBg">
+                    <div className="overflow-x-auto rounded-xl border border-gray-100 bg-white p-6 shadow dark:border-caramel/30 dark:bg-darkSurface">
                         <table className="w-full text-left">
                             <thead>
                                 <tr className="bg-gray-100 text-xs font-semibold uppercase tracking-wider text-gray-600 dark:bg-darkBg dark:text-gray-300">
@@ -248,7 +245,7 @@ export default function SourcesPageClient() {
                                     filteredSources.map(src => (
                                         <tr
                                             key={src.id}
-                                            className="border-b border-gray-100 transition-colors hover:bg-gray-50 dark:border-gray-800 dark:hover:bg-darkBg/50"
+                                            className="border-b border-gray-100 transition-colors hover:bg-gray-50 dark:border-white/10 dark:hover:bg-darkBg/50"
                                         >
                                             <td className="px-4 py-3 font-medium">
                                                 {src.source}
@@ -280,7 +277,7 @@ export default function SourcesPageClient() {
                             </tbody>
                         </table>
                     </div>
-                    <div className="rounded-xl border border-gray-100 bg-white p-6 shadow dark:border-gray-800 dark:bg-darkerBg">
+                    <div className="rounded-xl border border-gray-100 bg-white p-6 shadow dark:border-caramel/30 dark:bg-darkSurface">
                         <div className="h-96 w-full">
                             {loading ? (
                                 <div className="flex h-full items-center justify-center text-gray-500">

--- a/apps/caramel-app/src/app/(marketing)/sources/page.tsx
+++ b/apps/caramel-app/src/app/(marketing)/sources/page.tsx
@@ -1,6 +1,14 @@
+import { listActiveSources } from '@/lib/couponsRepo'
 import { BASE_URL } from '@/lib/env.client'
+import { toSourceMetrics } from '@/lib/sourceMetrics'
 import type { Metadata } from 'next'
 import SourcesPageClient from './SourcesPageClient'
+
+// This page reads the coupon catalog from Postgres, and the production image
+// builds against a deliberately unreachable placeholder DATABASE_URL (see the
+// Dockerfile's `.invalid` builder env) — so it must be rendered per-request,
+// never prerendered at build time (same pattern as app/sitemap.ts).
+export const dynamic = 'force-dynamic'
 
 const title = 'Where Caramel Coupon Codes Come From | Sources'
 const description =
@@ -40,6 +48,11 @@ export const metadata: Metadata = {
     },
 }
 
-export default function SourcesPage() {
-    return <SourcesPageClient />
+export default async function SourcesPage() {
+    // SEO: fetch the initial table server-side (same read + mapper as
+    // /api/sources) so crawlers get the populated HTML instead of the old
+    // client-fetch "Loading..." shell. The client keeps refetching through
+    // the API after a source submission.
+    const initialSources = toSourceMetrics(await listActiveSources())
+    return <SourcesPageClient initialSources={initialSources} />
 }

--- a/apps/caramel-app/src/app/(marketing)/supported-stores/page.tsx
+++ b/apps/caramel-app/src/app/(marketing)/supported-stores/page.tsx
@@ -1,6 +1,13 @@
 import SearchSection from '@/components/supported-site/search-section'
+import { listTopSites } from '@/lib/couponsRepo'
 import { BASE_URL } from '@/lib/env.client'
 import type { Metadata } from 'next'
+
+// This page reads the coupon catalog from Postgres, and the production image
+// builds against a deliberately unreachable placeholder DATABASE_URL (see the
+// Dockerfile's `.invalid` builder env) — so it must be rendered per-request,
+// never prerendered at build time (same pattern as app/sitemap.ts).
+export const dynamic = 'force-dynamic'
 
 const title = 'Caramel | Supported Stores'
 const description =
@@ -38,10 +45,19 @@ export const metadata: Metadata = {
     },
 }
 
-export default function SupportedSitesPage() {
+export default async function SupportedSitesPage() {
+    // SEO: fetch the "Top Supported Websites" grid server-side (same read the
+    // /api/sites/top-sites route uses) so crawlers see actual store names in
+    // the HTML instead of the old client-fetch empty shell. The nullable-site
+    // filter mirrors app/sitemap.ts — a null GROUP BY site is possible in the
+    // row shape and unrenderable here.
+    const topSiteRows = await listTopSites()
+    const initialTopSites = topSiteRows
+        .map(row => row.site)
+        .filter((site): site is string => Boolean(site && site.trim()))
     return (
         <main className="flex min-h-screen flex-col items-center px-6 pt-32 dark:bg-darkBg">
-            <SearchSection />
+            <SearchSection initialTopSites={initialTopSites} />
         </main>
     )
 }

--- a/apps/caramel-app/src/app/api/sources/route.ts
+++ b/apps/caramel-app/src/app/api/sources/route.ts
@@ -2,16 +2,8 @@ import { handleRouteError } from '@/lib/api/handleRouteError'
 import { withRoute } from '@/lib/api/withRoute'
 import { nextApiResponse } from '@/lib/apiResponseNext'
 import { listActiveSources, requestSource } from '@/lib/couponsRepo'
+import { toSourceMetrics } from '@/lib/sourceMetrics'
 import { z } from 'zod'
-
-type SourceMetrics = {
-    id: string
-    source: string
-    websites: string[]
-    numberOfCoupons: number
-    successRate: number
-    status: string
-}
 
 // Strict on presence only (missing/empty `website` -> 422 — the flagged
 // PLAN-F-007.md §Breaking change for this route, table row "POST
@@ -28,23 +20,11 @@ export const GET = withRoute(
     { method: 'GET', routeName: 'sources', rateLimit: 'read' },
     async ({ req }) => {
         try {
-            const rows = await listActiveSources()
-
-            const sourcesWithMetrics: SourceMetrics[] = rows
-                .map(r => {
-                    const denom = r.total_used + r.total_expired
-                    const successRate =
-                        denom === 0 ? 0 : (r.total_used / denom) * 100
-                    return {
-                        id: r.id,
-                        source: r.source,
-                        websites: r.websites,
-                        numberOfCoupons: r.total_coupons,
-                        successRate: parseFloat(successRate.toFixed(2)),
-                        status: r.status,
-                    }
-                })
-                .sort((a, b) => b.successRate - a.successRate)
+            // Same mapper the /sources server component uses — see
+            // lib/sourceMetrics.ts for why the two must never drift.
+            const sourcesWithMetrics = toSourceMetrics(
+                await listActiveSources(),
+            )
 
             return nextApiResponse(req, 200, 'sources', sourcesWithMetrics)
         } catch (error) {

--- a/apps/caramel-app/src/components/supported-site/search-section.tsx
+++ b/apps/caramel-app/src/components/supported-site/search-section.tsx
@@ -4,34 +4,23 @@ import Loader from '@/components/Loader'
 import { AnimatePresence, motion } from 'framer-motion'
 import debounce from 'lodash.debounce'
 import { useEffect, useRef, useState } from 'react'
-import { toast } from 'sonner'
 import SiteCard from './site-card'
 import SuggestionForm from './suggestion-form'
 
-export default function SearchSection() {
+export default function SearchSection({
+    initialTopSites,
+}: {
+    /** Server-rendered "Top Supported Websites" (SEO) — same read as /api/sites/top-sites. */
+    initialTopSites: string[]
+}) {
     const [query, setQuery] = useState('')
-    const [sites, setSites] = useState([])
-    const [topSites, setTopSites] = useState([])
+    const [sites, setSites] = useState<string[]>([])
+    // No mount-time fetch: the /supported-stores server component passes the
+    // top sites down so they are already in the server-rendered HTML.
+    const topSites = initialTopSites
     const [loading, setLoading] = useState(false)
     const [searched, setSearched] = useState(false)
 
-    const loadTopSites = async () => {
-        setLoading(true)
-        setSearched(false)
-        setSites([])
-        try {
-            const res = await fetch('/api/sites/top-sites')
-            const data = await res.json()
-            setTopSites(data.sites || [])
-        } catch (err) {
-            toast.error('Failed to load top sites.')
-            console.error('Failed to load top sites:', err)
-        }
-        setLoading(false)
-    }
-    useEffect(() => {
-        loadTopSites()
-    }, [])
     const runSearch = async (q: string) => {
         setLoading(true)
         try {

--- a/apps/caramel-app/src/lib/sourceMetrics.ts
+++ b/apps/caramel-app/src/lib/sourceMetrics.ts
@@ -1,0 +1,35 @@
+// The ONE producer of the public "source metrics" shape. Both consumers of
+// listActiveSources() — the /api/sources GET route (client refetch after a
+// source submission) and the /sources server component (SEO: initial data is
+// server-rendered into the HTML) — must emit identical objects, or the
+// hydrated table would flash different numbers than the crawler-visible HTML.
+// Keeping the mapping here (not duplicated in the route and the page) makes
+// that agreement structural instead of remembered.
+import type { SourceRow } from '@/lib/couponsDb'
+
+export type SourceMetrics = {
+    id: string
+    source: string
+    websites: string[]
+    numberOfCoupons: number
+    successRate: number
+    status: string
+}
+
+/** Maps the aggregated `sources` rows to the public shape, sorted by success rate descending (pre-existing /api/sources ordering, preserved verbatim). */
+export function toSourceMetrics(rows: SourceRow[]): SourceMetrics[] {
+    return rows
+        .map(r => {
+            const denom = r.total_used + r.total_expired
+            const successRate = denom === 0 ? 0 : (r.total_used / denom) * 100
+            return {
+                id: r.id,
+                source: r.source,
+                websites: r.websites,
+                numberOfCoupons: r.total_coupons,
+                successRate: parseFloat(successRate.toFixed(2)),
+                status: r.status,
+            }
+        })
+        .sort((a, b) => b.successRate - a.successRate)
+}


### PR DESCRIPTION
## SEO: server-render `/sources` and `/supported-stores` initial data

Both pages shipped thin client-fetched shells — a crawler got a `Loading...` placeholder (`/sources`) or an empty grid (`/supported-stores`) because all data arrived via `useEffect` fetches to `/api/sources` and `/api/sites/top-sites`.

### What changed
- **`/sources`**: the page server component now calls `listActiveSources()` (existing `couponsRepo` read, zod-parsed) and passes `initialSources` to `SourcesPageClient`. The row mapping was extracted to `src/lib/sourceMetrics.ts` — ONE producer shared by the API route and the page, so SSR HTML and the client refetch can never drift. The client keeps its interactivity (search filter, chart, submit-source modal + post-submit refetch through the API).
- **`/supported-stores`**: the page calls `listTopSites()` (same read as `/api/sites/top-sites`) and passes `initialTopSites` to `SearchSection`; the mount-time fetch is gone, live search is unchanged.
- **Build safety**: both pages export `dynamic = 'force-dynamic'` with the same comment/pattern as `app/sitemap.ts` — the production image builds against an unreachable `.invalid` `DATABASE_URL`, so nothing may prerender against the DB at build time.
- **Warm-dark polish on `/sources`** (while owning the page): cold `dark:bg-darkerBg` / `dark:border-gray-700/800` leftovers on the table card, chart card, inputs and modal swapped for the landing's warm tokens (`dark:bg-darkSurface`, `dark:bg-darkBg`, `dark:border-caramel/30`, `dark:border-white/10`), matching FeaturesSection/PricingSection. No layout changes. (The two remaining `darkerBg` hits in the page HTML are the shared navbar — out of scope.)

### Before / after (crawler view)
| Probe (raw server HTML, no JS) | Before | After (verified on local `next start` + seeded pg) |
| --- | --- | --- |
| `/sources` contains source rows | ❌ `Loading...` row only | ✅ `Caramel Sample Feed A`/`B` present, no `Loading...` (39.7 KB HTML, HTTP 200) |
| `/supported-stores` contains store content | ❌ heading + empty grid | ✅ `Top Supported Websites` + `ebay.com`, `codecademy.com` in HTML |
| Build route table | `○ (Static)` | `ƒ (Dynamic)` for both routes; `next build` green with DB unreachable |

### Tests
- `e2e/pages.spec.ts` extended: two deployment-safe raw-HTML crawler-view gates (both e2e contexts) + one hermetic-only seed-sources assertion gated on `test.skip(!process.env.DATABASE_URL, ...)`; no top-level `@prisma/client` import. Full `pages.spec.ts` run vs the local built server: **14/14 passed**.

### Gates
`pnpm lint` ✅ · `pnpm lint:oxlint` ✅ · `pnpm prettier-check` ✅ · `pnpm --filter caramel-app knip` ✅ · `pnpm -r run type-check` ✅ · `pnpm test` ✅ (406 app + 36 extension) · `pnpm --filter caramel-app run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
