### PR TITLE
feat(app): modernize auth pages — responsive, accessible, brand-consistent

### DIFF
--- a/apps/caramel-app/src/app/(auth)/layout.tsx
+++ b/apps/caramel-app/src/app/(auth)/layout.tsx
@@ -33,12 +33,16 @@ export default function AuthLayout({
         // so this needs no hydration suppression. <html> already carries the
         // real theme pre-paint — see app/layout.tsx.
         <div className={isDarkMode ? 'dark' : 'light'}>
-            <div className="relative flex min-h-screen items-center justify-center gap-10 overflow-hidden bg-gray-50 px-4 py-12 dark:bg-darkBg">
+            <div className="relative flex min-h-screen items-center justify-center gap-10 overflow-hidden bg-gray-50 px-4 py-12 dark:bg-darkBg sm:py-8 xs:px-3">
                 <div
                     aria-hidden="true"
                     className="pointer-events-none absolute -top-32 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-caramel/10 blur-3xl dark:bg-caramel/15"
                 />
-                <ThemeToggle className="absolute right-6 top-6" />
+                <div
+                    aria-hidden="true"
+                    className="pointer-events-none absolute -bottom-40 -right-32 h-96 w-96 rounded-full bg-caramel/[0.07] blur-3xl dark:bg-caramel/10"
+                />
+                <ThemeToggle className="absolute right-6 top-6 sm:right-4 sm:top-4" />
 
                 {/* Brand side panel — desktop only (this repo's Tailwind is
                     desktop-first: unprefixed = desktop, lg: is a MAX-width

--- a/apps/caramel-app/src/app/(auth)/login/LoginPageClient.tsx
+++ b/apps/caramel-app/src/app/(auth)/login/LoginPageClient.tsx
@@ -10,11 +10,13 @@ import { FaApple, FaGoogle } from 'react-icons/fa'
 import { toast } from 'sonner'
 
 const inputClasses =
-    'w-full rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-gray-900 placeholder:text-gray-400 transition focus:border-caramel focus:outline-none focus:ring-2 focus:ring-caramel/30 dark:border-gray-600 dark:bg-darkBg dark:text-gray-100 dark:placeholder:text-gray-500'
+    'w-full rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-gray-900 shadow-sm placeholder:text-gray-400 transition duration-200 hover:border-gray-400 focus:border-caramel focus:outline-none focus:ring-2 focus:ring-caramel/30 dark:border-gray-600 dark:bg-darkBg dark:text-gray-100 dark:shadow-none dark:placeholder:text-gray-500 dark:hover:border-gray-500 dark:focus:border-caramel'
 const labelClasses =
     'mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300'
 const socialButtonClasses =
-    'flex w-full items-center justify-center gap-3 rounded-lg border border-caramel/40 bg-white px-4 py-2.5 font-medium text-gray-700 transition hover:border-caramel hover:bg-caramel/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-caramel/50 dark:bg-darkBg dark:text-gray-200 dark:hover:bg-caramel/10'
+    'flex w-full items-center justify-center gap-3 rounded-lg border border-caramel/40 bg-white px-4 py-2.5 font-medium text-gray-700 shadow-sm transition duration-200 hover:border-caramel hover:bg-caramel/5 active:bg-caramel/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/50 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-caramel/50 dark:bg-darkBg dark:text-gray-200 dark:shadow-none dark:hover:bg-caramel/10 dark:active:bg-caramel/15 dark:focus-visible:ring-offset-darkerBg'
+const linkClasses =
+    'rounded-sm font-semibold text-caramel underline-offset-2 transition hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/50'
 
 export default function LoginPageClient({
     verified,
@@ -119,7 +121,7 @@ export default function LoginPageClient({
 
     return (
         <motion.div
-            className="w-full max-w-md rounded-2xl border border-gray-200/70 bg-white p-8 shadow-xl shadow-gray-300/40 dark:border-gray-800 dark:bg-darkerBg dark:shadow-black/40"
+            className="w-full min-w-0 max-w-md rounded-2xl border border-gray-200/70 bg-white p-8 shadow-xl shadow-gray-300/40 dark:border-gray-800 dark:bg-darkerBg dark:shadow-black/40 sm:p-6 xs:p-5"
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5 }}
@@ -136,7 +138,10 @@ export default function LoginPageClient({
             </h2>
 
             {showVerificationAlert && (
-                <div className="mb-4 rounded-lg border border-orange-300 bg-orange-50 p-4 dark:border-caramel/40 dark:bg-caramel/10">
+                <div
+                    role="alert"
+                    className="mb-4 rounded-lg border border-orange-300 bg-orange-50 p-4 dark:border-caramel/40 dark:bg-caramel/10"
+                >
                     <div className="flex items-start">
                         <div className="flex-1">
                             <p className="text-sm font-medium text-orange-800 dark:text-orange-200">
@@ -154,7 +159,7 @@ export default function LoginPageClient({
                     <button
                         type="button"
                         onClick={() => router.push('/verify')}
-                        className="mt-3 w-full rounded-lg border border-orange-300 bg-white px-4 py-2 text-sm font-semibold text-caramel transition hover:bg-orange-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/50 dark:border-caramel/40 dark:bg-darkBg dark:hover:bg-caramel/10"
+                        className="mt-3 w-full rounded-lg border border-orange-300 bg-white px-4 py-2 text-sm font-semibold text-caramel shadow-sm transition duration-200 hover:bg-orange-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/50 focus-visible:ring-offset-2 dark:border-caramel/40 dark:bg-darkBg dark:shadow-none dark:hover:bg-caramel/10 dark:focus-visible:ring-offset-darkerBg"
                     >
                         {isTokenExpired
                             ? 'Request New Link'
@@ -237,17 +242,14 @@ export default function LoginPageClient({
                 <button
                     type="submit"
                     disabled={loading}
-                    className="w-full rounded-lg bg-caramel py-2.5 font-semibold text-white shadow-sm transition hover:bg-caramel/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 dark:focus-visible:ring-offset-darkerBg"
+                    className="w-full rounded-lg bg-caramel py-2.5 font-semibold text-white shadow-sm transition duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel focus-visible:ring-offset-2 enabled:hover:bg-caramel/90 enabled:hover:shadow-caramel-sm enabled:active:bg-caramel disabled:cursor-not-allowed disabled:opacity-60 dark:focus-visible:ring-offset-darkerBg"
                 >
                     {loading ? 'Logging in...' : 'Login'}
                 </button>
             </form>
             <p className="mt-6 text-center text-sm text-gray-600 dark:text-gray-400">
                 Don&apos;t have an account?{' '}
-                <Link
-                    className="font-semibold text-caramel hover:underline"
-                    href="/signup"
-                >
+                <Link className={linkClasses} href="/signup">
                     Sign Up
                 </Link>
             </p>

--- a/apps/caramel-app/src/app/(auth)/signup/SignupPageClient.tsx
+++ b/apps/caramel-app/src/app/(auth)/signup/SignupPageClient.tsx
@@ -33,11 +33,13 @@ const validationSchema = object().shape({
 })
 
 const inputClasses =
-    'w-full rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-gray-900 placeholder:text-gray-400 transition focus:border-caramel focus:outline-none focus:ring-2 focus:ring-caramel/30 dark:border-gray-600 dark:bg-darkBg dark:text-gray-100 dark:placeholder:text-gray-500'
+    'w-full rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-gray-900 shadow-sm placeholder:text-gray-400 transition duration-200 hover:border-gray-400 focus:border-caramel focus:outline-none focus:ring-2 focus:ring-caramel/30 dark:border-gray-600 dark:bg-darkBg dark:text-gray-100 dark:shadow-none dark:placeholder:text-gray-500 dark:hover:border-gray-500 dark:focus:border-caramel'
 const labelClasses =
     'mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300'
 const socialButtonClasses =
-    'flex w-full items-center justify-center gap-3 rounded-lg border border-caramel/40 bg-white px-4 py-2.5 font-medium text-gray-700 transition hover:border-caramel hover:bg-caramel/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-caramel/50 dark:bg-darkBg dark:text-gray-200 dark:hover:bg-caramel/10'
+    'flex w-full items-center justify-center gap-3 rounded-lg border border-caramel/40 bg-white px-4 py-2.5 font-medium text-gray-700 shadow-sm transition duration-200 hover:border-caramel hover:bg-caramel/5 active:bg-caramel/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/50 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-caramel/50 dark:bg-darkBg dark:text-gray-200 dark:shadow-none dark:hover:bg-caramel/10 dark:active:bg-caramel/15 dark:focus-visible:ring-offset-darkerBg'
+const linkClasses =
+    'rounded-sm font-semibold text-caramel underline-offset-2 transition hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/50'
 
 export default function SignupPageClient() {
     const [showPasswordChecker, setShowPasswordChecker] = useState(false)
@@ -112,7 +114,7 @@ export default function SignupPageClient() {
 
     return (
         <motion.div
-            className="w-full max-w-md rounded-2xl border border-gray-200/70 bg-white p-8 shadow-xl shadow-gray-300/40 dark:border-gray-800 dark:bg-darkerBg dark:shadow-black/40"
+            className="w-full min-w-0 max-w-md rounded-2xl border border-gray-200/70 bg-white p-8 shadow-xl shadow-gray-300/40 dark:border-gray-800 dark:bg-darkerBg dark:shadow-black/40 sm:p-6 xs:p-5"
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5 }}
@@ -126,7 +128,7 @@ export default function SignupPageClient() {
                     width={90}
                     className="my-auto mt-2"
                 />
-                <div className="my-auto">account</div>
+                <div className="my-auto whitespace-nowrap">account</div>
             </h2>
             <div className="mb-4 space-y-3">
                 <button
@@ -183,9 +185,12 @@ export default function SignupPageClient() {
                         placeholder="@nickname"
                         className={inputClasses}
                     />
-                    <div className="ml-1 h-1 pb-2">
+                    <div className="ml-1 mt-1 min-h-[1.25rem]">
                         {errors.username && touched.username && (
-                            <div className="text-sm text-red-500 dark:text-red-400">
+                            <div
+                                role="alert"
+                                className="text-sm text-red-500 dark:text-red-400"
+                            >
                                 {errors.username}
                             </div>
                         )}
@@ -206,9 +211,12 @@ export default function SignupPageClient() {
                         placeholder="Enter your email"
                         className={inputClasses}
                     />
-                    <div className="ml-1 h-1 pb-2">
+                    <div className="ml-1 mt-1 min-h-[1.25rem]">
                         {errors.email && touched.email && (
-                            <div className="text-sm text-red-500 dark:text-red-400">
+                            <div
+                                role="alert"
+                                className="text-sm text-red-500 dark:text-red-400"
+                            >
                                 {errors.email}
                             </div>
                         )}
@@ -268,22 +276,22 @@ export default function SignupPageClient() {
                 <button
                     disabled={loading || Object.keys(errors).length > 0}
                     type="submit"
-                    className={`w-full ${loading || Object.keys(errors).length > 0 ? 'pointer-events-none opacity-60' : 'hover:bg-caramel/90'} rounded-lg bg-caramel py-2.5 font-semibold text-white shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel focus-visible:ring-offset-2 dark:focus-visible:ring-offset-darkerBg`}
+                    className="w-full rounded-lg bg-caramel py-2.5 font-semibold text-white shadow-sm transition duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel focus-visible:ring-offset-2 enabled:hover:bg-caramel/90 enabled:hover:shadow-caramel-sm enabled:active:bg-caramel disabled:cursor-not-allowed disabled:opacity-60 dark:focus-visible:ring-offset-darkerBg"
                 >
                     {loading ? 'Loading...' : 'Sign Up'}
                 </button>
             </form>
             <p className="mt-6 text-center text-sm text-gray-600 dark:text-gray-400">
                 Already have an account?{' '}
-                <Link
-                    href="/login"
-                    className="font-semibold text-caramel hover:underline"
-                >
+                <Link href="/login" className={linkClasses}>
                     Login
                 </Link>
             </p>
             {error ? (
-                <p className="mt-4 text-center text-sm text-red-500 dark:text-red-400">
+                <p
+                    role="alert"
+                    className="mt-4 text-center text-sm text-red-500 dark:text-red-400"
+                >
                     {error}
                 </p>
             ) : null}

--- a/apps/caramel-app/src/app/(auth)/verify/VerifyPageClient.tsx
+++ b/apps/caramel-app/src/app/(auth)/verify/VerifyPageClient.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
 const inputClasses =
-    'w-full rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-gray-900 placeholder:text-gray-400 transition focus:border-caramel focus:outline-none focus:ring-2 focus:ring-caramel/30 dark:border-gray-600 dark:bg-darkBg dark:text-gray-100 dark:placeholder:text-gray-500'
+    'w-full rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-gray-900 shadow-sm placeholder:text-gray-400 transition duration-200 hover:border-gray-400 focus:border-caramel focus:outline-none focus:ring-2 focus:ring-caramel/30 dark:border-gray-600 dark:bg-darkBg dark:text-gray-100 dark:shadow-none dark:placeholder:text-gray-500 dark:hover:border-gray-500 dark:focus:border-caramel'
 
 export default function VerifyPageClient({
     signup,
@@ -69,13 +69,13 @@ export default function VerifyPageClient({
 
     return (
         <motion.div
-            className="w-full max-w-md rounded-2xl border border-gray-200/70 bg-white p-8 shadow-xl shadow-gray-300/40 dark:border-gray-800 dark:bg-darkerBg dark:shadow-black/40"
+            className="w-full min-w-0 max-w-md rounded-2xl border border-gray-200/70 bg-white p-8 shadow-xl shadow-gray-300/40 dark:border-gray-800 dark:bg-darkerBg dark:shadow-black/40 sm:p-6 xs:p-5"
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5 }}
         >
-            <h2 className="mb-6 flex justify-center gap-2 text-center text-2xl font-bold text-caramel">
-                <div className="my-auto">Verify your</div>
+            <h2 className="mb-6 flex flex-wrap items-center justify-center gap-2 text-center text-2xl font-bold text-caramel">
+                <div className="my-auto whitespace-nowrap">Verify your</div>
                 <Image
                     src="/full-logo.png"
                     alt="logo"
@@ -83,7 +83,7 @@ export default function VerifyPageClient({
                     width={90}
                     className="my-auto mt-2"
                 />
-                <div className="my-auto">account</div>
+                <div className="my-auto whitespace-nowrap">account</div>
             </h2>
 
             <div className="mb-6 text-center text-gray-600 dark:text-gray-300">
@@ -122,7 +122,7 @@ export default function VerifyPageClient({
                     type="button"
                     onClick={handleResendVerification}
                     disabled={resendingEmail}
-                    className="w-full rounded-lg bg-caramel py-2.5 font-semibold text-white shadow-sm transition hover:bg-caramel/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 dark:focus-visible:ring-offset-darkerBg"
+                    className="w-full rounded-lg bg-caramel py-2.5 font-semibold text-white shadow-sm transition duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel focus-visible:ring-offset-2 enabled:hover:bg-caramel/90 enabled:hover:shadow-caramel-sm enabled:active:bg-caramel disabled:cursor-not-allowed disabled:opacity-60 dark:focus-visible:ring-offset-darkerBg"
                 >
                     {resendingEmail ? 'Sending...' : 'Send verification email'}
                 </button>
@@ -131,7 +131,7 @@ export default function VerifyPageClient({
             <p className="mt-6 text-center text-sm text-gray-600 dark:text-gray-400">
                 Already verified?{' '}
                 <Link
-                    className="font-semibold text-caramel hover:underline"
+                    className="rounded-sm font-semibold text-caramel underline-offset-2 transition hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/50"
                     href="/login"
                 >
                     Sign In


### PR DESCRIPTION
Presentation-only refresh of the (auth) route group — login, signup, verify — plus the shared auth layout. No auth logic, form handlers, Better Auth calls, routes, or validation touched; no exports renamed.

## Visual changes

**All three cards (login / signup / verify)**
- Responsive card padding: `p-8` desktop → `sm:p-6` (≤639px) → `xs:p-5` (≤475px), plus `min-w-0`, so the card breathes on 320px phones instead of eating a third of the width in padding (this repo's Tailwind is desktop-first max-width breakpoints).
- Inputs: subtle `shadow-sm` (light mode), hover border feedback (`hover:border-gray-400` / dark `gray-500`), `duration-200` transitions; caramel focus border+ring kept.
- Primary buttons: hover/active states now gated on `enabled:` (no more phantom hover on disabled), warm `hover:shadow-caramel-sm` brand glow, `active:` press feedback.
- Social buttons: `shadow-sm`, active-state tint, and `focus-visible:ring-offset` for a cleaner keyboard ring in both themes.
- Footer links (Sign Up / Login / Sign In): `focus-visible` caramel ring + `underline-offset-2`.

**Login**
- Verification alert box gets `role="alert"`; its CTA button gains ring-offset + dark-mode-correct shadow handling.

**Signup**
- Submit button: replaced the `pointer-events-none opacity-60` ternary hack with standard `disabled:` variants on a static class (the `disabled` attribute logic is unchanged).
- Field error slots: `h-1 pb-2` (4px box the error text overflowed) → `mt-1 min-h-[1.25rem]`, so validation messages push content instead of overlapping the next field on small screens; error messages get `role="alert"`.
- Heading "account" chunk gets `whitespace-nowrap`, matching the #150 wrap fix.

**Verify**
- Heading brought onto the #150 pattern: `flex-wrap` + `whitespace-nowrap` chunks (it previously had neither, the one heading that could still clip at 320px).

**Auth layout**
- `sm:py-8` / `xs:px-3` so the shell doesn't overflow tiny viewports; ThemeToggle pulls in to `right-4 top-4` on phones.
- Second soft caramel glow bottom-right balancing the existing top glow (light + dark variants).

Dark mode verified on every touched element (`dark:` twins added wherever a light-only utility landed: `dark:shadow-none`, `dark:hover:border-gray-500`, `dark:focus-visible:ring-offset-darkerBg`, dark glow opacities).

## Gates (apps/caramel-app, pnpm@9)
- `type-check` (tsc --noEmit): clean (after `prisma generate`)
- `lint` (eslint): clean
- `prettier-check`: clean (prettier-write run first; tailwind class-order plugin applied)
- `test` (vitest): 61 files, **517/517 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)