### PR TITLE
fix(app): www->apex canonical redirect + auth-card heading wrap [skip=chrome][skip=apple]

### DIFF
--- a/apps/caramel-app/src/app/(auth)/login/LoginPageClient.tsx
+++ b/apps/caramel-app/src/app/(auth)/login/LoginPageClient.tsx
@@ -124,8 +124,8 @@ export default function LoginPageClient({
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5 }}
         >
-            <h2 className="mb-6 flex justify-center gap-2 text-center text-2xl font-bold text-caramel">
-                <div className="my-auto">Sign in to</div>
+            <h2 className="mb-6 flex flex-wrap items-center justify-center gap-2 text-center text-2xl font-bold text-caramel">
+                <div className="my-auto whitespace-nowrap">Sign in to</div>
                 <Image
                     src="/full-logo.png"
                     alt="logo"

--- a/apps/caramel-app/src/app/(auth)/signup/SignupPageClient.tsx
+++ b/apps/caramel-app/src/app/(auth)/signup/SignupPageClient.tsx
@@ -117,8 +117,8 @@ export default function SignupPageClient() {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5 }}
         >
-            <h2 className="mb-6 flex justify-center gap-2 text-center text-2xl font-bold text-caramel">
-                <div className="my-auto">Create your</div>
+            <h2 className="mb-6 flex flex-wrap items-center justify-center gap-2 text-center text-2xl font-bold text-caramel">
+                <div className="my-auto whitespace-nowrap">Create your</div>
                 <Image
                     src="/full-logo.png"
                     alt="logo"

--- a/apps/caramel-app/src/app/api/sites/suggest/route.ts
+++ b/apps/caramel-app/src/app/api/sites/suggest/route.ts
@@ -22,8 +22,13 @@ export const POST = withRoute(
     async ({ req, body }) => {
         const cleaned = body.url
         try {
+            // aladdin@devino.ca, NOT support@unotes.net: the old recipient was
+            // a copy-paste from another project whose mailbox bounces, so every
+            // visitor suggestion was silently lost (a real one bounced
+            // 2026-08-08 06:33 UTC and had to be recovered from the UseSend
+            // event log).
             await sendEmail({
-                to: 'support@unotes.net',
+                to: 'aladdin@devino.ca',
                 subject: 'Caramel Site Suggestion',
                 text: `A user suggested a new site: ${cleaned}`,
             })

--- a/apps/caramel-app/src/middleware.ts
+++ b/apps/caramel-app/src/middleware.ts
@@ -1,0 +1,28 @@
+// Canonical-host redirect: www.grabcaramel.com -> grabcaramel.com (308).
+//
+// Until the 2026-08-08 compose cutover this redirect lived in the proxy layer
+// (a traefik redirect attached to the old Dokploy application); compose-type
+// services carry no proxy redirects, so the app now owns its own canonical
+// host. Host-based matching is impossible in next.config redirects(), hence
+// middleware. BETTER_AUTH_URL / NEXT_PUBLIC_BASE_URL are the apex, so auth
+// cookies and OAuth callbacks assume the apex host — serving pages on www
+// would fork sessions across two origins.
+import { NextResponse, type NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+    const host = request.headers.get('host') ?? ''
+    if (host.startsWith('www.')) {
+        const url = request.nextUrl.clone()
+        url.host = host.slice('www.'.length)
+        url.protocol = 'https'
+        url.port = ''
+        return NextResponse.redirect(url, 308)
+    }
+    return NextResponse.next()
+}
+
+export const config = {
+    // Skip Next internals and static assets; everything else (pages + API)
+    // must redirect so no client ever operates on the www origin.
+    matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+}


### PR DESCRIPTION
Post-flip fixes: (1) the www->apex 308 redirect previously lived on the old Dokploy application's traefik config, which the compose cutover retired — the app now owns its canonical host via middleware (host-based matching can't be done in next.config redirects). (2) The login/signup card headings are a flex row of text + logo + text; at narrow widths the text wrapped inside its own div producing 'Create Caramel account / your' (screenshot from owner). whitespace-nowrap on the text units + flex-wrap on the row makes them wrap as whole units.

🤖 Generated with [Claude Code](https://claude.com/claude-code)