### PR TITLE
ext: the popup greets non-web tabs instead of blaming the connection

### DIFF
--- a/apps/caramel-extension/popup.js
+++ b/apps/caramel-extension/popup.js
@@ -240,6 +240,13 @@ async function initPopup() {
         url = null
     }
 
+    // Only web pages can have coupons. The service worker hands back whatever
+    // tab is active — on a new tab, a chrome:// page, or this popup itself
+    // that is a URL no store owns, and asking the coupons API about it painted
+    // "Couldn't load coupons — check your connection" over what should be the
+    // introduction view.
+    if (url && !/^https?:\/\//i.test(url)) url = null
+
     // Wrapped in a Promise so initPopup() itself doesn't resolve until the
     // chosen render state has actually been painted (the storage APIs are
     // chrome-callback based, not natively awaitable) — the DOMContentLoaded

--- a/apps/caramel-extension/scripts/test-extension.mjs
+++ b/apps/caramel-extension/scripts/test-extension.mjs
@@ -266,7 +266,35 @@ async function main() {
                 (await popup.locator('#loginToggleBtn').count()) > 0
             if (hasLoginToggle) await popup.locator('#loginToggleBtn').click()
 
-            await popup.waitForSelector('#email', { timeout: 5000 })
+            try {
+                await popup.waitForSelector('#email', { timeout: 5000 })
+            } catch (err) {
+                // Diagnostic dump: what did the popup actually render?
+                const diag = await popup
+                    .evaluate(() => ({
+                        url: location.href,
+                        loaderShown: (() => {
+                            const l =
+                                document.getElementById('loading-container')
+                            return l ? getComputedStyle(l).display : 'absent'
+                        })(),
+                        visibleIds: [...document.querySelectorAll('[id]')]
+                            .filter(el => el.offsetParent !== null)
+                            .map(el => el.id)
+                            .slice(0, 40),
+                        authContainer: (
+                            document.getElementById('auth-container')
+                                ?.innerHTML || '(empty)'
+                        ).slice(0, 1500),
+                        bodyText: (document.body.innerText || '').slice(0, 600),
+                    }))
+                    .catch(e => ({ evalFailed: String(e) }))
+                console.log(
+                    '[diag] popup state at #email timeout:',
+                    JSON.stringify(diag, null, 2),
+                )
+                throw err
+            }
             await popup.fill('#email', TEST_EMAIL)
             await popup.fill('#password', TEST_PASSWORD)
             await popup.locator('#loginForm button[type="submit"]').click()

--- a/apps/caramel-extension/scripts/test-extension.mjs
+++ b/apps/caramel-extension/scripts/test-extension.mjs
@@ -249,11 +249,14 @@ async function main() {
 
         // 7. POPUP UI LOGIN FLOW
         {
-            // Clear storage.sync so popup starts logged out (popup.js uses storage.sync)
+            // Clear BOTH storage areas so the popup starts logged out —
+            // sessions live in storage.local since the sync->local migration.
             await sw.evaluate(
                 () =>
                     new Promise(res =>
-                        chrome.storage.sync.remove(['token', 'user'], res),
+                        chrome.storage.local.remove(['token', 'user'], () =>
+                            chrome.storage.sync.remove(['token', 'user'], res),
+                        ),
                     ),
             )
 
@@ -307,12 +310,17 @@ async function main() {
                 /* fall through */
             }
 
-            // Give storage.sync a moment to flush
+            // Give storage a moment to flush. Sessions live in storage.LOCAL
+            // since the sync->local migration (credentials must not roam via
+            // Chrome Sync); sync is read as the pre-migration fallback only.
             await popup.waitForTimeout(500)
             const stored = await sw.evaluate(
                 () =>
                     new Promise(res =>
-                        chrome.storage.sync.get(['token', 'user'], res),
+                        chrome.storage.local.get(['token', 'user'], local => {
+                            if (local?.token) return res(local)
+                            chrome.storage.sync.get(['token', 'user'], res)
+                        }),
                     ),
             )
             log(


### PR DESCRIPTION
Fixes the extension e2e gate that is red on dev (proven by no-op probe PR #142) and a real UX bug behind it.

Since dc834a4 tightened the coupons API, the popup asking about a non-web tab (new tab, chrome:// page, the popup itself) gets a failed fetch and renders "Couldn't load coupons — check your connection" — wrong message, and it also hides the sign-in controls (which is what the e2e suite trips on: probe #142's diagnostic dump shows the error view where the login form should be). Non-web URLs are now treated as no-site, so those tabs get the introduction view with sign-in available.

Second commit adds a failure-only diagnostic dump to the e2e harness so the next silent popup regression names itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)