### PR TITLE
fix(landing): AA footer links on gradient, FAQ cards above ornaments

### DIFF
--- a/apps/caramel-app/src/components/FaqSection.tsx
+++ b/apps/caramel-app/src/components/FaqSection.tsx
@@ -83,9 +83,16 @@ export default function FaqSection(): React.JSX.Element {
 
                 <div className="mx-auto max-w-4xl space-y-4">
                     {faqItems.map(item => (
+                        /* Opaque base color (bg-gray-50/darkBg = the page bg the
+                           translucent gradient already composited over, so the
+                           card looks identical) — without it the fixed Doodles
+                           ornament layer (z-[1]) showed THROUGH the low-alpha
+                           card gradient and painted "over" the card surface.
+                           z-order was never the issue: this z-10 container
+                           already beats z-[1]; only opacity stops show-through. */
                         <details
                             key={item.question}
-                            className="group overflow-hidden rounded-2xl border border-caramel/20 bg-gradient-to-br from-caramel/5 via-orange-50/30 to-caramel/5 shadow-md transition-all duration-300 open:border-caramel/60 hover:border-caramel/60 dark:border-caramel/30 dark:from-caramel/10 dark:via-orange-900/20 dark:to-caramel/10"
+                            className="group overflow-hidden rounded-2xl border border-caramel/20 bg-gray-50 bg-gradient-to-br from-caramel/5 via-orange-50/30 to-caramel/5 shadow-md transition-all duration-300 open:border-caramel/60 hover:border-caramel/60 dark:border-caramel/30 dark:bg-darkBg dark:from-caramel/10 dark:via-orange-900/20 dark:to-caramel/10"
                         >
                             <summary className="flex cursor-pointer list-none items-center justify-between gap-4 p-6 text-left text-lg font-bold tracking-tight text-gray-800 marker:hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/70 dark:text-white sm:p-4 sm:text-base [&::-webkit-details-marker]:hidden">
                                 {item.question}

--- a/apps/caramel-app/src/layouts/Footer/Footer.tsx
+++ b/apps/caramel-app/src/layouts/Footer/Footer.tsx
@@ -56,6 +56,12 @@ export default function Footer() {
         // both fail — so the footer runs a deepened caramel pair instead:
         // #c14e14 (4.81:1) → #a63f10 (6.29:1). Same hue family, text stays
         // white. Don't lighten these back to from-caramel without re-checking.
+        //
+        // Re-verified 2026-07-28 — the nav links in linkClasses are the same
+        // white (4.81:1 / 6.29:1 vs the two stops), hover keeps white (underline
+        // only). gray-300 here would FAIL: 3.26:1 / 4.27:1 — never use it on
+        // this gradient. Dark mode swaps the surface to darkSurface #1E1916,
+        // where gray-300 links hit 11.8:1 (hover white 17.4:1) — both pass.
         <footer className="border-t-2 border-dashed border-white/40 bg-gradient-to-br from-[#c14e14] to-[#a63f10] text-white dark:border-caramel/40 dark:bg-darkSurface dark:bg-none">
             <div className="container mx-auto px-6 pt-12">
                 <motion.div


### PR DESCRIPTION
Two live-verified landing fixes, both browser-verified against a local prod build (light + dark).

## 1. Footer link contrast (WCAG AA)

The reported gray-300 links turned out to be a deploy race: `e9b7fb6` (white links) + `aa7ae70` (deepened gradient) had already landed on `dev` but weren't deployed when the live check ran. This PR independently re-verifies the math and bakes the link-specific numbers into the WCAG comment in `Footer.tsx` so nobody regresses them:

| Text color | vs #c14e14 (light stop) | vs #a63f10 (dark stop) | AA 4.5:1 |
|---|---|---|---|
| white (links, headings, body) | **4.81:1** | **6.29:1** | pass |
| gray-300 rgb(209,213,219) | 3.26:1 | 4.27:1 | **fail — never use on this gradient** |

Hover keeps white (underline only), so hover state stays at 4.81/6.29. Dark mode is scoped separately (footer surface swaps to `darkSurface` #1E1916): gray-300 links = 11.8:1, hover white = 17.4:1 — both pass. Computed-style check on the prod build: light `footer nav a` = `rgb(255,255,255)`.

## 2. FAQ ornaments painting over card surfaces

Root cause was NOT z-order: the fixed `Doodles` ornament layer is `z-[1]` and the FAQ content container is already `z-10` in the root stacking context. The cards only had a 5-30% alpha gradient with **no background-color**, so the ornaments showed *through* the card surface in both themes. Fix: give the cards an opaque base (`bg-gray-50 dark:bg-darkBg` — exactly the page background the translucent gradient already composited over), so rendering is pixel-identical except ornaments can no longer bleed through. Ornaments untouched and still visible everywhere else. Verified via prod-build screenshots (light + dark): card computed background is opaque `rgb(249,250,251)` / `rgb(25,26,28)`, no ornament over any card.

## Gates

`pnpm lint` / `lint:oxlint` / `prettier-check` / `knip` / `type-check` / `pnpm test` / prod `build` — all green (husky pre-commit also passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)