### PR TITLE
ext: a discount already on the cart no longer poisons a valid code's verdict

### DIFF
--- a/apps/caramel-extension/.size-limit.js
+++ b/apps/caramel-extension/.size-limit.js
@@ -135,7 +135,27 @@ module.exports = [
         // empty list — silence on every fresh install. ~2.5 kB is code; the
         // rest is the measurement prose that stops the next edit undoing it.
         // Measured 254.83 kB.
-        limit: '256 KB',
+        //
+        // 2026-08-08 — 256 → 258 KB. Two residuals in the already-applied
+        // discount handling, both in coupon-runner.js. The no-win path reported
+        // 'failed' to the trust loop with no preExistingDiscount gate, so a
+        // store refusing to stack ("cannot be combined with the discount
+        // already applied" — text that reaches lastStoreReason WITHOUT
+        // rejection vocabulary) spent a permanent verdict on a valid code; the
+        // report is now withheld, because the endpoint's vocabulary is exactly
+        // {worked, failed} and has no neutral value to send. And the
+        // zero-effect branch, which had the same snapshot in scope, hedged at
+        // shoppers whose live discount we could see and dropped the
+        // replace-warning its sibling treats as mandatory. ~0.6 kB is code and
+        // message copy; the rest states the constraint, which is the whole
+        // defence against the next edit reinstating a false 'failed'. A first
+        // pass paid back 0.7 kB by cutting prose. Measured 256.71 kB — 258
+        // rather than 257 for the same reason the 249 line gives: ~290 B of
+        // headroom makes the next comment edit a build failure that says
+        // nothing true about bundle weight. The standing recommendation above
+        // (price MINIFIED bytes) is now five raises overdue and still the
+        // owner's call.
+        limit: '258 KB',
         brotli: false,
     },
     {

--- a/apps/caramel-extension/coupon-runner.js
+++ b/apps/caramel-extension/coupon-runner.js
@@ -1088,10 +1088,21 @@ async function startApplyingCoupons(rec, options) {
             const reason = lastStoreReason
                 ? ` The store said: “${String(lastStoreReason).slice(0, 140)}”.`
                 : ''
+            /* "a discount you already have" is a guess in general and a KNOWN
+             * fact when preExistingDiscount is set — this is that same
+             * already-discounted cart, seen from the side where our code was
+             * accepted and moved nothing. So name it, and carry the sentence
+             * the sibling no-win branch below treats as mandatory: on most
+             * checkouts pasting another code REPLACES the live one. The copy
+             * list is still handed over — a shopper may want to swap — but
+             * never without saying what a swap costs. */
+            const tail = preExistingDiscount
+                ? `Your cart already has a discount on it, and the store may not combine another with it — check your order summary before you check out. Pasting another may replace what you've got, so only swap if you want to.`
+                : `It may need a minimum spend, or the store may not combine it with a discount you already have — check your order summary before you check out.`
             showFinalModal(
                 0,
                 null,
-                `We put ${bestCode} into the promo box, but your total didn't change.${reason} It may need a minimum spend, or the store may not combine it with a discount you already have — check your order summary before you check out.`,
+                `We put ${bestCode} into the promo box, but your total didn't change.${reason} ${tail}`,
                 false,
                 caramelSinkTriedCodes(
                     allCoupons.map(c =>
@@ -1118,7 +1129,25 @@ async function startApplyingCoupons(rec, options) {
         // budget, or an untrusted synthetic click — lastFailId stays null and
         // we fire NOTHING: a valid code the store rejected only because our
         // click isn't trusted must never be recorded as a coupon failure.
-        if (lastFailId) reportOutcome(lastFailId, 'failed', lastStoreReason)
+        // A cart that already carried a discount makes the evidence just as
+        // unattributable. "Cannot be combined with the discount already
+        // applied" reaches lastStoreReason via coupon-apply.js's
+        // empty-container-to-text branch, which does NOT require rejection
+        // vocabulary — the code is valid and the rejection describes the cart.
+        // Withheld rather than softened: the endpoint takes {worked, failed}
+        // and nothing else, so there is no neutral verdict to send, and a false
+        // 'failed' down-ranks a working code for every future shopper.
+        if (lastFailId) {
+            if (preExistingDiscount) {
+                log('AUTO_INSERT_VERDICT_WITHHELD', {
+                    id: lastFailId,
+                    storeReason: lastStoreReason,
+                    reason: 'the cart arrived with a discount, so this rejection is not evidence about the code',
+                })
+            } else {
+                reportOutcome(lastFailId, 'failed', lastStoreReason)
+            }
+        }
         // Nothing auto-applied. Hand the tried codes to the modal so the user
         // gets a manual copy/paste fallback (covers valid codes the store's
         // checkout rejected only because our synthetic click isn't trusted).

--- a/apps/caramel-extension/tests/pre-existing-discount.test.mjs
+++ b/apps/caramel-extension/tests/pre-existing-discount.test.mjs
@@ -19,6 +19,7 @@ let startApplyingCoupons
 let removeAppliedCoupon
 let finalModalCalls
 let removedRows
+let reportedOutcomes
 
 const REC = {
     domain: 'example.com',
@@ -74,6 +75,7 @@ beforeEach(() => {
     setTotalText('Order Total $80.00')
     removedRows = []
     finalModalCalls = []
+    reportedOutcomes = []
     globalThis._caramelCancelled = false
     // The cleanup path waits ~600ms after each click for the cart to settle,
     // and the loop pauses between codes. Under a full-suite run that real time
@@ -94,7 +96,8 @@ beforeEach(() => {
     globalThis.showTestingModal = async () => {}
     globalThis.updateTestingModal = async () => {}
     globalThis.hideTestingModal = () => {}
-    globalThis.reportOutcome = () => {}
+    globalThis.reportOutcome = (id, outcome, storeReason) =>
+        reportedOutcomes.push({ id, outcome, storeReason })
     globalThis.caramelRecordSaving = () => {}
     globalThis.showFinalModal = (...args) => finalModalCalls.push(args)
     // Every code "commits" a row and then errors — the exact state that
@@ -214,5 +217,99 @@ describe('an already-discounted cart is not reported as a failure', () => {
         expect(finalModalCalls[0][2] ?? '').not.toMatch(
             /already has a discount/i,
         )
+    })
+})
+
+// The modal told this shopper the truth; the BACKEND was told a lie. Same run,
+// same rejection text, two different audiences — and only one of them was
+// fixed. A store that refuses a second code ("cannot be combined with the
+// discount already applied") produces error text with no rejection vocabulary
+// in it, which coupon-apply.js hands back verbatim, and the no-win path spent
+// it as a 'failed' verdict on a coupon that is in perfect health. That verdict
+// outlives the session and follows the code to every future shopper.
+describe('a rejection caused by the shopper’s own discount is not a coupon verdict', () => {
+    it('sends no failure verdict when the cart already carried a discount', async () => {
+        addAppliedRow('SHOPPER50')
+
+        await startApplyingCoupons(REC)
+
+        // The run still ends with no win, and the shopper still sees why.
+        expect(finalModalCalls[0][2]).toMatch(/already has a discount/i)
+        expect(reportedOutcomes).toEqual([])
+    })
+
+    it("withholds it even when the store's words sound like a code problem", async () => {
+        // The exact trap: wording that reads as a verdict on the code, on a
+        // cart where it cannot be one. There is no neutral outcome to send in
+        // its place — the endpoint takes 'worked' or 'failed' and nothing else
+        // — so the honest report is no report.
+        addAppliedRow('SHOPPER50')
+        globalThis.applyCoupon = async () => ({
+            success: false,
+            newTotal: 80,
+            committed: true,
+            errorMsg:
+                'This code cannot be combined with the discount already applied',
+            errorIsNew: true,
+        })
+
+        await startApplyingCoupons(REC)
+
+        expect(reportedOutcomes).toEqual([])
+    })
+
+    it('still reports the failure when the cart arrived clean', async () => {
+        // Guards the guard. The suppression is scoped to the one situation
+        // that makes the evidence unattributable; everywhere else the trust
+        // loop must keep learning, or the fix costs more signal than the bug.
+        await startApplyingCoupons(REC)
+
+        expect(reportedOutcomes).toEqual([
+            {
+                id: 'c2', // the last code to produce real rejection text
+                outcome: 'failed',
+                storeReason: 'Not valid for these items',
+            },
+        ])
+    })
+})
+
+// The other half of the same cart: our code went in, the store took it, and
+// the total never moved — which on an already-discounted cart is what "they
+// won't combine" looks like from the winning side. This branch knew about the
+// live discount (it had the same snapshot) and still hedged at the shopper
+// with "a discount you already have", then sent them off to paste codes
+// without the warning its sibling treats as mandatory.
+describe('a code that changed nothing on a discounted cart says so plainly', () => {
+    beforeEach(() => {
+        // Accepted, committed, total identical → the zero-effect branch.
+        globalThis.applyCoupon = async code => {
+            addAppliedRow(code)
+            return { success: true, newTotal: 80, committed: true }
+        }
+    })
+
+    it('names the live discount and warns what pasting another costs', async () => {
+        addAppliedRow('SHOPPER50')
+
+        await startApplyingCoupons(REC)
+
+        const message = finalModalCalls[0][2] ?? ''
+        expect(message).toMatch(/already has a discount/i)
+        expect(message).toMatch(/may replace/i)
+        // The guess is gone: we can SEE the discount, so we stop offering a
+        // minimum spend as the likely explanation.
+        expect(message).not.toMatch(/minimum spend/i)
+        // The codes are still handed over — a shopper may want to swap.
+        expect(finalModalCalls[0][4]?.length).toBeGreaterThan(0)
+    })
+
+    it('keeps the original hedge when no discount was on the cart', async () => {
+        await startApplyingCoupons(REC)
+
+        const message = finalModalCalls[0][2] ?? ''
+        expect(message).toMatch(/minimum spend/i)
+        expect(message).not.toMatch(/may replace/i)
+        expect(message).not.toMatch(/already has a discount/i)
     })
 })


### PR DESCRIPTION
Two residuals in the already-applied-discount handling. The feature is fixed overall; these are the two places the same snapshot was in scope and went unused.

## Residual A — a valid coupon was reported to the backend as `failed`

`coupon-runner.js` ran the DOM-form no-win path as `if (lastFailId) reportOutcome(lastFailId, 'failed', lastStoreReason)` with no `preExistingDiscount` gate.

When a store refuses to stack — "cannot be combined with the discount already applied" — that sentence reaches `lastStoreReason` through the empty-container-to-text branch in `coupon-apply.js`, which returns the text **without** requiring rejection vocabulary. So a perfectly valid code got a permanent `failed` verdict purely because the shopper already had a discount on. The user-facing message was already correct; only the backend verdict was wrong.

**Outcome vocabulary.** `POST /api/coupons/[id]/report` validates `outcome: z.enum(['worked', 'failed'])` — strictly binary, no neutral/skipped/unknown value exists, and `background.js` forwards the string unchanged. So the report is **suppressed**, not relabelled: when `preExistingDiscount` is truthy the run logs `AUTO_INSERT_VERDICT_WITHHELD` (id + the store's reason) instead of firing. A missing data point costs one signal; a false `failed` down-ranks a working code for every future shopper.

Suppression is scoped to that one situation — on a cart that arrived clean, `failed` still reports exactly as before.

## Residual B — the zero-effect branch hedged over a discount it could see

The `zeroEffect` branch (our code accepted, total never moved — i.e. the already-discounted cart seen from the winning side) had `preExistingDiscount` in scope and ignored it: it offered "a discount you already have" as a guess and handed over the copy list without the "pasting another may replace what you've got" warning its sibling no-win branch treats as mandatory.

It now mirrors the sibling: names the live discount and carries the same replace-warning, verbatim. The copy list stays unfiltered in both branches, matching the sibling.

## Test evidence

Extended `tests/pre-existing-discount.test.mjs` (the file that already owns this feature) with 5 tests — 3 behaviour, 2 pinning current behaviour so the fix cannot over-reach.

Red-proofed against the unfixed source — exactly 3 fail, and the 2 pinning tests pass on both sides:

```
1. ...sends no failure verdict when the cart already carried a discount
   AssertionError: expected [ { id: 'c2', ...(2) } ] to deeply equal []
2. ...withholds it even when the store's words sound like a code problem
   AssertionError: expected [ { id: 'c2', ...(2) } ] to deeply equal []
3. ...names the live discount and warns what pasting another costs
   AssertionError: expected 'We put TRYME into the promo box, but ...' to match /already has a discount/i
```

All CI gates green on the fix (mirrors `checks-extension.yml`):

| gate | result |
| --- | --- |
| `vitest run` | 650 passed, 0 failed |
| `eslint .` | exit 0 (only pre-existing `no-console` warnings, same as `main`) |
| `prettier --check` | all files formatted correctly |
| `knip` | clean |
| `size-limit` | green (see below) |
| `build` | `built dist/ — 28 entries` |

## One thing to flag: the size budget

`content-scripts` measures **raw source bytes**, so comments are priced as if they ran. The fix pushed it from 254.83 kB to 257.39 kB, over the 256 KB limit. I trimmed prose first and paid back 0.7 kB (256.71 kB); the remaining 714 B is the constraint statement itself, which is the whole defence against a future edit reinstating the false `failed`.

Per the budget file's own rule — "Raising a number is allowed; raising it silently is not. Date the reason beside it." — I raised it to **258 KB** with a dated note. 258 rather than 257 for the reason the existing 249 note gives: ~290 B of headroom turns the next comment edit into a build failure that says nothing true about bundle weight. The file's standing recommendation to price *minified* bytes is now five raises overdue and remains the owner's call.

No version numbers touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
