### PR TITLE
feat(hero): three-stat centered scene, SSR coupon placeholder with cross-fade

### DIFF
--- a/apps/caramel-app/src/components/HeroSection.tsx
+++ b/apps/caramel-app/src/components/HeroSection.tsx
@@ -10,14 +10,25 @@
 // next/dynamic ssr:false component mounted ONLY once every gate passes — the
 // browser is idle (requestIdleCallback, setTimeout fallback) AND a real WebGL
 // context exists AND motion is allowed AND the viewport is lg+ (matchMedia,
-// re-checked on resize). Until then the right column shows a premium CSS ticket
-// poster (shared ticketNotchMask). The right column reserves its box up front,
-// and the live canvas cross-fades in over the poster, so there is zero CLS.
+// re-checked on resize). Until then the right column shows HeroCouponPoster —
+// a server-rendered DOM/CSS twin of the 3D scene: the SAME three stat coupons
+// (shared HERO_STATS + ticketNotchMask, espresso ink, dashed perforation) at
+// the same scatter positions, so the canvas cross-fade is a material swap,
+// not a composition change. The right column reserves its box up front, and
+// the live canvas cross-fades in over the poster on its first-frame onReady
+// signal, so there is zero CLS and no flash of empty space. The poster is
+// ALSO the permanent presentation for no-WebGL / reduced-motion desktops, and
+// because it SSRs, the three stats exist as crawlable HTML (SEO bonus).
 // The scene's frameloop is paused (frameloop='never') whenever the hero is
 // scrolled out of view via an IntersectionObserver.
 
 import { ThemeContext } from '@/lib/contexts'
-import { formatStat, HERO_STATS, useCountUp } from '@/lib/heroStats'
+import {
+    formatStat,
+    formatStatDigits,
+    HERO_STATS,
+    useCountUp,
+} from '@/lib/heroStats'
 import { useReducedMotion } from '@/lib/reducedMotion'
 import { ticketNotchMask } from '@/lib/ticketMask'
 import { detectWebGL } from '@/lib/webglSupport'
@@ -33,49 +44,228 @@ const HeroTicketScene = dynamic(() => import('./HeroTicketScene'), {
 
 const revealEase: [number, number, number, number] = [0.22, 1, 0.36, 1]
 
-// Still-beautiful CSS-only stand-in shown until (or instead of) the live scene:
-// reduced-motion / no-WebGL / non-desktop, and underneath the canvas while its
-// chunk loads. aria-hidden — purely decorative; the real headline/links are DOM
-// in the left column. A caramel coupon ticket: side notches (mask) + a dashed
-// perforation across the axis + a big embossed "%".
-function HeroTicketPoster(): React.JSX.Element {
+// HeroCouponPoster — the server-rendered DOM/CSS twin of HeroTicketScene's
+// three-stat composition, and the ONE placeholder for both of its roles:
+// (a) the instant face of the hero canvas box until the WebGL scene signals
+// ready (the parent cross-fades this out), and (b) the PERMANENT presentation
+// on no-WebGL / reduced-capability / reduced-motion desktops. Index-matched
+// to HERO_STATS and to the scene's SCATTER: each spot mirrors that coupon's
+// anchor (as % of the layout box), z-order (depth), base rotZ, relative size
+// and type scale, so the poster→canvas cross-fade reads as the same three
+// coupons gaining glass and light — not a layout jump. Same brand recipe as
+// every ticket in the app: caramel gradient face, ticketNotchMask side
+// notches, dashed mid perforation, espresso print-ink type (the 3D STAT_INK)
+// with the small raised suffix. Values render via useCountUp, which SSRs the
+// FINAL numbers — so the stats are real crawlable HTML and the count-up only
+// replays after hydration. NOT aria-hidden: this is the accessible/crawler
+// face of the stats on desktop (the mobile StatCards row below lg covers
+// small viewports).
+const POSTER_INK = '#4a1c05'
+interface PosterSpot {
+    left: string
+    top: string
+    width: string
+    aspect: string
+    rotate: number
+    z: number
+    radius: string
+    notch: string
+    valueSize: string
+    labelSize: string
+    floatDuration: number
+    floatDelay: number
+}
+// Geometry mapping (reference 470×544 layout box, scene fit ≈ 0.67 → ≈77
+// px/world): anchor (x,y) → left/top %, ticket width = 2.5 · scale ·
+// perspective, type = the 3D 0.54/0.17 world sizes through the same factor.
+const POSTER_SPOTS: PosterSpot[] = [
+    {
+        left: '35%',
+        top: '68%',
+        width: '13.5rem',
+        aspect: '2.5 / 1.6',
+        rotate: -4,
+        z: 30,
+        radius: '1.1rem',
+        notch: '0.95rem',
+        valueSize: '2.7rem',
+        labelSize: '0.8rem',
+        floatDuration: 5.8,
+        floatDelay: 0.1,
+    },
+    {
+        left: '46%',
+        top: '29%',
+        width: '11.75rem',
+        aspect: '2.5 / 1.6',
+        rotate: 4,
+        z: 20,
+        radius: '0.95rem',
+        notch: '0.85rem',
+        valueSize: '2.35rem',
+        labelSize: '0.7rem',
+        floatDuration: 4.9,
+        floatDelay: 0.35,
+    },
+    {
+        left: '72%',
+        top: '51%',
+        width: '10.25rem',
+        aspect: '2.5 / 1.6',
+        rotate: -6,
+        z: 10,
+        radius: '0.85rem',
+        notch: '0.72rem',
+        valueSize: '2.05rem',
+        labelSize: '0.62rem',
+        floatDuration: 6.6,
+        floatDelay: 0.55,
+    },
+]
+
+function PosterCoupon({
+    stat,
+    spot,
+    index,
+    start,
+    reduce,
+}: {
+    stat: (typeof HERO_STATS)[number]
+    spot: PosterSpot
+    index: number
+    start: boolean
+    reduce: boolean
+}): React.JSX.Element {
+    const n = useCountUp(stat.value, start, reduce)
     return (
+        // Plain wrapper owns the anchor transform (center on the % spot +
+        // base rotation) so framer's animated transforms on the inner nodes
+        // never overwrite it.
         <div
-            aria-hidden="true"
-            className="pointer-events-none absolute inset-0 overflow-hidden"
+            className="absolute"
+            style={{
+                left: spot.left,
+                top: spot.top,
+                width: spot.width,
+                zIndex: spot.z,
+                transform: `translate(-50%, -50%) rotate(${spot.rotate}deg)`,
+            }}
         >
-            <div className="absolute left-1/2 top-1/2 h-72 w-72 -translate-x-1/2 -translate-y-1/2 rounded-full bg-caramel/25 blur-3xl dark:bg-caramel/20" />
-            <div className="absolute left-[42%] top-[38%] h-36 w-36 -translate-x-1/2 -translate-y-1/2 rounded-full bg-orange-300/30 blur-2xl" />
-            <div className="absolute inset-0 flex items-center justify-center">
-                <div className="relative h-52 w-72 rotate-[-8deg]">
+            <motion.div
+                initial={
+                    reduce ? { opacity: 0 } : { opacity: 0, y: 24, scale: 0.9 }
+                }
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                transition={{
+                    duration: 0.6,
+                    delay: 0.35 + index * 0.12,
+                    ease: revealEase,
+                }}
+            >
+                {/* Inner looping float on its own node so the one-shot
+                    entrance transform above never fights the loop; each coupon
+                    gets its own duration + delay, so no two ever bob in sync
+                    (the DOM cousin of the scene's per-coupon
+                    frequencies/phases). */}
+                <motion.div
+                    animate={reduce ? undefined : { y: [0, -9, 0] }}
+                    transition={
+                        reduce
+                            ? undefined
+                            : {
+                                  duration: spot.floatDuration,
+                                  delay: spot.floatDelay,
+                                  repeat: Infinity,
+                                  ease: 'easeInOut',
+                              }
+                    }
+                    className="relative"
+                    style={{ aspectRatio: spot.aspect }}
+                >
                     <div
-                        className="absolute inset-0 rounded-[2rem] bg-gradient-to-br from-caramel via-orange-500 to-orange-600 shadow-caramel-lg"
-                        style={ticketNotchMask('1.1rem', '58%')}
+                        className="absolute inset-0 bg-gradient-to-br from-caramel via-orange-500 to-orange-600 shadow-caramel-lg"
+                        style={{
+                            borderRadius: spot.radius,
+                            ...ticketNotchMask(spot.notch, '50%'),
+                        }}
                     />
                     <div
-                        className="absolute inset-0 rounded-[2rem] bg-gradient-to-tr from-white/35 via-transparent to-transparent"
-                        style={ticketNotchMask('1.1rem', '58%')}
+                        className="absolute inset-0 bg-gradient-to-tr from-white/30 via-transparent to-transparent"
+                        style={{
+                            borderRadius: spot.radius,
+                            ...ticketNotchMask(spot.notch, '50%'),
+                        }}
                     />
-                    <span className="absolute inset-x-0 top-[20%] select-none text-center text-7xl font-black text-white/90 drop-shadow-lg">
-                        %
-                    </span>
-                    <div className="absolute inset-x-7 top-[58%] border-t-2 border-dashed border-white/70" />
+                    {/* Perforation: a row of discrete dashes (repeating
+                        gradient, ~11 dashes across like the 3D Perforation
+                        row) rather than border-dashed, whose long dashes read
+                        as a different motif than the scene's. */}
                     <div
-                        className="absolute -right-9 -top-7 h-14 w-20 rotate-12 rounded-2xl bg-caramelLight/90 shadow-caramel-sm"
-                        style={ticketNotchMask('0.6rem', '50%')}
+                        className="absolute inset-x-[9%] top-1/2 h-[3px] -translate-y-1/2"
+                        style={{
+                            backgroundImage:
+                                'repeating-linear-gradient(90deg, rgba(255,242,230,0.85) 0 8px, transparent 8px 19px)',
+                        }}
                     />
-                </div>
-            </div>
+                    {/* Value: cap-centered at 37.5% (3D VALUE_Y 0.2 over half-h
+                    0.8), suffix at 0.6× raised to cap-align — the DOM twin of
+                    StatValueText. */}
+                    <div
+                        className="absolute inset-x-0 top-[37.5%] -translate-y-1/2 whitespace-nowrap text-center font-black leading-none tracking-tight"
+                        style={{ color: POSTER_INK, fontSize: spot.valueSize }}
+                    >
+                        {formatStatDigits(n, stat)}
+                        <span className="align-[0.45em] text-[0.6em]">
+                            {stat.suffix}
+                        </span>
+                    </div>
+                    <div
+                        className="absolute inset-x-0 top-[70.5%] -translate-y-1/2 whitespace-nowrap text-center font-bold uppercase tracking-[0.08em]"
+                        style={{ color: POSTER_INK, fontSize: spot.labelSize }}
+                    >
+                        {stat.label}
+                    </div>
+                </motion.div>
+            </motion.div>
         </div>
     )
 }
 
-// DOM fallback for the three hero stats, rendered as caramel coupon-ticket
-// cards (shared ticketNotchMask), ALL THE SAME SIZE, each counting its number
-// up from 0 on first paint. The primary presentation on desktop is now the 3D
-// stat coupons inside HeroTicketScene; these DOM cards are the stand-in shown
-// on mobile / reduced-motion / no-WebGL (and briefly under the canvas while its
-// chunk loads), sharing the same HERO_STATS data so the two never drift.
+function HeroCouponPoster({
+    start,
+    reduce,
+}: {
+    start: boolean
+    reduce: boolean
+}): React.JSX.Element {
+    return (
+        <div className="pointer-events-none absolute inset-0">
+            <div
+                aria-hidden="true"
+                className="absolute inset-0 overflow-hidden"
+            >
+                <div className="absolute left-1/2 top-1/2 h-72 w-72 -translate-x-1/2 -translate-y-1/2 rounded-full bg-caramel/25 blur-3xl dark:bg-caramel/20" />
+                <div className="absolute left-[38%] top-[32%] h-36 w-36 -translate-x-1/2 -translate-y-1/2 rounded-full bg-orange-300/30 blur-2xl" />
+            </div>
+            {HERO_STATS.map((stat, index) => (
+                <PosterCoupon
+                    key={stat.label}
+                    stat={stat}
+                    spot={POSTER_SPOTS[index]}
+                    index={index}
+                    start={start}
+                    reduce={reduce}
+                />
+            ))}
+        </div>
+    )
+}
+
+// MOBILE-ONLY row of the three hero stats, rendered as small uniform caramel
+// coupon-ticket cards (shared ticketNotchMask) in normal flow under the copy,
+// each counting its number up from 0 on first paint. Desktop presentations
+// are HeroTicketScene (live) and HeroCouponPoster (placeholder/fallback);
+// all three share the same HERO_STATS data so they never drift.
 function StatCard({
     stat,
     index,
@@ -113,7 +303,7 @@ function StatCard({
     )
 }
 
-// A centered row of the three uniform stat cards (DOM fallback).
+// A centered row of the three uniform stat cards (mobile flow).
 function StatCards({
     start,
     reduce,
@@ -471,32 +661,27 @@ export default function HeroSection() {
                 </div>
 
                 {/* RIGHT column: on desktop, ONE interactive WebGL box holds
-                    the main 3D coupon AND three large 3D stat coupons
-                    scattered around it at varied depths (soft independent
-                    floating + pointer reaction — see HeroTicketScene's
-                    SCATTER). A poster + the DOM stat cards cross-fade
-                    underneath until the canvas is ready — and stay as the
-                    permanent presentation for reduced-motion / no-WebGL desktop.
-                    Below lg the box is hidden (phones never mount three) and the
+                    the three large 3D stat coupons scattered around the
+                    center at varied depths (soft independent floating +
+                    pointer reaction — see HeroTicketScene's SCATTER).
+                    HeroCouponPoster — the SSR'd DOM twin of that exact
+                    composition — paints instantly underneath, cross-fades out
+                    when the canvas signals ready, and stays as the permanent
+                    presentation for reduced-motion / no-WebGL desktop. Below
+                    lg the box is hidden (phones never mount three) and the
                     DOM stat cards render in normal flow under the copy. */}
                 <div className="relative flex w-[45%] flex-col items-center lg:w-full">
                     {/* DESKTOP 3D box: reserved up front; the live canvas
-                        cross-fades in over the fallback, so there is zero CLS. */}
+                        cross-fades in over the poster, so there is zero CLS. */}
                     <div className="relative h-[34rem] w-full lg:hidden">
                         <div
-                            className="absolute inset-0 flex flex-col justify-between transition-opacity duration-700 ease-out"
+                            className="absolute inset-0 transition-opacity duration-700 ease-out"
                             style={{
                                 opacity: canvasReady ? 0 : 1,
                                 pointerEvents: canvasReady ? 'none' : undefined,
                             }}
                         >
-                            <div
-                                aria-hidden="true"
-                                className="relative h-[22rem] w-full"
-                            >
-                                <HeroTicketPoster />
-                            </div>
-                            <StatCards
+                            <HeroCouponPoster
                                 start={statsStarted}
                                 reduce={reduceMotion}
                             />

--- a/apps/caramel-app/src/components/HeroTicketScene.tsx
+++ b/apps/caramel-app/src/components/HeroTicketScene.tsx
@@ -2,40 +2,35 @@
 
 // HeroTicketScene — the compact WebGL half of the split hero (right column,
 // desktop/lg+ only). Same ticket visual language as the shared ./couponTicket3d
-// geometry + palette, deliberately LIGHT: one big main ticket with springy
-// mouse-parallax tilt + Float, PLUS three LARGE 3D stat coupons (each a real
-// ticket mesh at 0.68–0.81× the main coupon's size) SCATTERED around it at
-// varied depths — an art-directed "random soft floating" composition, not a
-// row. Each stat coupon drifts/bobs/sways on its own frequency + phase (never
-// in sync), and reacts to the pointer: the coupon nearest the cursor gently
-// lifts toward the camera, tilts toward the pointer and pops ~4% — all damped,
-// no snapping. Numbers count up as IN-CANVAS 3D text so the type moves with
-// the ticket like print. A handful of instanced droplets, low-count Sparkles,
-// and a one-frame Lightformer environment complete the scene. No
-// ContactShadows and no scroll dolly — the hero doesn't scroll-drive. Loaded
-// via next/dynamic ssr:false and only mounted after the browser is idle + a
-// real WebGL context + a lg+ viewport (HeroSection gates all of that), so the
-// `three` chunk never touches phones or first paint. Below lg /
-// reduced-motion / no-WebGL the stats fall back to DOM coupon cards in
-// HeroSection (shared HERO_STATS data).
+// geometry + palette, deliberately LIGHT: THREE large 3D stat coupons (real
+// ticket meshes) scattered around the canvas center at varied depths — an
+// art-directed "random soft floating" composition, not a row. The big main
+// "%" coupon from earlier iterations is GONE (owner call 2026-07-29: "just
+// keep the 3 stats… remove the % big one"); the three stat tickets ARE the
+// scene now, recomposed to read centered and balanced on their own. Each
+// coupon drifts/bobs/sways on its own frequency + phase (never in sync), and
+// reacts to the pointer: the coupon nearest the cursor gently lifts toward
+// the camera, tilts toward the pointer and pops ~4% — all damped, no
+// snapping. Numbers count up as IN-CANVAS 3D text so the type moves with the
+// ticket like print. A handful of instanced droplets, low-count Sparkles, and
+// a one-frame Lightformer environment complete the scene. No ContactShadows
+// and no scroll dolly — the hero doesn't scroll-drive. Loaded via
+// next/dynamic ssr:false and only mounted after the browser is idle + a real
+// WebGL context + a lg+ viewport (HeroSection gates all of that), so the
+// `three` chunk never touches phones or first paint. Until (or instead of)
+// the canvas, HeroSection renders the SSR'd DOM twin of this exact
+// composition (HeroCouponPoster) and cross-fades it out on onReady.
 //
 // Perf posture (brief "not heavy"): DPR clamped [1, 1.5]; frameloop gated by
 // the `active` prop (parent IntersectionObserver → 'never' when the hero is
-// scrolled out of view); every ticket geometry is built once (memoized) and the
-// three stat coupons SHARE one geometry; droplets are ONE instanced mesh (≤10);
-// the environment + emblem ship no network fetch; the stat type is SDF text
-// (drei <Text>) on a SELF-HOSTED font, count-up runs only ~1.2s after mount.
-// The per-coupon pointer reaction adds one Vector3 project per stat coupon per
-// frame (3 total) — negligible.
+// scrolled out of view); the three stat coupons SHARE one memoized geometry;
+// droplets are ONE instanced mesh (≤10); the environment ships no network
+// fetch; the stat type is SDF text (drei <Text>) on a SELF-HOSTED font,
+// count-up runs only ~1.2s after mount. The per-coupon pointer reaction adds
+// one Vector3 project per stat coupon per frame (3 total) — negligible.
 
 import { formatStatDigits, HERO_STATS, useCountUp } from '@/lib/heroStats'
-import {
-    Environment,
-    Float,
-    Lightformer,
-    Sparkles,
-    Text,
-} from '@react-three/drei'
+import { Environment, Lightformer, Sparkles, Text } from '@react-three/drei'
 import { Canvas, useFrame, useThree } from '@react-three/fiber'
 import { useCallback, useMemo, useRef } from 'react'
 import * as THREE from 'three'
@@ -44,32 +39,10 @@ import {
     CARAMEL_DEEP,
     CARAMEL_LIGHT,
     makeTicketGeometry,
-    PercentEmblem,
     Perforation,
 } from './couponTicket3d'
 
-// One main coupon ticket. Front-face Z after center() is depth/2 + bevel —
-// the perforation dashes + emblem sit just proud of it.
-const CARD = {
-    w: 3.1,
-    h: 2,
-    cr: 0.22,
-    nr: 0.2,
-    ny: -0.5,
-    depth: 0.4,
-    bevel: 0.05,
-}
-const CARD_FRONT = CARD.depth / 2 + CARD.bevel
-
-// The main coupon's rest anchor — nudged left/up so the right-heavy stat
-// scatter (see SCATTER below) balances asymmetrically instead of stacking.
-const MAIN_POS: [number, number, number] = [-0.15, 0.9, 0.1]
-// drei Float on the main card translates ~±0.05 world at floatIntensity 0.45.
-const MAIN_FLOAT_SLACK = 0.06
-
-// The three stat coupons — ONE shared geometry, deliberately BIG (w 2.5 =
-// 0.81× the main coupon's 3.1, up from 2.2 after the 2026-07-29 design pass)
-// so they read as siblings of the hero ticket, not chips. Per-coupon size
+// The stat coupon ticket — ONE shared geometry for all three; per-coupon size
 // variety comes from SCATTER[i].scale, not from separate geometries.
 // Front-face Z (post-center) is depth/2 + bevel.
 const STAT = {
@@ -83,39 +56,36 @@ const STAT = {
 }
 const STAT_FRONT = STAT.depth / 2 + STAT.bevel
 
-// Art-directed scatter: one spot per HERO_STATS entry (index-matched). Varied
-// x/y/z, individual base rotations and per-coupon float parameters make the
-// composition read as coupons drifting in space around the main ticket —
-// "random-looking" but balanced:
-//   [0] "3,000+ Supported Stores" — front-left-low, nearest the camera and the
-//       largest (the headline stat).
-//   [1] "100% Open Source" — top-right, IN FRONT of the main coupon so its
-//       lower-left overlaps the main card's top-right corner like a fanned
-//       coupon stack. In-front on purpose: iteration-2 screenshots proved a
-//       behind-main placement intermittently occludes the label at float
-//       extremes ("EN SOURCE"), and the overlap only covers blank main-card
-//       face (emblem is central, perforation sits at ny −0.5). The in-front
-//       guarantee is POINTER-PROOF by construction: the main card's parallax
-//       is capped at rotY 0.25 / rotX 0.2 (see HeroCard), so its top-right
-//       corner's worst forward swing is 0.1 + 1.55·sin(0.25) + 1.05·sin(0.2)
-//       ≈ 0.69, while this coupon's overlapping lower-left corner never dips
-//       below ≈ z 0.72 + 0.20 (field parallax, forward on the same pointer
-//       side that swings the main corner forward) − 0.19 (its own worst
-//       rotY+sway corner dip, 1.05·0.84·sin(0.18)) ≈ 0.73. Iteration-3's
-//       z 0.35 + main rotY 0.5 violated exactly this and re-ate the label on
-//       hover — the 2026-07-29 resize kept the margin by bumping z 0.65→0.72.
-//   [2] "0% Data Selling" — mid-right and the DEEPEST ticket, so the four
-//       tickets cascade top-right → bottom-left (1.72 / 0.9 / −1.06 / −1.38)
-//       instead of pairing into a residual bottom row, with depth spread
-//       front→back (0.72 / 0.45 / 0.1 / −0.55). Its y sits low enough that
-//       its top edge keeps clear air from the main card's bottom-right corner
-//       at rest (iteration-1 screenshots showed them nearly touching at −0.98
-//       — a second, accidental-looking overlap moment; the deliberate overlap
-//       belongs to [1] alone).
-// The 2026-07-29 bigger-coupon pass pulled every |x|/|y| slightly INWARD:
-// SCENE_BOUNDS is derived from these numbers, so tighter anchors mean a LARGER
-// fit scale — the bigger tickets land bigger on screen instead of being eaten
-// by their own bounds growth (fit 0.62 → 0.65 at the reference viewport).
+// Art-directed scatter: one spot per HERO_STATS entry (index-matched). With
+// the main "%" coupon removed (2026-07-29) the three tickets were recomposed
+// to CENTER the constellation in the canvas: the scale-weighted centroid of
+// the anchors is ≈ (0.00, 0.00), and no two anchor pairs are collinear with
+// the third (no straight line through the scatter). Varied x/y/z, individual
+// base rotations and per-coupon float parameters keep it reading as coupons
+// drifting in space:
+//   [0] "3,000+ Supported Stores" — bottom-left, nearest the camera and the
+//       largest (the headline stat). Its top-right corner deliberately fans
+//       OVER the deeper [2] ticket's blank bottom-left corner — a coupon-
+//       stack moment, kept clear of [2]'s type (see the occlusion contract
+//       below).
+//   [1] "100% Open Source" — top, slightly LEFT of center (owner call
+//       2026-07-29: "make the open source slight to left so it's on
+//       center") — this is the coupon that re-centers the composition after
+//       living at the far top-right in the four-ticket layout.
+//   [2] "0% Data Selling" — mid-right and the DEEPEST ticket, so the three
+//       tickets cascade top → mid-right → bottom-left with depth spread
+//       front→back (0.45 / 0.05 / −0.5).
+//
+// OCCLUSION CONTRACT (checked whenever an anchor/scale/rotation moves): a
+// nearer coupon's body may only ever cover a deeper coupon's BLANK corner
+// face, never its type, including at float/hover extremes.
+//   [0] over [2]: [0]'s right-edge worst reach ≈ x −0.9 + 1.30 (rotZ-rotated
+//       half-extent) + 0.07 drift ≈ 0.47; [2]'s label ("DATA SELLING", ≈1.19
+//       wide at scale 0.86) starts at ≈ 1.32 − 0.60 − 0.08 drift = 0.64 —
+//       ≥0.17 clear. The fan overlap covers only [2]'s empty corner.
+//   [1] over [2]: [1]'s right corner reaches x ≈ −0.25 + 1.10 + 0.06 drift +
+//       0.05 pop ≈ 0.96; [2]'s "0%" digits start at ≈ 1.32 − 0.26 = 1.06 —
+//       clear in x alone, so [1]'s bob can never dip onto [2]'s value.
 // Frequencies/phases are mutually irrational-ish so no two coupons ever sync.
 interface ScatterSpot {
     position: [number, number, number]
@@ -130,7 +100,7 @@ interface ScatterSpot {
 }
 const SCATTER: ScatterSpot[] = [
     {
-        position: [-1.22, -1.38, 0.45],
+        position: [-0.9, -1.25, 0.45],
         scale: 1,
         rotZ: 0.07,
         rotY: 0.16,
@@ -141,19 +111,19 @@ const SCATTER: ScatterSpot[] = [
         phase: 0,
     },
     {
-        position: [1.42, 1.72, 0.72],
-        scale: 0.84,
-        rotZ: -0.08,
+        position: [-0.25, 1.45, 0.05],
+        scale: 0.92,
+        rotZ: -0.07,
         rotY: -0.12,
-        bobAmp: 0.12,
+        bobAmp: 0.1,
         bobFreq: 0.72,
         driftAmp: 0.06,
         swayFreq: 0.62,
         phase: 2.1,
     },
     {
-        position: [1.58, -1.06, -0.55],
-        scale: 0.88,
+        position: [1.32, -0.1, -0.5],
+        scale: 0.86,
         rotZ: 0.1,
         rotY: -0.16,
         bobAmp: 0.16,
@@ -166,7 +136,7 @@ const SCATTER: ScatterSpot[] = [
 
 // Pointer-reaction envelope (per stat coupon): proximity is a gaussian of the
 // NDC distance between the pointer and the coupon's projected rest anchor
-// (sigma² = PROX_SIGMA_SQ, ~0.45 NDC sigma — reaction peaks while hovering the
+// (sigma² = PROX_SIGMA_SQ, ~0.63 NDC sigma — reaction peaks while hovering the
 // coupon, fades smoothly by ~1 NDC). The nearest coupon lifts toward the
 // camera (≤ LIFT_MAX), tilts toward the cursor (the d·e^(−d²/σ²) product
 // self-caps at ~0.15 rad) and pops ≤ (POP_MAX−1). All damped — no snapping.
@@ -182,9 +152,9 @@ const POP_MAX = 1.045
 // then the whole extent is scaled by the perspective factor at the ticket's
 // CLOSEST approach to the camera (rest z + LIFT_MAX), because the camera
 // projects near geometry wider than the z=0 plane the fit math reasons in.
-// Pointer-parallax swing of the whole scatter group and the main card's Float
-// spill past these rest bounds by a few % — that lands in the canvas bleed
-// below, never at the raster edge.
+// Pointer-parallax swing of the whole scatter group spills past these rest
+// bounds by a few % — that lands in the canvas bleed below, never at the
+// raster edge.
 const CAM_DIST = 7
 const TILT_ALLOWANCE = 0.25
 
@@ -207,11 +177,8 @@ function perspectiveFactor(closestZ: number): number {
 }
 
 const SCENE_BOUNDS = ((): { halfW: number; halfH: number } => {
-    const mainExt = tiltedHalfExtents(CARD.w / 2, CARD.h / 2, CARD.bevel, 1)
-    const mainPersp = perspectiveFactor(MAIN_POS[2] + MAIN_FLOAT_SLACK)
-    let halfW = (Math.abs(MAIN_POS[0]) + mainExt.x) * mainPersp
-    let halfH =
-        (Math.abs(MAIN_POS[1]) + MAIN_FLOAT_SLACK + mainExt.y) * mainPersp
+    let halfW = 0
+    let halfH = 0
     for (const spot of SCATTER) {
         const ext = tiltedHalfExtents(
             STAT.w / 2,
@@ -255,12 +222,11 @@ interface DropletDatum {
 // Randomized droplet layout is computed ONCE at module load (client-only — the
 // scene is dynamically imported ssr:false, single instance), never during
 // render, so Math.random() stays out of the render phase (react-hooks/purity)
-// and the field is stable across re-renders. The y-spread is capped at 5 (not
-// the previous 6) because the field now lives inside the fit-scaled group:
-// worst case |y| = 2.5 origin + 0.9 drift + 0.17 radius = 3.57, times the
-// largest realistic fit (~0.66) = 2.36 world — safely inside the frustum
-// half-height (2.687), so a floating sphere never gets sliced at the top or
-// bottom raster edge.
+// and the field is stable across re-renders. The y-spread is capped at 5
+// because the field lives inside the fit-scaled group: worst case |y| = 2.5
+// origin + 0.9 drift + 0.17 radius = 3.57, times the largest realistic fit
+// (~0.70) = 2.50 world — safely inside the frustum half-height (2.687), so a
+// floating sphere never gets sliced at the top or bottom raster edge.
 const DROPLET_DATA: DropletDatum[] = Array.from(
     { length: DROPLET_COUNT },
     () => ({
@@ -290,8 +256,8 @@ export interface HeroTicketSceneProps {
     onReady?: () => void
 }
 
-// Shared caramel-glass material for every ticket (main + stats) so they read as
-// one family. Slightly tuned per theme.
+// Shared caramel-glass material for every ticket so they read as one family.
+// Slightly tuned per theme.
 function TicketMaterial({ isDark }: { isDark: boolean }): React.JSX.Element {
     return (
         <meshPhysicalMaterial
@@ -313,68 +279,6 @@ function TicketMaterial({ isDark }: { isDark: boolean }): React.JSX.Element {
             attenuationColor={CARAMEL_LIGHT}
             attenuationDistance={2.2}
         />
-    )
-}
-
-function HeroCard({ isDark }: { isDark: boolean }): React.JSX.Element {
-    const groupRef = useRef<THREE.Group>(null)
-    const geometry = useMemo(
-        () =>
-            makeTicketGeometry(
-                CARD.w,
-                CARD.h,
-                CARD.cr,
-                CARD.nr,
-                CARD.ny,
-                CARD.depth,
-                CARD.bevel,
-            ),
-        [],
-    )
-
-    useFrame((state, delta) => {
-        const group = groupRef.current
-        if (!group) return
-        const { x: px, y: py } = state.pointer
-        // Springy mouse-parallax tilt, eased with frame-rate-independent damp.
-        // No scroll term — the hero ticket only responds to the pointer.
-        // Capped at 0.25/0.2 (was 0.5/0.35): calmer for the biggest object,
-        // and load-bearing for the coupon-stack z-order — SCATTER[1] sits in
-        // front of this card and its comment derives the corner-swing budget
-        // from THESE two constants. Don't raise them without redoing that.
-        const targetRotY = px * 0.25
-        const targetRotX = -py * 0.2
-        group.rotation.y = THREE.MathUtils.damp(
-            group.rotation.y,
-            targetRotY,
-            4,
-            delta,
-        )
-        group.rotation.x = THREE.MathUtils.damp(
-            group.rotation.x,
-            targetRotX,
-            4,
-            delta,
-        )
-    })
-
-    return (
-        <Float speed={2} rotationIntensity={0.25} floatIntensity={0.45}>
-            <group ref={groupRef}>
-                <mesh geometry={geometry} castShadow receiveShadow>
-                    <TicketMaterial isDark={isDark} />
-                </mesh>
-                <Perforation
-                    width={CARD.w - CARD.nr * 2 - 0.1}
-                    y={CARD.ny}
-                    z={CARD_FRONT + 0.02}
-                    count={13}
-                    dash={0.075}
-                    color={isDark ? CARAMEL_LIGHT : '#fff2e6'}
-                />
-                <PercentEmblem isDark={isDark} frontZ={CARD_FRONT} />
-            </group>
-        </Float>
     )
 }
 
@@ -627,9 +531,9 @@ function StatCoupons({ isDark }: { isDark: boolean }): React.JSX.Element {
         [],
     )
 
-    // Mild whole-field pointer parallax (well under the main card's 0.5/0.35)
-    // so the scatter answers the mouse as one drifting constellation; the
-    // per-coupon proximity reaction in StatCoupon3D layers on top of this.
+    // Mild whole-field pointer parallax so the scatter answers the mouse as
+    // one drifting constellation; the per-coupon proximity reaction in
+    // StatCoupon3D layers on top of this.
     useFrame((state, delta) => {
         const field = fieldRef.current
         if (!field) return
@@ -715,18 +619,17 @@ function Droplets({ isDark }: { isDark: boolean }): React.JSX.Element {
 
 function SceneContents({ isDark }: { isDark: boolean }): React.JSX.Element {
     // The vertical FOV keeps world height constant, so on the narrow hero
-    // column the main ticket + the scattered stat coupons can overflow the
-    // frustum — scale the whole ticket group down to fit both dimensions
-    // (bounds come from SCENE_BOUNDS, computed from the scatter config). The
-    // canvas raster is BLED past the layout box (CANVAS_BLEED_*_PX), so the
-    // fit is computed against the layout-box slice of the frustum, not the
-    // whole canvas: the composition keeps the size it had when canvas ==
-    // layout box, and the bleed becomes pure headroom that tilted geometry can
-    // swing into without clipping. The 0.92 margin leaves ~8% of the layout
-    // box as rest-pose slack before the bleed even starts (SCENE_BOUNDS
-    // already bakes in tilt/lift/pop/drift extremes, so this is belt-and-
-    // braces, not the only guard). Reactive to resize via R3F size state; no
-    // per-frame camera work.
+    // column the scattered stat coupons can overflow the frustum — scale the
+    // whole ticket group down to fit both dimensions (bounds come from
+    // SCENE_BOUNDS, computed from the scatter config). The canvas raster is
+    // BLED past the layout box (CANVAS_BLEED_*_PX), so the fit is computed
+    // against the layout-box slice of the frustum, not the whole canvas: the
+    // composition keeps the size it had when canvas == layout box, and the
+    // bleed becomes pure headroom that tilted geometry can swing into without
+    // clipping. The 0.92 margin leaves ~8% of the layout box as rest-pose
+    // slack before the bleed even starts (SCENE_BOUNDS already bakes in
+    // tilt/lift/pop/drift extremes, so this is belt-and-braces, not the only
+    // guard). Reactive to resize via R3F size state; no per-frame camera work.
     const { width, height } = useThree(state => state.size)
     const halfH = Math.tan((42 * Math.PI) / 180 / 2) * CAM_DIST
     const worldPerPx = (halfH * 2) / height
@@ -756,9 +659,6 @@ function SceneContents({ isDark }: { isDark: boolean }): React.JSX.Element {
             />
 
             <group scale={fit}>
-                <group position={MAIN_POS}>
-                    <HeroCard isDark={isDark} />
-                </group>
                 <StatCoupons isDark={isDark} />
                 {/* Inside the fit group ON PURPOSE: the droplet field is wider
                     than the layout box in raw world units, so scaling it with

--- a/apps/caramel-app/src/components/couponTicket3d.tsx
+++ b/apps/caramel-app/src/components/couponTicket3d.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-// couponTicket3d — the reusable ticket visual language shared by BOTH 3D
-// scenes (CouponVaultScene's full vault + HeroTicketScene's compact hero
-// ticket) so the notched-ticket geometry has ONE codepath and zero
-// duplication. Holds the caramel palette, the pure geometry factories
-// (rounded rect + two inward semicircular notches, extruded with a bevel)
-// and the two small mesh building blocks (Perforation, PercentEmblem). No
-// scene/camera/frameloop logic lives here — that stays per-scene.
+// couponTicket3d — the reusable ticket visual language for the 3D scenes
+// (today: HeroTicketScene's three-stat hero constellation) so the
+// notched-ticket geometry has ONE codepath and zero duplication. Holds the
+// caramel palette, the pure geometry factories (rounded rect + two inward
+// semicircular notches, extruded with a bevel) and the Perforation mesh
+// building block. No scene/camera/frameloop logic lives here — that stays
+// per-scene. (PercentEmblem, the primitive-built "%" for the retired big
+// main hero coupon, was removed 2026-07-29 with that coupon.)
 //
 // IMPORTANT: this module imports `three`, so it may ONLY be imported from the
 // lazily-loaded scene chunks (next/dynamic ssr:false). The DOM shells in the
@@ -130,58 +131,4 @@ export function Perforation({
     }, [xs, y, z])
 
     return <instancedMesh ref={meshRef} args={[geometry, material, count]} />
-}
-
-// The "%" is built from primitives (two rings + a diagonal bar) instead of 3D
-// text so the scene ships no font file / network fetch. Raised off the card
-// face (frontZ = the card's front-face Z) with an emissive caramel tone to
-// read as embossed.
-export function PercentEmblem({
-    isDark,
-    frontZ,
-}: {
-    isDark: boolean
-    frontZ: number
-}): React.JSX.Element {
-    const emissive = isDark ? 1.1 : 0.65
-    return (
-        <group position={[0, 0.28, frontZ + 0.03]}>
-            <mesh position={[-0.42, 0.34, 0]}>
-                <torusGeometry args={[0.22, 0.09, 16, 40]} />
-                <meshPhysicalMaterial
-                    color={CARAMEL_LIGHT}
-                    emissive={CARAMEL}
-                    emissiveIntensity={emissive}
-                    metalness={0.35}
-                    roughness={0.2}
-                    clearcoat={1}
-                    clearcoatRoughness={0.12}
-                />
-            </mesh>
-            <mesh position={[0.42, -0.34, 0]}>
-                <torusGeometry args={[0.22, 0.09, 16, 40]} />
-                <meshPhysicalMaterial
-                    color={CARAMEL_LIGHT}
-                    emissive={CARAMEL}
-                    emissiveIntensity={emissive}
-                    metalness={0.35}
-                    roughness={0.2}
-                    clearcoat={1}
-                    clearcoatRoughness={0.12}
-                />
-            </mesh>
-            <mesh rotation={[0, 0, -Math.PI / 4]}>
-                <boxGeometry args={[0.15, 1.35, 0.15]} />
-                <meshPhysicalMaterial
-                    color={CARAMEL_LIGHT}
-                    emissive={CARAMEL}
-                    emissiveIntensity={emissive}
-                    metalness={0.35}
-                    roughness={0.2}
-                    clearcoat={1}
-                    clearcoatRoughness={0.12}
-                />
-            </mesh>
-        </group>
-    )
 }


### PR DESCRIPTION
Third hero refinement round, from the owner's brief: *"just keep the 3 stats and make the open source slight to left so its on center, remove the % big one, also the initial placeholder isn't good"*.

## Before → After

**Before:** big main "%" coupon + three stat tickets scattered around it; the pre-canvas placeholder was a lone CSS "%" ticket with the stat cards parked in a row at the bottom of the box — unrelated to what the canvas then showed.

**After:**
- **Big % coupon removed entirely** — `HeroCard`, its `CARD` geometry, `MAIN_POS`/float slack, and the now-orphaned `PercentEmblem` in `couponTicket3d.tsx` are gone. The droplet field stays (ambient background, z ∈ [−3.2, −1.2], strictly behind every coupon — it never dressed the main card).
- **Three-stat composition recomposed to center**: scale-weighted centroid of the scatter anchors ≈ (0, 0); "100% OPEN SOURCE" moved from far top-right (x 1.42) to top, slightly LEFT of center (x −0.25) per the brief; "3,000+ SUPPORTED STORES" bottom-left front (largest); "0% DATA SELLING" mid-right deepest. No three anchors collinear, varied depth (0.45 / 0.05 / −0.5), per-coupon float frequencies/phases, pointer parallax + proximity lift/tilt/pop all kept. `SCENE_BOUNDS` still derives from the scatter config; a documented **occlusion contract** in the scatter comment proves (x-clearance + corner math) that a nearer coupon's body can only ever cover a deeper coupon's blank corner — never its type — including at float/hover/pop extremes.
- **New placeholder: `HeroCouponPoster`** — a server-rendered DOM/CSS twin of the exact 3D composition: same three coupons at the same anchors/z-order/rotations/relative sizes, same brand recipe (caramel gradient + `ticketNotchMask` notches + discrete-dash perforation matching the 3D `Perforation` row + espresso print-ink type with the small raised suffix). It paints instantly (SSR), cross-fades out on the canvas's `onReady` first-frame signal (existing 700ms fade), and doubles as the **permanent fallback** for no-WebGL / reduced-motion desktops — one component, both roles. Zero CLS (absolute inside the reserved `h-[34rem]` box), no flash of empty space, and the cross-fade is a material swap, not a layout jump.
- **SEO bonus:** the poster is real (non-`aria-hidden`) SSR HTML via `useCountUp`'s hydration-safe final-value seeding, so the three stats now exist in crawler-visible HTML on desktop. Mobile keeps the `StatCards` row in normal flow.

## Visual verification (prod build + headless Chrome, swiftshader)

Two full iterations, light + dark, live canvas + placeholder + forced no-WebGL (`--disable-3d-apis`) + hover-extreme probes (pointer parked on each coupon and in the seams):
- % coupon gone everywhere; no orphaned props.
- Composition centered/balanced with the open-source ticket left-of-old, cascade top → mid-right → bottom-left.
- Poster and canvas line up ticket-for-ticket (cross-fade has no jump).
- Hover extremes: proximity lift/tilt/pop never occludes a deeper ticket's text; nothing clips at the bled raster edge.
- Iteration 2 refined the poster perforation from `border-dashed` (long dashes, wrong motif) to a repeating-gradient row of discrete dashes matching the 3D `Perforation`.

## Gates

- `pnpm -r type-check` / `pnpm lint` / `pnpm lint:oxlint` / `pnpm prettier-check` / `pnpm --filter caramel-app knip`: green
- `pnpm test`: 418/418
- `pnpm --filter caramel-app run build`: green (×2)
- e2e vs local prod server: `home.spec.ts` + `seo-regression.spec.ts` — 18/18 passed (visible-text minimums now additionally backed by the SSR'd stats)

Note for reviewers: Argos will show an intentional hero visual diff (that's the feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8ENhE681xtMpb3iqmxNRs