### PR TITLE
chore(extension): 1.3.0

### DIFF
--- a/apps/caramel-extension/manifest-firefox.json
+++ b/apps/caramel-extension/manifest-firefox.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Caramel - Trusted Honey Alternative",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "Open‑source coupon extension that auto‑applies deals without selling data or hijacking commissions.",
     "browser_specific_settings": {
         "gecko": {

--- a/apps/caramel-extension/manifest.json
+++ b/apps/caramel-extension/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Caramel - Trusted Honey Alternative",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "Open‑source coupon extension that auto‑applies deals without selling data or hijacking commissions.",
     "browser_specific_settings": {
         "gecko": {

--- a/apps/caramel-extension/package.json
+++ b/apps/caramel-extension/package.json
@@ -1,6 +1,6 @@
 {
     "name": "caramel-extension",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "Caramel browser extension",
     "private": true,
     "scripts": {


### PR DESCRIPTION
Bumps the extension's single version authority (manifest.json, manifest-firefox.json, package.json) from 1.2.0 to 1.3.0.

**Why 1.3.0 and not 1.2.1.** App Store Connect already holds an Apple-APPROVED macOS version **1.2.3** sitting in `PENDING_DEVELOPER_RELEASE` (created 2025-08-01, never released), so any macOS submission at or below 1.2.3 is rejected — the extension's one-version-authority scheme does not know about the Mac app's independent version history. 1.3.0 clears every store at once: above Chrome's published 1.1.0, above AMO's listed 1.0.3, above iOS 1.1.20 and macOS 1.2.3.

Carries the build-time environment fix (#155), so this is the first release whose Safari and Firefox packages resolve to production rather than dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)