### PR TITLE
fix(hero): crisp readable 3D stat text and % glyphs

### DIFF
--- a/apps/caramel-app/src/components/HeroTicketScene.tsx
+++ b/apps/caramel-app/src/components/HeroTicketScene.tsx
@@ -261,41 +261,50 @@ function StatCoupon3D({
                     dash={0.05}
                     color={isDark ? CARAMEL_LIGHT : '#fff2e6'}
                 />
-                {/* Soft dark outline-blur = printed-ink shadow, so the type
-                    reads as pressed into the caramel glass (deliberately a
-                    touch stronger on the number so it pops off the caramel). */}
+                {/* Sticker-print treatment (2026-07-29 legibility rework):
+                    white fill + a SOLID full-opacity espresso outline — the
+                    old blurred half-opacity halo (outlineBlur 0.024/0.012 at
+                    50%/35%) read as smudged ink and let the glossy caramel
+                    highlights swallow the white fill. A crisp dark rim keeps
+                    contrast against BOTH theme faces (bright CARAMEL in light,
+                    CARAMEL_DEEP in dark) no matter where the clearcoat
+                    highlight sweeps. sdfGlyphSize 128 (troika default 64) is
+                    what fixes the "%" specifically — its two small counters
+                    and thin diagonal go lumpy at 64. Lifted a touch off the
+                    face (0.03) so the specular sheen doesn't kiss the glyph
+                    edges. */}
                 <Text
                     font={STAT_FONT}
-                    fontSize={0.34}
-                    position={[0, 0.13, STAT_FRONT + 0.012]}
+                    fontSize={0.38}
+                    position={[0, 0.14, STAT_FRONT + 0.03]}
                     anchorX="center"
                     anchorY="middle"
                     color="#ffffff"
-                    outlineWidth={0.016}
-                    outlineBlur={0.024}
-                    outlineColor="#7a2f00"
-                    outlineOpacity={0.5}
+                    outlineWidth={0.024}
+                    outlineColor="#4a1c05"
+                    outlineOpacity={1}
+                    sdfGlyphSize={128}
                 >
                     {shown}
                 </Text>
                 {/* Label fit math (longest label = "SUPPORTED STORES", 16
                     glyphs): Poppins-Bold uppercase averages ~0.62em advance,
-                    so width ≈ 16 × 0.11 × (0.62 + 0.08 letterSpacing) ≈ 1.23 —
+                    so width ≈ 16 × 0.12 × (0.62 + 0.06 letterSpacing) ≈ 1.31 —
                     inside the usable face width of STAT.w 1.7 − 2 × notch r
-                    0.14 = 1.42, with ~0.095 margin per side. That's why the
-                    letterSpacing dropped 0.12 → 0.08 alongside the size bump. */}
+                    0.14 = 1.42, with ~0.055 margin per side (float tilt only
+                    rotates the ticket, the type rides it like print). */}
                 <Text
                     font={STAT_FONT}
-                    fontSize={0.11}
-                    letterSpacing={0.08}
-                    position={[0, -0.22, STAT_FRONT + 0.012]}
+                    fontSize={0.12}
+                    letterSpacing={0.06}
+                    position={[0, -0.22, STAT_FRONT + 0.03]}
                     anchorX="center"
                     anchorY="middle"
                     color="#ffffff"
-                    outlineWidth={0.006}
-                    outlineBlur={0.012}
-                    outlineColor="#7a2f00"
-                    outlineOpacity={0.35}
+                    outlineWidth={0.008}
+                    outlineColor="#4a1c05"
+                    outlineOpacity={1}
+                    sdfGlyphSize={128}
                 >
                     {stat.label.toUpperCase()}
                 </Text>


### PR DESCRIPTION
## What

Rework the in-canvas 3D stat text treatment on the hero's three floating stat coupons (`HeroTicketScene.tsx`) so the numbers, labels, and especially the `%` glyphs are crisply readable in both themes.

## Root cause (why the previous "legible text" pass still read badly)

Three compounding issues in the drei/troika `<Text>` setup:

1. **Blurred, half-opacity outline** — `outlineBlur 0.024/0.012` at `outlineOpacity 0.5/0.35` rendered as a smudged ink halo around every glyph instead of a contrast edge. On the small `%` counters the blur bled *into* the counter holes and clogged them.
2. **Default SDF resolution (64)** — troika's default `sdfGlyphSize` of 64 is too coarse for Poppins-Bold's `%` (two small ring counters + a thin diagonal): the rings rendered lumpy/filled at the on-screen size the coupons get.
3. **White fill over a glossy specular face with no solid rim** — the ticket material is clearcoated/transmissive caramel; wherever a highlight swept the face, the white fill lost its edge (worst in light theme).

## Fix

- Solid, full-opacity espresso (`#4a1c05`) outline — a crisp print/sticker rim instead of a blur halo. High contrast against both theme faces (bright `CARAMEL` light / `CARAMEL_DEEP` dark), independent of where the clearcoat highlight lands.
- `sdfGlyphSize` 64 → 128 on both texts — this is what specifically fixes the ugly `%`: counters stay open, the diagonal stays clean.
- Number `fontSize` 0.34 → 0.38, label 0.11 → 0.12 (letterSpacing 0.08 → 0.06; longest label still fits the face with margin — fit math updated in the comment).
- Text lifted slightly off the face (z 0.012 → 0.03) so the specular sheen doesn't kiss the glyph edges.

Kept: count-up via shared `useCountUp` (hydration-safe pattern untouched), three-coupon layout/float/parallax, reduced-motion + WebGL gating, canvas clip-bleed math, DPR clamp `[1, 1.5]`. No new dependency — drei `<Text>`/troika were already in the tree. No e2e/visual test pins the old props (verified: no references in `e2e/` or `tests/`).

## Verification

Screenshotted on a local **production build** (`next build` + `next start`), headless Chromium, light + dark, dsf 1 and 2 (before-state captured from dev.grabcaramel.com, which runs current `dev`):

- `%` counters: clogged/lumpy → open, clean diagonal
- Number edges: smudged halo → crisp espresso rim
- Light-theme contrast: fill washed out near clearcoat highlights → stable in both themes
- Full-hero composition, float animation, and canvas clip bleed unchanged

Gates: `pnpm lint` ✅ · `lint:oxlint` ✅ · `prettier-check` ✅ · `knip` ✅ · `type-check` ✅ · `pnpm test` (36 ext + 418 app) ✅ · prod build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
