### PR TITLE
fix(app): header avatar showed "U" for accounts with no name

### DIFF
--- a/apps/caramel-app/src/app/(auth)/login/LoginPageClient.tsx
+++ b/apps/caramel-app/src/app/(auth)/login/LoginPageClient.tsx
@@ -130,7 +130,7 @@ export default function LoginPageClient({
                 <div className="my-auto whitespace-nowrap">Sign in to</div>
                 <Image
                     src="/full-logo.png"
-                    alt="logo"
+                    alt="Caramel"
                     height={90}
                     width={90}
                     className="my-auto mt-2"

--- a/apps/caramel-app/src/app/(auth)/signup/SignupPageClient.tsx
+++ b/apps/caramel-app/src/app/(auth)/signup/SignupPageClient.tsx
@@ -123,7 +123,7 @@ export default function SignupPageClient() {
                 <div className="my-auto whitespace-nowrap">Create your</div>
                 <Image
                     src="/full-logo.png"
-                    alt="logo"
+                    alt="Caramel"
                     height={90}
                     width={90}
                     className="my-auto mt-2"

--- a/apps/caramel-app/src/app/(auth)/verify/VerifyPageClient.tsx
+++ b/apps/caramel-app/src/app/(auth)/verify/VerifyPageClient.tsx
@@ -78,7 +78,7 @@ export default function VerifyPageClient({
                 <div className="my-auto whitespace-nowrap">Verify your</div>
                 <Image
                     src="/full-logo.png"
-                    alt="logo"
+                    alt="Caramel"
                     height={90}
                     width={90}
                     className="my-auto mt-2"

--- a/apps/caramel-app/src/app/profile/ProfilePageClient.tsx
+++ b/apps/caramel-app/src/app/profile/ProfilePageClient.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useSession } from '@/lib/auth/client'
+import { userInitial } from '@/lib/userInitial'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 
@@ -42,10 +43,7 @@ export default function ProfilePageClient() {
     }
 
     const user = session.user
-    const userInitial =
-        user.name?.charAt(0).toUpperCase() ||
-        user.email?.charAt(0).toUpperCase() ||
-        'U'
+    const avatarLetter = userInitial(user)
 
     return (
         <main className="relative -mt-[6.7rem] w-full">
@@ -58,7 +56,7 @@ export default function ProfilePageClient() {
                     <div className="rounded-2xl border border-gray-100 bg-white p-8 shadow-lg dark:border-gray-800 dark:bg-darkerBg">
                         <div className="mb-6 flex items-center gap-6">
                             <div className="flex h-20 w-20 items-center justify-center rounded-full bg-caramel text-2xl font-semibold text-white ring-4 ring-caramel/15">
-                                {userInitial}
+                                {avatarLetter}
                             </div>
                             <div>
                                 <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">

--- a/apps/caramel-app/src/layouts/Header/Header.tsx
+++ b/apps/caramel-app/src/layouts/Header/Header.tsx
@@ -3,6 +3,7 @@ import { useScrollDirection } from '@/hooks/useScrollDirection'
 import { useWindowSize } from '@/hooks/useWindowSize'
 import { resetPosthogIdentity } from '@/lib/analytics/identity'
 import { signOut, useSession } from '@/lib/auth/client'
+import { userInitial } from '@/lib/userInitial'
 import { AnimatePresence, motion } from 'framer-motion'
 import Image from 'next/image'
 import L from 'next/link'
@@ -67,7 +68,7 @@ export default function Header({ scrollRef }: HeaderProps) {
         window.location.href = '/'
     }
 
-    const userInitial = session?.user?.name?.charAt(0).toUpperCase() || 'U'
+    const avatarLetter = session?.user ? userInitial(session.user) : 'U'
 
     useEffect(() => {
         if (isScrollingDown) {
@@ -95,7 +96,7 @@ export default function Header({ scrollRef }: HeaderProps) {
             >
                 <Image
                     src="/full-logo.png"
-                    alt="logo"
+                    alt="Caramel"
                     height={120}
                     width={120}
                     className="mb-auto mt-auto w-4/5 cursor-pointer sm:w-5/12"
@@ -136,7 +137,7 @@ export default function Header({ scrollRef }: HeaderProps) {
                             aria-label="Account menu"
                             className="flex h-8 w-8 items-center justify-center rounded-full bg-caramel text-sm font-semibold text-white ring-2 ring-caramel/20 transition hover:scale-105 hover:ring-caramel/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/60"
                         >
-                            {userInitial}
+                            {avatarLetter}
                         </button>
                         <AnimatePresence>
                             {isUserMenuOpen && (

--- a/apps/caramel-app/src/lib/userInitial.ts
+++ b/apps/caramel-app/src/lib/userInitial.ts
@@ -1,0 +1,17 @@
+/**
+ * The single source of truth for the avatar letter.
+ *
+ * The header and the profile page each derived this themselves and drifted: the
+ * profile page fell back name -> email -> 'U', the header went straight to 'U'.
+ * A Google account whose profile carries no `name` (Better Auth only writes the
+ * provider profile at account creation, so accounts that predate social sign-in
+ * keep a null name) therefore showed a meaningless "U" in the header while the
+ * profile page showed the right letter for the same session.
+ */
+export function userInitial(user: {
+    name?: string | null
+    email?: string | null
+}): string {
+    const source = user.name?.trim() || user.email?.trim() || ''
+    return source.charAt(0).toUpperCase() || 'U'
+}

--- a/apps/caramel-app/tests/unit/userInitial.test.ts
+++ b/apps/caramel-app/tests/unit/userInitial.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { userInitial } from '@/lib/userInitial'
+
+describe('userInitial', () => {
+    it('prefers the display name', () => {
+        expect(userInitial({ name: 'Aladdin Bensalah', email: 'x@y.z' })).toBe(
+            'A',
+        )
+    })
+
+    it('falls back to the email when the account carries no name', () => {
+        // The exact production case: a Google account created before social
+        // sign-in wrote the provider profile, so `name` is null. The header
+        // used to render a meaningless "U" here while the profile page showed
+        // "A" for the same session.
+        expect(userInitial({ name: null, email: 'aladdin@devino.ca' })).toBe(
+            'A',
+        )
+    })
+
+    it('falls back to the email when the name is only whitespace', () => {
+        expect(userInitial({ name: '   ', email: 'zoe@example.com' })).toBe('Z')
+    })
+
+    it('uses U only when there is neither a name nor an email', () => {
+        expect(userInitial({ name: null, email: null })).toBe('U')
+        expect(userInitial({})).toBe('U')
+    })
+
+    it('uppercases a lowercase source', () => {
+        expect(userInitial({ email: 'ben.amos94@hotmail.com' })).toBe('B')
+    })
+})
+
+/**
+ * The bug was not the fallback chain itself — it was TWO components each
+ * deriving one. This is the check that keeps the helper the only derivation, so
+ * the next component to show an avatar cannot quietly grow a third variant.
+ */
+describe('avatar letter has exactly one derivation', () => {
+    const SRC = join(__dirname, '..', '..', 'src')
+    const HELPER = join(SRC, 'lib', 'userInitial.ts')
+    // `user.name?.charAt(0)`, `session.user.email.charAt(0)`, … — any charAt(0)
+    // taken off a name/email rather than through the helper.
+    const RAW_DERIVATION =
+        /\b(?:name|email)\??\.(?:trim\(\)\s*\|\|\s*)?charAt\(0\)/
+
+    function walk(dir: string): string[] {
+        return readdirSync(dir).flatMap(entry => {
+            const full = join(dir, entry)
+            if (statSync(full).isDirectory()) return walk(full)
+            return /\.(ts|tsx)$/.test(entry) ? [full] : []
+        })
+    }
+
+    it('no component derives the avatar letter itself', () => {
+        const offenders = walk(SRC)
+            .filter(file => file !== HELPER)
+            .filter(file => RAW_DERIVATION.test(readFileSync(file, 'utf8')))
+            .map(file => file.slice(SRC.length + 1))
+
+        expect(offenders).toEqual([])
+    })
+})


### PR DESCRIPTION
Found while doing the prod OAuth pass (task #15) — signed in on live `grabcaramel.com` with Google and the header rendered a generic **U** while the profile page rendered the right letter for the same session.

## The defect

Two components each derived the avatar letter, and they had drifted:

| where | fallback chain |
|---|---|
| `layouts/Header/Header.tsx` | `name` → `'U'` |
| `app/profile/ProfilePageClient.tsx` | `name` → `email` → `'U'` |

Better Auth only writes the provider profile **at account creation**, so an account that predates social sign-in keeps `name: null` and never gets one on later logins. Those users saw a meaningless "U" in the header on every page. Reproduced live on prod with `aladdin@devino.ca` (`name: null`, header "U", profile "A").

## The fix

- `src/lib/userInitial.ts` — one derivation: `name` → `email` → `'U'`, trimming whitespace-only names.
- Both components now call it. Nothing else derives it.

## The check, not just the rule

`tests/unit/userInitial.test.ts` pins the chain **and** walks `src/` asserting no component takes `charAt(0)` off a name/email itself — so a third component can't grow a fourth variant.

Red-proofed: dropping a file with the raw derivation into `src/components/` fails the guard with that exact path; removing it goes green again.

## Also here

`alt="logo"` → `alt="Caramel"` on the four `full-logo.png` uses. On the auth pages the logo **is** the product word, so screen readers were announcing "Sign in to logo" / "Create your logo" / "Verify your logo".

## Gates

- `tsc --noEmit` clean · `eslint .` clean · `prettier` clean
- `vitest run` — **527 passed / 62 files**