### PR TITLE
app: PWA shell foundation — AASA, assetlinks, and an honest service-worker story

### DIFF
--- a/apps/caramel-app/knip.json
+++ b/apps/caramel-app/knip.json
@@ -12,7 +12,6 @@
         "postcss.config.mjs",
         "postcss.config.ts",
         "tailwind.config.ts",
-        "public/sw.js",
         "src/components/StoreButtons.tsx",
         "src/lib/capitalizeFirst.ts",
         "src/lib/gtag.ts",

--- a/apps/caramel-app/public/manifest.json
+++ b/apps/caramel-app/public/manifest.json
@@ -337,6 +337,11 @@
         },
         {
             "src": "/app/android/android-launchericon-192-192.png",
+            "sizes": "192x192",
+            "purpose": "maskable"
+        },
+        {
+            "src": "/app/android/android-launchericon-192-192.png",
             "sizes": "192x192"
         },
         {

--- a/apps/caramel-app/src/app/.well-known/apple-app-site-association/route.ts
+++ b/apps/caramel-app/src/app/.well-known/apple-app-site-association/route.ts
@@ -1,0 +1,34 @@
+// Apple App Site Association — universal links + iOS password AutoFill for the
+// Caramel iOS shell (DevinoSolutions/caramel-pwa-apple, bundle
+// com.devino.caramel.app, team NYVG3QV9G2).
+//
+// Served from a route handler rather than public/.well-known/ because the file
+// is extensionless: Next ships bare public files as application/octet-stream,
+// and Apple wants application/json with no redirect. force-static keeps it on
+// the SSG path like the rest of the site.
+//
+// NOT the Safari extension app (com.devino.Caramel / id6741873881) — that one
+// ships through release-extension.yml and claims no universal links.
+
+export const dynamic = 'force-static'
+
+const APP_ID = 'NYVG3QV9G2.com.devino.caramel.app'
+
+export function GET() {
+    return Response.json({
+        applinks: {
+            details: [
+                {
+                    appIDs: [APP_ID],
+                    // Everything except the API surface, which is never a
+                    // navigable destination and should stay in the browser.
+                    components: [
+                        { '/': '/api/*', exclude: true },
+                        { '/': '*' },
+                    ],
+                },
+            ],
+        },
+        webcredentials: { apps: [APP_ID] },
+    })
+}

--- a/apps/caramel-app/src/app/.well-known/assetlinks.json/route.ts
+++ b/apps/caramel-app/src/app/.well-known/assetlinks.json/route.ts
@@ -1,0 +1,37 @@
+// Digital Asset Links — Android App Links verification for the Caramel Android
+// shell (DevinoSolutions/caramel-pwa-android, applicationId com.devino.caramel).
+// Without this file the shell's autoVerify intent-filter never verifies and
+// grabcaramel.com links open in the browser instead of the app.
+//
+// Route handler rather than a public/ file purely for symmetry with the AASA
+// next door, which has to be one.
+
+export const dynamic = 'force-static'
+
+// Upload key: C:\Users\alaed\.android-keys\caramel-upload.keystore (minted
+// 2026-08-06; credentials beside it, never regenerate — a new key orphans every
+// installed build).
+const UPLOAD_KEY_SHA256 =
+    'A8:AB:BD:05:30:0E:97:DA:53:90:E9:E7:D4:E9:BB:CC:CF:2C:66:E5:68:AA:66:65:5A:45:02:0F:38:B0:AE:BA'
+
+// TODO: append the Play App Signing SHA-256 the moment the Play record exists
+// (Console -> Setup -> App signing). Play RE-SIGNS uploaded bundles, so a file
+// carrying only the upload key verifies for sideloaded builds and silently
+// fails for every user who installed from Play.
+const PLAY_APP_SIGNING_SHA256: string[] = []
+
+export function GET() {
+    return Response.json([
+        {
+            relation: ['delegate_permission/common.handle_all_urls'],
+            target: {
+                namespace: 'android_app',
+                package_name: 'com.devino.caramel',
+                sha256_cert_fingerprints: [
+                    UPLOAD_KEY_SHA256,
+                    ...PLAY_APP_SIGNING_SHA256,
+                ],
+            },
+        },
+    ])
+}

--- a/apps/caramel-app/src/app/.well-known/assetlinks.json/route.ts
+++ b/apps/caramel-app/src/app/.well-known/assetlinks.json/route.ts
@@ -14,11 +14,14 @@ export const dynamic = 'force-static'
 const UPLOAD_KEY_SHA256 =
     'A8:AB:BD:05:30:0E:97:DA:53:90:E9:E7:D4:E9:BB:CC:CF:2C:66:E5:68:AA:66:65:5A:45:02:0F:38:B0:AE:BA'
 
-// TODO: append the Play App Signing SHA-256 the moment the Play record exists
-// (Console -> Setup -> App signing). Play RE-SIGNS uploaded bundles, so a file
-// carrying only the upload key verifies for sideloaded builds and silently
-// fails for every user who installed from Play.
-const PLAY_APP_SIGNING_SHA256: string[] = []
+// Play App Signing key (Console -> Setup -> App signing, app id
+// 4973996853903051088). Play RE-SIGNS every uploaded bundle with this key, so
+// installs from Play present THIS fingerprint, not the upload key's. Both must
+// be listed: the upload key covers sideloaded/locally-signed builds, this one
+// covers everyone who installed from the store.
+const PLAY_APP_SIGNING_SHA256 = [
+    '28:20:9D:A2:CC:76:D5:34:17:85:7F:4B:90:51:4C:39:03:DC:E1:DC:1B:63:65:80:74:FD:F4:24:8A:AD:9B:FD',
+]
 
 export function GET() {
     return Response.json([


### PR DESCRIPTION
Caramel is getting native iOS and Android shells (owner ruling, PWA fleet Phase-F). Shells live in their own private repos — `DevinoSolutions/caramel-pwa-android` (built, pushed, emulator-proven) and `DevinoSolutions/caramel-pwa-apple` (in progress) — and nothing native lands in this repo. This PR is the web-side half: the three things the shells need from grabcaramel.com, plus one file that was lying about itself.

Per fleet law the web ships FIRST and is tolerant of both old and new shells, so none of this depends on a shell existing.

## What's here

**`.well-known/apple-app-site-association` and `.well-known/assetlinks.json` (new).** Both were 404 on prod. Without them the iOS shell's `applinks:`/`webcredentials:` entitlements and the Android shell's `autoVerify` intent-filter cannot verify, so grabcaramel.com links open in a browser instead of the app and iOS password AutoFill never associates.

They are route handlers rather than files in `public/`, which is the fleet standard for a specific reason: `apple-app-site-association` is extensionless, so Next serves a bare public file as `application/octet-stream`, and Apple wants `application/json`. Both are `force-static`, so they prerender with everything else. Verified by reading the prerendered output rather than the source — `.next/server/app/.well-known/*.meta` gives `content-type: application/json`, status 200, with the expected bodies.

Two details worth review:

- The AASA excludes `/api/*` before the catch-all. API routes are never a navigable destination and shouldn't be hijacked into the app.
- **`assetlinks.json` currently carries only the upload-key fingerprint, and that is not yet sufficient.** Play re-signs uploaded bundles with its own App Signing key, so this file verifies for sideloaded builds and will silently fail for anyone who installs from Play. There is no Play record for Caramel yet; the moment one exists, the Play App Signing SHA-256 has to be appended. There is a `TODO` on the exact constant.

**`public/sw.js` deleted.** It was a 0-byte file, served live at `https://grabcaramel.com/sw.js` as 200 with an empty body. Nothing in `src/` ever registered it, and there is no serwist/workbox/next-pwa dependency — it was an orphan advertising a service worker that does nothing. Its `knip.json` ignore entry goes with it, keeping the "zero unjustified ignores" rule honest.

This is a deletion, not a replacement: installing Serwist properly is a real piece of work (offline route, precache revisioning, install UX) and wants its own PR. Deleting the empty file is strictly better than leaving prod advertising a URL that serves nothing.

**Manifest: added the maskable 192.** There was a maskable 512 but no maskable 192; Android launchers want both, and without it the icon can get letterboxed inside the adaptive mask on some launchers.

## Deliberately NOT in this PR

**No web-side shell detection.** `shells.md` §5b has a rule for exactly this situation — grep the web repo for shell detection first, and *an empty grep is a real answer*. Caramel has none, so the shells apply the fleet UA convention (`Caramel_native_ios` / `Caramel_native_android`, both keeping the generic ` PWAShell` tag) and each shell repo's `DELTA.md` records the contract note for whoever adds detection here later. Adding a detector now would mean either dead code — which this repo's knip gate correctly rejects — or inventing product behaviour to justify it.

There is a real candidate when someone wants it: the "Available on Your Favorite Browser" blocks in `FeaturesSection.tsx` and `coupons-section.tsx` link to Chrome/Firefox/Edge extension listings, which are dead ends inside a phone shell. That is a product decision (the Safari entry actually *is* reachable from an iOS shell), so it isn't being made silently here. The idiomatic implementation would mirror the existing `THEME_INIT_SCRIPT` — stamp a pre-hydration attribute on `<html>` and let CSS do the rest — rather than a mount effect that flashes.

**No manifest `screenshots`.** They're a genuine installability win, but the right source is a store kit, and `devino-store-screenshots\caramel` doesn't exist yet. Inventing screenshots now guarantees they diverge from the kit later.

**No Serwist.** See above.

## Checks

`type-check` clean · `lint` clean · `knip` clean · `next build` green, 40 app routes including both new ones · unit suite 435/435 passing (a full run also emits 5 vitest worker-pool timeouts on this machine — infrastructure flake under load, no assertion failures; `repo-integrity`, `manifest-sync` and `deps-pinned` re-run serially give 54 passed / 0 failed).

Not merging this myself — CLAUDE.md's hard boundary is that `dev`/`main` merges are human-only, and the prod cutover stays human-run.

---

## Verify steps (exact — run these after merge + deploy)

Everything below is a copy-paste command with the expected answer beside it. Nothing here needs a device.

**1. Both `.well-known` files serve JSON, 200, no redirect.**

```bash
curl -sI https://grabcaramel.com/.well-known/apple-app-site-association | head -3
curl -sI https://grabcaramel.com/.well-known/assetlinks.json | head -3
```
Expect `HTTP/2 200` and `content-type: application/json` on both, and NO `location:` header. A 301/302 here fails Apple outright.

**2. The payloads are the right ones.**

```bash
curl -s https://grabcaramel.com/.well-known/apple-app-site-association
curl -s https://grabcaramel.com/.well-known/assetlinks.json
```
The AASA must contain `NYVG3QV9G2.com.devino.caramel.app` in BOTH `applinks.details[0].appIDs` and `webcredentials.apps`. The assetlinks must contain `com.devino.caramel` and the fingerprint `A8:AB:...:AE:BA`.

**3. Google's own checker agrees** (authoritative for Android — our file being correct is not the same as Google accepting it):

```bash
curl -s "https://digitalassetlinks.googleapis.com/v1/statements:list?source.web.site=https://grabcaramel.com&relation=delegate_permission/common.handle_all_urls"
```
Expect a statement listing `com.devino.caramel`, and `"maxAge"` present with no `errorCode`.

**4. Apple's CDN copy** — this is what devices actually fetch, and it is NOT the same as our origin:

```bash
curl -s https://app-site-association.cdn-apple.com/a/v1/grabcaramel.com
```
⚠️ Apple's CDN caches for roughly 24-48h and will 404 until it first crawls us. Mark this PREPARED-AWAITING-PROBE and re-check on the next doctor run — do not tick it early, and do not conclude the AASA is broken from a 404 here on day one.

**5. The dead service worker is actually gone.**

```bash
curl -sI https://grabcaramel.com/sw.js | head -1
```
Expect `404`. It currently returns `200` with a zero-byte body, which is the defect.

**6. Nothing else regressed.** `/manifest.json` still 200 with `theme_color: #ea6925`, and the site's own CI (typecheck, lint, knip, unit, e2e) is green on the PR.

## Both Android fingerprints are now present

`assetlinks.json` originally shipped only the upload-key fingerprint, which would have verified sideloaded builds and **silently failed for every user who installed from Play** — Play re-signs each uploaded bundle with its own App Signing key, so store installs present a different certificate. The Play record now exists (Console app id `4973996853903051088`), so the file carries both:

| Key | Covers |
| --- | --- |
| `A8:AB:BD:…:AE:BA` | upload key — sideloaded / locally-signed builds |
| `28:20:9D:…:9B:FD` | Play App Signing key — everyone who installs from the store |

Verified out of the prerendered output rather than the source: two entries, both 32 bytes, `content-type: application/json`, status 200. Step 3 of the verify list (Google's `digitalassetlinks` checker) is what re-proves this once deployed.
