### PR TITLE
feat(hero): bigger scattered floating stat coupons with pointer interaction

### DIFF
--- a/apps/caramel-app/src/components/HeroSection.tsx
+++ b/apps/caramel-app/src/components/HeroSection.tsx
@@ -471,8 +471,10 @@ export default function HeroSection() {
                 </div>
 
                 {/* RIGHT column: on desktop, ONE interactive WebGL box holds
-                    the main 3D coupon AND the row of three same-size 3D stat
-                    coupons beneath it. A poster + the DOM stat cards cross-fade
+                    the main 3D coupon AND three large 3D stat coupons
+                    scattered around it at varied depths (soft independent
+                    floating + pointer reaction — see HeroTicketScene's
+                    SCATTER). A poster + the DOM stat cards cross-fade
                     underneath until the canvas is ready — and stay as the
                     permanent presentation for reduced-motion / no-WebGL desktop.
                     Below lg the box is hidden (phones never mount three) and the

--- a/apps/caramel-app/src/components/HeroTicketScene.tsx
+++ b/apps/caramel-app/src/components/HeroTicketScene.tsx
@@ -3,16 +3,21 @@
 // HeroTicketScene — the compact WebGL half of the split hero (right column,
 // desktop/lg+ only). Same ticket visual language as the shared ./couponTicket3d
 // geometry + palette, deliberately LIGHT: one big main ticket with springy
-// mouse-parallax tilt + Float, PLUS a row of THREE same-size 3D stat coupons
-// beneath it (each a real ticket mesh, floating like the main card, its number
-// counting up as IN-CANVAS 3D text so the type moves with the ticket like
-// print), a handful of instanced droplets, low-count Sparkles,
-// and a one-frame Lightformer environment. No ContactShadows and no scroll
-// dolly — the hero doesn't scroll-drive. Loaded via next/dynamic ssr:false and
-// only mounted after the browser is idle + a real WebGL context + a lg+ viewport
-// (HeroSection gates all of that), so the `three` chunk never touches phones or
-// first paint. Below lg / reduced-motion / no-WebGL the stats fall back to DOM
-// coupon cards in HeroSection (shared HERO_STATS data).
+// mouse-parallax tilt + Float, PLUS three LARGE 3D stat coupons (each a real
+// ticket mesh at 0.62–0.71× the main coupon's size) SCATTERED around it at
+// varied depths — an art-directed "random soft floating" composition, not a
+// row. Each stat coupon drifts/bobs/sways on its own frequency + phase (never
+// in sync), and reacts to the pointer: the coupon nearest the cursor gently
+// lifts toward the camera, tilts toward the pointer and pops ~4% — all damped,
+// no snapping. Numbers count up as IN-CANVAS 3D text so the type moves with
+// the ticket like print. A handful of instanced droplets, low-count Sparkles,
+// and a one-frame Lightformer environment complete the scene. No
+// ContactShadows and no scroll dolly — the hero doesn't scroll-drive. Loaded
+// via next/dynamic ssr:false and only mounted after the browser is idle + a
+// real WebGL context + a lg+ viewport (HeroSection gates all of that), so the
+// `three` chunk never touches phones or first paint. Below lg /
+// reduced-motion / no-WebGL the stats fall back to DOM coupon cards in
+// HeroSection (shared HERO_STATS data).
 //
 // Perf posture (brief "not heavy"): DPR clamped [1, 1.5]; frameloop gated by
 // the `active` prop (parent IntersectionObserver → 'never' when the hero is
@@ -20,6 +25,8 @@
 // three stat coupons SHARE one geometry; droplets are ONE instanced mesh (≤10);
 // the environment + emblem ship no network fetch; the stat type is SDF text
 // (drei <Text>) on a SELF-HOSTED font, count-up runs only ~1.2s after mount.
+// The per-coupon pointer reaction adds one Vector3 project per stat coupon per
+// frame (3 total) — negligible.
 
 import { formatStat, HERO_STATS, useCountUp } from '@/lib/heroStats'
 import {
@@ -54,35 +61,165 @@ const CARD = {
 }
 const CARD_FRONT = CARD.depth / 2 + CARD.bevel
 
-// The three stat coupons — deliberately ALL THE SAME SIZE (a uniform row reads
-// cleaner than mixed sizes). Shared geometry, laid out in a row below the main
-// ticket. Front-face Z (post-center) is depth/2 + bevel; the <Html> label sits
-// just proud of it.
+// The main coupon's rest anchor — nudged left/up so the right-heavy stat
+// scatter (see SCATTER below) balances asymmetrically instead of stacking.
+const MAIN_POS: [number, number, number] = [-0.15, 0.9, 0.1]
+// drei Float on the main card translates ~±0.05 world at floatIntensity 0.45.
+const MAIN_FLOAT_SLACK = 0.06
+
+// The three stat coupons — ONE shared geometry, deliberately BIG (w 2.2 =
+// 0.71× the main coupon's 3.1) so they read as siblings of the hero ticket,
+// not chips. Per-coupon size variety comes from SCATTER[i].scale, not from
+// separate geometries. Front-face Z (post-center) is depth/2 + bevel.
 const STAT = {
-    w: 1.7,
-    h: 1.15,
-    cr: 0.15,
-    nr: 0.14,
+    w: 2.2,
+    h: 1.42,
+    cr: 0.18,
+    nr: 0.16,
     ny: 0,
-    depth: 0.24,
-    bevel: 0.035,
+    depth: 0.3,
+    bevel: 0.045,
 }
 const STAT_FRONT = STAT.depth / 2 + STAT.bevel
-const STAT_Y = -1.55
-const STAT_X = [-2.15, 0, 2.15]
-const MAIN_Y = 1.4
 
-// Content bounds of the main + stat group (world units, pre-fit) used to scale
-// the group so it sizes itself to the LAYOUT box. Derivation against the
-// actual layout:
-//   half-W = max(CARD.w/2 = 1.55, STAT_X[2] + STAT.w/2 = 2.15 + 0.85) = 3.0
-//   half-H = max(MAIN_Y + CARD.h/2 = 1.4 + 1.0 = 2.4,
-//                |STAT_Y| + STAT.h/2 = 1.55 + 0.575 = 2.125)         = 2.4
-// Float amplitude + parallax tilt (rotY 0.5 main / 0.22 row + Float
-// rotationIntensity 0.2–0.25) swing a few % PAST these rest bounds — that
-// spill lands in the canvas bleed below, never at the raster edge.
-const CONTENT_HALF_W = 3.0
-const CONTENT_HALF_H = 2.4
+// Art-directed scatter: one spot per HERO_STATS entry (index-matched). Varied
+// x/y/z, individual base rotations and per-coupon float parameters make the
+// composition read as coupons drifting in space around the main ticket —
+// "random-looking" but balanced:
+//   [0] "3,000+ Supported Stores" — front-left-low, nearest the camera and the
+//       largest (the headline stat).
+//   [1] "100% Open Source" — top-right, IN FRONT of the main coupon so its
+//       lower-left overlaps the main card's top-right corner like a fanned
+//       coupon stack. In-front on purpose: iteration-2 screenshots proved a
+//       behind-main placement intermittently occludes the label at float
+//       extremes ("EN SOURCE"), and the overlap only covers blank main-card
+//       face (emblem is central, perforation sits at ny −0.5). The in-front
+//       guarantee is POINTER-PROOF by construction: the main card's parallax
+//       is capped at rotY 0.25 / rotX 0.2 (see HeroCard), so its top-right
+//       corner's worst forward swing is 0.1 + 1.55·sin(0.25) + 1.05·sin(0.2)
+//       ≈ 0.69, while this coupon's overlapping corner never dips below
+//       ≈ z 0.65 + 0.10 (field parallax moves it forward on the same pointer
+//       side that swings the main corner forward). Iteration-3's z 0.35 +
+//       main rotY 0.5 violated exactly this and re-ate the label on hover.
+//   [2] "0% Data Selling" — mid-right and the DEEPEST ticket, so the four
+//       tickets cascade top-right → bottom-left (1.9 / 0.9 / −0.95 / −1.35)
+//       instead of pairing into a residual bottom row, with depth spread
+//       front→back (0.65 / 0.4 / 0.1 / −0.5).
+// Frequencies/phases are mutually irrational-ish so no two coupons ever sync.
+interface ScatterSpot {
+    position: [number, number, number]
+    scale: number
+    rotZ: number
+    rotY: number
+    bobAmp: number
+    bobFreq: number
+    driftAmp: number
+    swayFreq: number
+    phase: number
+}
+const SCATTER: ScatterSpot[] = [
+    {
+        position: [-1.4, -1.35, 0.4],
+        scale: 1,
+        rotZ: 0.07,
+        rotY: 0.16,
+        bobAmp: 0.15,
+        bobFreq: 0.55,
+        driftAmp: 0.07,
+        swayFreq: 0.5,
+        phase: 0,
+    },
+    {
+        position: [1.6, 1.9, 0.65],
+        scale: 0.88,
+        rotZ: -0.08,
+        rotY: -0.12,
+        bobAmp: 0.13,
+        bobFreq: 0.72,
+        driftAmp: 0.06,
+        swayFreq: 0.62,
+        phase: 2.1,
+    },
+    {
+        position: [1.8, -0.95, -0.5],
+        scale: 0.92,
+        rotZ: 0.1,
+        rotY: -0.16,
+        bobAmp: 0.17,
+        bobFreq: 0.45,
+        driftAmp: 0.08,
+        swayFreq: 0.55,
+        phase: 4.2,
+    },
+]
+
+// Pointer-reaction envelope (per stat coupon): proximity is a gaussian of the
+// NDC distance between the pointer and the coupon's projected rest anchor
+// (sigma² = PROX_SIGMA_SQ, ~0.45 NDC sigma — reaction peaks while hovering the
+// coupon, fades smoothly by ~1 NDC). The nearest coupon lifts toward the
+// camera (≤ LIFT_MAX), tilts toward the cursor (the d·e^(−d²/σ²) product
+// self-caps at ~0.15 rad) and pops ≤ (POP_MAX−1). All damped — no snapping.
+const PROX_SIGMA_SQ = 0.4
+const LIFT_MAX = 0.3
+const POP_MAX = 1.045
+
+// --- Scene bounds (drive the fit-to-layout-box scale) ----------------------
+// Computed FROM the scatter config so moving/resizing a coupon can never
+// silently break the clip math. For every ticket the half-extent includes:
+// worst-case in-plane tilt (base rotZ + sway + parallax ≤ TILT_ALLOWANCE, via
+// the rotated-rect formula), bevel, pointer pop, ambient drift/bob amplitude —
+// then the whole extent is scaled by the perspective factor at the ticket's
+// CLOSEST approach to the camera (rest z + LIFT_MAX), because the camera
+// projects near geometry wider than the z=0 plane the fit math reasons in.
+// Pointer-parallax swing of the whole scatter group and the main card's Float
+// spill past these rest bounds by a few % — that lands in the canvas bleed
+// below, never at the raster edge.
+const CAM_DIST = 7
+const TILT_ALLOWANCE = 0.25
+
+function tiltedHalfExtents(
+    halfW: number,
+    halfH: number,
+    bevel: number,
+    scale: number,
+): { x: number; y: number } {
+    const c = Math.cos(TILT_ALLOWANCE)
+    const s = Math.sin(TILT_ALLOWANCE)
+    return {
+        x: (halfW * c + halfH * s + bevel) * scale,
+        y: (halfH * c + halfW * s + bevel) * scale,
+    }
+}
+
+function perspectiveFactor(closestZ: number): number {
+    return CAM_DIST / (CAM_DIST - closestZ)
+}
+
+const SCENE_BOUNDS = ((): { halfW: number; halfH: number } => {
+    const mainExt = tiltedHalfExtents(CARD.w / 2, CARD.h / 2, CARD.bevel, 1)
+    const mainPersp = perspectiveFactor(MAIN_POS[2] + MAIN_FLOAT_SLACK)
+    let halfW = (Math.abs(MAIN_POS[0]) + mainExt.x) * mainPersp
+    let halfH =
+        (Math.abs(MAIN_POS[1]) + MAIN_FLOAT_SLACK + mainExt.y) * mainPersp
+    for (const spot of SCATTER) {
+        const ext = tiltedHalfExtents(
+            STAT.w / 2,
+            STAT.h / 2,
+            STAT.bevel,
+            spot.scale * POP_MAX,
+        )
+        const persp = perspectiveFactor(spot.position[2] + LIFT_MAX)
+        halfW = Math.max(
+            halfW,
+            (Math.abs(spot.position[0]) + spot.driftAmp + ext.x) * persp,
+        )
+        halfH = Math.max(
+            halfH,
+            (Math.abs(spot.position[1]) + spot.bobAmp + ext.y) * persp,
+        )
+    }
+    return { halfW, halfH }
+})()
 
 // The DOM shell (HeroSection) bleeds the canvas raster past the reserved
 // layout box by these px per side (the -inset-x-[48px] -inset-y-[40px]
@@ -116,10 +253,14 @@ interface DropletDatum {
 const DROPLET_DATA: DropletDatum[] = Array.from(
     { length: DROPLET_COUNT },
     () => ({
+        // z ∈ [−3.2, −1.2]: strictly BEHIND every coupon (deepest stat rests
+        // at −0.5; its type sits nearer still), so a drifting droplet can
+        // never occlude a stat glyph — iteration-1 screenshots caught one
+        // parked on the "100%" in dark mode.
         origin: new THREE.Vector3(
             (Math.random() - 0.5) * 7,
             (Math.random() - 0.5) * 5,
-            (Math.random() - 0.5) * 4 - 1,
+            -1.2 - Math.random() * 2,
         ),
         speed: 0.2 + Math.random() * 0.5,
         phase: Math.random() * Math.PI * 2,
@@ -186,8 +327,12 @@ function HeroCard({ isDark }: { isDark: boolean }): React.JSX.Element {
         const { x: px, y: py } = state.pointer
         // Springy mouse-parallax tilt, eased with frame-rate-independent damp.
         // No scroll term — the hero ticket only responds to the pointer.
-        const targetRotY = px * 0.5
-        const targetRotX = -py * 0.35
+        // Capped at 0.25/0.2 (was 0.5/0.35): calmer for the biggest object,
+        // and load-bearing for the coupon-stack z-order — SCATTER[1] sits in
+        // front of this card and its comment derives the corner-swing budget
+        // from THESE two constants. Don't raise them without redoing that.
+        const targetRotY = px * 0.25
+        const targetRotX = -py * 0.2
         group.rotation.y = THREE.MathUtils.damp(
             group.rotation.y,
             targetRotY,
@@ -229,17 +374,23 @@ const STAT_FONT = '/fonts/Poppins-Bold.ttf'
 
 // One 3D stat coupon: a real caramel-glass ticket mesh (shared geometry) with
 // the number/label as IN-CANVAS 3D text (drei <Text>, SDF) sitting on the
-// coupon face — it inherits the Float + parallax transforms, so the type moves
-// and tilts WITH the ticket like print, instead of hovering as a flat DOM
-// billboard. The number counts up from 0 on mount.
+// coupon face — it inherits every float/tilt transform, so the type moves
+// with the ticket like print, instead of hovering as a flat DOM billboard.
+// The number counts up from 0 on mount.
+//
+// Motion = two nested groups:
+//   anchor (outer) — ambient drift/bob position (set directly each frame from
+//     smooth periodic functions) + damped pointer lift (z) + damped scale pop.
+//   tilt (inner)   — damped rotations: base pose + slow sway + tilt-toward-
+//     cursor. Split so position writes never fight rotation damping.
 function StatCoupon3D({
     geometry,
-    position,
+    spot,
     stat,
     isDark,
 }: {
     geometry: THREE.ExtrudeGeometry
-    position: [number, number, number]
+    spot: ScatterSpot
     stat: (typeof HERO_STATS)[number]
     isDark: boolean
 }): React.JSX.Element {
@@ -247,40 +398,107 @@ function StatCoupon3D({
     // so count-up always animates here — start=true, reduce=false.
     const n = useCountUp(stat.value, true, false)
     const shown = formatStat(n, stat)
+    const anchorRef = useRef<THREE.Group>(null)
+    const tiltRef = useRef<THREE.Group>(null)
+    const scratch = useMemo(() => new THREE.Vector3(), [])
+
+    useFrame((state, delta) => {
+        const anchor = anchorRef.current
+        const tilt = tiltRef.current
+        if (!anchor || !tilt || !anchor.parent) return
+        const t = state.clock.elapsedTime
+
+        // Ambient float: independent frequencies + phase offsets per coupon.
+        anchor.position.x =
+            spot.position[0] +
+            Math.cos(t * spot.bobFreq * 0.63 + spot.phase * 1.7) * spot.driftAmp
+        anchor.position.y =
+            spot.position[1] +
+            Math.sin(t * spot.bobFreq + spot.phase) * spot.bobAmp
+
+        // Pointer proximity, measured in NDC against the coupon's projected
+        // REST anchor (parent world matrix = fit scale + scatter parallax).
+        scratch
+            .set(spot.position[0], spot.position[1], spot.position[2])
+            .applyMatrix4(anchor.parent.matrixWorld)
+            .project(state.camera)
+        const dx = THREE.MathUtils.clamp(state.pointer.x - scratch.x, -0.8, 0.8)
+        const dy = THREE.MathUtils.clamp(state.pointer.y - scratch.y, -0.8, 0.8)
+        const influence = Math.exp(-(dx * dx + dy * dy) / PROX_SIGMA_SQ)
+
+        // Lift toward the camera + gentle scale pop under the cursor.
+        anchor.position.z = THREE.MathUtils.damp(
+            anchor.position.z,
+            spot.position[2] + LIFT_MAX * influence,
+            3.5,
+            delta,
+        )
+        const pop = THREE.MathUtils.damp(
+            anchor.scale.x,
+            spot.scale * (1 + (POP_MAX - 1) * influence),
+            3.5,
+            delta,
+        )
+        anchor.scale.setScalar(pop)
+
+        // Base pose + slow sway + tilt toward the cursor (the d·gaussian
+        // product self-caps at ~0.15 rad — tasteful, never a snap).
+        tilt.rotation.y = THREE.MathUtils.damp(
+            tilt.rotation.y,
+            spot.rotY +
+                Math.sin(t * spot.swayFreq + spot.phase) * 0.06 +
+                dx * 0.55 * influence,
+            3.5,
+            delta,
+        )
+        tilt.rotation.x = THREE.MathUtils.damp(
+            tilt.rotation.x,
+            Math.sin(t * spot.swayFreq * 0.8 + spot.phase * 2.3) * 0.045 -
+                dy * 0.4 * influence,
+            3.5,
+            delta,
+        )
+        tilt.rotation.z = THREE.MathUtils.damp(
+            tilt.rotation.z,
+            spot.rotZ +
+                Math.sin(t * spot.swayFreq * 0.7 + spot.phase * 0.9) * 0.035,
+            3.5,
+            delta,
+        )
+    })
+
     return (
-        <Float speed={2} rotationIntensity={0.2} floatIntensity={0.45}>
-            <group position={position}>
+        <group ref={anchorRef} position={spot.position} scale={spot.scale}>
+            <group ref={tiltRef} rotation={[0, spot.rotY, spot.rotZ]}>
                 <mesh geometry={geometry} castShadow receiveShadow>
                     <TicketMaterial isDark={isDark} />
                 </mesh>
                 <Perforation
-                    width={STAT.w - STAT.nr * 2 - 0.06}
+                    width={STAT.w - STAT.nr * 2 - 0.08}
                     y={STAT.ny}
                     z={STAT_FRONT + 0.015}
-                    count={9}
-                    dash={0.05}
+                    count={11}
+                    dash={0.06}
                     color={isDark ? CARAMEL_LIGHT : '#fff2e6'}
                 />
                 {/* Sticker-print treatment (2026-07-29 legibility rework):
-                    white fill + a SOLID full-opacity espresso outline — the
-                    old blurred half-opacity halo (outlineBlur 0.024/0.012 at
-                    50%/35%) read as smudged ink and let the glossy caramel
-                    highlights swallow the white fill. A crisp dark rim keeps
-                    contrast against BOTH theme faces (bright CARAMEL in light,
-                    CARAMEL_DEEP in dark) no matter where the clearcoat
-                    highlight sweeps. sdfGlyphSize 128 (troika default 64) is
-                    what fixes the "%" specifically — its two small counters
-                    and thin diagonal go lumpy at 64. Lifted a touch off the
-                    face (0.03) so the specular sheen doesn't kiss the glyph
-                    edges. */}
+                    white fill + a SOLID full-opacity espresso outline — a
+                    crisp dark rim keeps contrast against BOTH theme faces
+                    (bright CARAMEL in light, CARAMEL_DEEP in dark) no matter
+                    where the clearcoat highlight sweeps. sdfGlyphSize 128
+                    (troika default 64) keeps the "%" crisp — its two small
+                    counters and thin diagonal go lumpy at 64. Lifted a touch
+                    off the face (0.03) so the specular sheen doesn't kiss the
+                    glyph edges. Sizes are the shipped 1.7-wide treatment
+                    scaled by the new 2.2-wide face (×1.29). */}
                 <Text
                     font={STAT_FONT}
-                    fontSize={0.38}
-                    position={[0, 0.14, STAT_FRONT + 0.03]}
+                    fontSize={0.49}
+                    position={[0, 0.18, STAT_FRONT + 0.03]}
                     anchorX="center"
                     anchorY="middle"
                     color="#ffffff"
-                    outlineWidth={0.024}
+                    outlineWidth={0.031}
                     outlineColor="#4a1c05"
                     outlineOpacity={1}
                     sdfGlyphSize={128}
@@ -289,19 +507,19 @@ function StatCoupon3D({
                 </Text>
                 {/* Label fit math (longest label = "SUPPORTED STORES", 16
                     glyphs): Poppins-Bold uppercase averages ~0.62em advance,
-                    so width ≈ 16 × 0.12 × (0.62 + 0.06 letterSpacing) ≈ 1.31 —
-                    inside the usable face width of STAT.w 1.7 − 2 × notch r
-                    0.14 = 1.42, with ~0.055 margin per side (float tilt only
-                    rotates the ticket, the type rides it like print). */}
+                    so width ≈ 16 × 0.155 × (0.62 + 0.06 letterSpacing) ≈ 1.69
+                    — inside the usable face width of STAT.w 2.2 − 2 × notch r
+                    0.16 = 1.88, with ~0.095 margin per side (tilt only rotates
+                    the ticket, the type rides it like print). */}
                 <Text
                     font={STAT_FONT}
-                    fontSize={0.12}
+                    fontSize={0.155}
                     letterSpacing={0.06}
-                    position={[0, -0.22, STAT_FRONT + 0.03]}
+                    position={[0, -0.285, STAT_FRONT + 0.03]}
                     anchorX="center"
                     anchorY="middle"
                     color="#ffffff"
-                    outlineWidth={0.008}
+                    outlineWidth={0.01}
                     outlineColor="#4a1c05"
                     outlineOpacity={1}
                     sdfGlyphSize={128}
@@ -309,13 +527,14 @@ function StatCoupon3D({
                     {stat.label.toUpperCase()}
                 </Text>
             </group>
-        </Float>
+        </group>
     )
 }
 
 function StatCoupons({ isDark }: { isDark: boolean }): React.JSX.Element {
-    const rowRef = useRef<THREE.Group>(null)
-    // ONE geometry shared by all three coupons (they're the same size).
+    const fieldRef = useRef<THREE.Group>(null)
+    // ONE geometry shared by all three coupons (same shape; per-coupon size
+    // comes from SCATTER[i].scale on the anchor group).
     const geometry = useMemo(
         () =>
             makeTicketGeometry(
@@ -330,34 +549,34 @@ function StatCoupons({ isDark }: { isDark: boolean }): React.JSX.Element {
         [],
     )
 
-    // Mild pointer parallax for the whole row (about half the main card's) so
-    // the stat coupons answer the mouse like the main model does — Float alone
-    // reads static next to the parallaxing hero card.
+    // Mild whole-field pointer parallax (well under the main card's 0.5/0.35)
+    // so the scatter answers the mouse as one drifting constellation; the
+    // per-coupon proximity reaction in StatCoupon3D layers on top of this.
     useFrame((state, delta) => {
-        const row = rowRef.current
-        if (!row) return
+        const field = fieldRef.current
+        if (!field) return
         const { x: px, y: py } = state.pointer
-        row.rotation.y = THREE.MathUtils.damp(
-            row.rotation.y,
-            px * 0.22,
+        field.rotation.y = THREE.MathUtils.damp(
+            field.rotation.y,
+            px * 0.14,
             4,
             delta,
         )
-        row.rotation.x = THREE.MathUtils.damp(
-            row.rotation.x,
-            -py * 0.16,
+        field.rotation.x = THREE.MathUtils.damp(
+            field.rotation.x,
+            -py * 0.1,
             4,
             delta,
         )
     })
 
     return (
-        <group ref={rowRef}>
+        <group ref={fieldRef}>
             {HERO_STATS.map((stat, i) => (
                 <StatCoupon3D
                     key={stat.label}
                     geometry={geometry}
-                    position={[STAT_X[i], STAT_Y, 0]}
+                    spot={SCATTER[i]}
                     stat={stat}
                     isDark={isDark}
                 />
@@ -417,19 +636,21 @@ function Droplets({ isDark }: { isDark: boolean }): React.JSX.Element {
 }
 
 function SceneContents({ isDark }: { isDark: boolean }): React.JSX.Element {
-    // The vertical FOV keeps world height constant, so on the narrow hero column
-    // the main ticket + the stat-coupon row can overflow the frustum — scale the
-    // whole ticket group down to fit both dimensions. The canvas raster is BLED
-    // past the layout box (CANVAS_BLEED_*_PX), so the fit is computed against
-    // the layout-box slice of the frustum, not the whole canvas: the composition
-    // keeps the size it had when canvas == layout box, and the bleed becomes
-    // pure headroom that tilted geometry can swing into without clipping. The
-    // 0.9 margin (was 0.94) leaves ~10% of the layout box as rest-pose slack
-    // before the bleed even starts. Reactive to resize via R3F size state; no
+    // The vertical FOV keeps world height constant, so on the narrow hero
+    // column the main ticket + the scattered stat coupons can overflow the
+    // frustum — scale the whole ticket group down to fit both dimensions
+    // (bounds come from SCENE_BOUNDS, computed from the scatter config). The
+    // canvas raster is BLED past the layout box (CANVAS_BLEED_*_PX), so the
+    // fit is computed against the layout-box slice of the frustum, not the
+    // whole canvas: the composition keeps the size it had when canvas ==
+    // layout box, and the bleed becomes pure headroom that tilted geometry can
+    // swing into without clipping. The 0.92 margin leaves ~8% of the layout
+    // box as rest-pose slack before the bleed even starts (SCENE_BOUNDS
+    // already bakes in tilt/lift/pop/drift extremes, so this is belt-and-
+    // braces, not the only guard). Reactive to resize via R3F size state; no
     // per-frame camera work.
     const { width, height } = useThree(state => state.size)
-    const dist = 7
-    const halfH = Math.tan((42 * Math.PI) / 180 / 2) * dist
+    const halfH = Math.tan((42 * Math.PI) / 180 / 2) * CAM_DIST
     const worldPerPx = (halfH * 2) / height
     const layoutHalfW =
         (Math.max(1, width - CANVAS_BLEED_X_PX * 2) / 2) * worldPerPx
@@ -437,8 +658,8 @@ function SceneContents({ isDark }: { isDark: boolean }): React.JSX.Element {
         (Math.max(1, height - CANVAS_BLEED_Y_PX * 2) / 2) * worldPerPx
     const fit = Math.min(
         1,
-        (layoutHalfW * 0.9) / CONTENT_HALF_W,
-        (layoutHalfH * 0.9) / CONTENT_HALF_H,
+        (layoutHalfW * 0.92) / SCENE_BOUNDS.halfW,
+        (layoutHalfH * 0.92) / SCENE_BOUNDS.halfH,
     )
 
     return (
@@ -457,7 +678,7 @@ function SceneContents({ isDark }: { isDark: boolean }): React.JSX.Element {
             />
 
             <group scale={fit}>
-                <group position={[0, MAIN_Y, 0]}>
+                <group position={MAIN_POS}>
                     <HeroCard isDark={isDark} />
                 </group>
                 <StatCoupons isDark={isDark} />
@@ -515,7 +736,7 @@ export default function HeroTicketScene({
             className="h-full w-full"
             dpr={[1, 1.5]}
             frameloop={active ? 'always' : 'never'}
-            camera={{ position: [0, 0, 7], fov: 42 }}
+            camera={{ position: [0, 0, CAM_DIST], fov: 42 }}
             gl={{
                 alpha: true,
                 antialias: true,

--- a/apps/caramel-app/src/lib/heroStats.ts
+++ b/apps/caramel-app/src/lib/heroStats.ts
@@ -13,8 +13,9 @@ export interface HeroStat {
     format?: 'comma'
 }
 
-// Same size for all three (deliberate — a uniform row reads cleaner than mixed
-// sizes). Order = left→right / first→last.
+// Order matters: HeroTicketScene's SCATTER array is index-matched to this
+// (entry 0 = the front/largest coupon); the DOM fallback renders them as a
+// uniform row left→right in the same order.
 export const HERO_STATS: HeroStat[] = [
     { value: 3000, suffix: '+', label: 'Supported Stores', format: 'comma' },
     { value: 100, suffix: '%', label: 'Open Source' },


### PR DESCRIPTION
## What

Reworks the hero 3D scene's three stat coupons per design feedback: the small same-size chips sitting in one horizontal row read as cheap. They are now LARGE coupon tickets (same shape family as the main hero coupon) scattered organically around it, each softly floating on its own rhythm, with a per-coupon pointer reaction.

## Before → After

**Before:** three 1.7-wide stat chips (0.55× the main coupon) in a single straight row under the main ticket, all moving in near-sync (one shared row parallax + identical Float).

**After:**
- **Bigger:** stat ticket geometry grows to 2.2×1.42 (0.71× the main coupon's width) with per-coupon scale variety (1.0 / 0.92 / 0.88) — apparent on-screen widths land at ~74% / ~62% / ~68% of the main coupon.
- **Scattered, not linear:** an art-directed cascade — "3,000+ Supported Stores" front-left-low (z +0.4), "0% Data Selling" mid-right and deepest (z −0.5), "100% Open Source" top-right IN FRONT of the main card (z +0.65), its lower-left corner fanning over the main coupon's top-right corner like a stacked coupon fan. Varied base rotations on every axis; the main card nudged left so the right-heavy scatter balances asymmetrically.
- **Soft independent floating:** each coupon bobs/drifts/sways on its own frequency + phase (mutually irrational-ish — never in sync), replacing the shared drei Float on the row.
- **Pointer interaction:** whole-field parallax kept (damped), plus a per-coupon proximity reaction — the coupon nearest the cursor gently lifts toward the camera (≤0.3), tilts toward the pointer (gaussian-capped ~0.15 rad) and pops ~4.5%, all `MathUtils.damp`-eased, no snapping.

## Iterated visually (4 rounds, light+dark+hover screenshots per round)

1. First scatter pass — good, but a droplet parked on the "100%" glyph in dark mode, and Stores/Data-Selling still paired into a bottom row.
2. Droplets moved strictly behind the coupon plane (z ≤ −1.2); cascade fixed — but the behind-main "peek" placement intermittently occluded "OPEN SOURCE" at float extremes.
3. Flipped Open Source in front of the main card — hover testing then caught the main card's ±0.5 parallax swinging its corner forward past it, eating the label again.
4. Final: Open Source at z 0.65 + main parallax capped at 0.25/0.2 (calmer for the biggest object, and load-bearing for the z-order — derivation in the SCATTER comment). Verified clean at rest and at hover extremes in both themes.

## Kept (hard constraints)

- PR #130 text treatment: white fill + solid #4a1c05 espresso outline, `sdfGlyphSize` 128 — sizes rescaled ×1.29 for the bigger faces (0.49 number / 0.155 label), label fit re-derived for the 2.2-wide face.
- `useCountUp` hydration-safe pattern, reduced-motion gating, WebGL gating/fallback, DPR clamp [1, 1.5], canvas clip-bleed — bounds are now COMPUTED from the scatter config (`SCENE_BOUNDS`: worst-case tilt via rotated-rect, pointer lift/pop, drift/bob amplitude, perspective factor at closest approach), so moving a coupon can't silently break the clip math. Nothing clips at float + pointer extremes combined (verified via hover-extreme screenshots).
- DOM layout untouched: canvas still owns only the right-column box + the same 48/40px bleed; below-lg fallback (DOM stat cards) unchanged.
- Perf posture: still one shared stat geometry, one instanced droplet mesh; the new reaction adds 3 Vector3 projections/frame.

## Gates

`pnpm lint` / `lint:oxlint` / `prettier-check` / `knip` / `type-check` all green, `pnpm test` 418/418, prod build green. No e2e/test assertions pin the scene (canvas-only change; Argos canvas diffs expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6mwHJLfAZkkpSmztWUQMi
