### PR TITLE
ci: gated manual workflow to submit the Chrome Web Store draft for review

### DIFF
--- a/.github/workflows/submit-extension-chrome.yml
+++ b/.github/workflows/submit-extension-chrome.yml
@@ -1,0 +1,178 @@
+name: Submit – Chrome Web Store
+
+# The release workflow uploads to the Chrome Web Store with `publish: false`, so
+# a released version sits in the dashboard as a DRAFT until a human submits it.
+# That gap is exactly how the listing froze at 1.1.0 for months: the release ran
+# green, nobody clicked submit, and the store kept serving the old build to
+# ~3,000 users.
+#
+# This workflow closes the gap without weakening it. It does NOT run on a tag or
+# a merge — only a deliberate manual dispatch where the operator types the exact
+# version they intend to publish and the literal word PUBLISH. Everything else
+# is a guard:
+#
+#   * the four Chrome secrets must be live (proven against items.get)
+#   * the DRAFT in the store must already be the typed version — this refuses to
+#     publish whatever happens to be sitting there
+#   * the currently PUBLISHED version (read from Chrome's own update service,
+#     the same source the release freeze-guard uses) must be strictly lower
+#
+# Only then does it call the publish endpoint. Google's human review still
+# follows; this submits, it does not make the version live.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Exact version to publish, e.g. 1.3.0 — must match the draft already uploaded to the store'
+        type: string
+        required: true
+      confirm:
+        description: 'Type PUBLISH to confirm this submits the draft for Google review'
+        type: string
+        required: true
+
+concurrency:
+  group: submit-extension-chrome
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  submit:
+    name: '🚀 Submit the Chrome draft for review'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require an explicit confirmation
+        env:
+          CONFIRM: ${{ inputs.confirm }}
+        run: |
+          set -euo pipefail
+          if [ "$CONFIRM" != "PUBLISH" ]; then
+            echo "::error::confirm must be exactly PUBLISH (got something else). Nothing was submitted."
+            exit 1
+          fi
+
+      # Mirrors the release workflow's credential assert: a workflow that
+      # references an unset secret gets an empty string and fails deep inside
+      # the call instead of up front.
+      - name: Assert Chrome Web Store credentials are live
+        id: creds
+        env:
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+        run: |
+          set -euo pipefail
+          for name in CHROME_CLIENT_ID CHROME_CLIENT_SECRET CHROME_REFRESH_TOKEN CHROME_EXTENSION_ID; do
+            if [ -z "${!name}" ]; then
+              echo "::error::Repository secret $name is not set."
+              exit 1
+            fi
+          done
+
+          token=$(curl -sS -X POST "https://oauth2.googleapis.com/token" \
+            --data-urlencode "client_id=${CHROME_CLIENT_ID}" \
+            --data-urlencode "client_secret=${CHROME_CLIENT_SECRET}" \
+            --data-urlencode "refresh_token=${CHROME_REFRESH_TOKEN}" \
+            --data-urlencode "grant_type=refresh_token" | jq -r '.access_token // empty')
+          if [ -z "$token" ]; then
+            echo "::error::Could not exchange the Chrome refresh token for an access token."
+            exit 1
+          fi
+          echo "::add-mask::$token"
+          echo "token=$token" >> "$GITHUB_OUTPUT"
+          echo "Chrome Web Store credentials verified."
+
+      - name: Assert the store draft is the version we were told to publish
+        env:
+          TOKEN: ${{ steps.creds.outputs.token }}
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          WANT: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          body=$(curl -sS \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "x-goog-api-version: 2" \
+            "https://www.googleapis.com/chromewebstore/v1.1/items/${CHROME_EXTENSION_ID}?projection=DRAFT")
+          draft=$(printf '%s' "$body" | jq -r '.crxVersion // empty')
+          if [ -z "$draft" ]; then
+            echo "::error::items.get returned no crxVersion — cannot tell what the draft is, refusing to publish."
+            printf '%s\n' "$body"
+            exit 1
+          fi
+          if [ "$draft" != "$WANT" ]; then
+            echo "::error::The store draft is $draft but you asked to publish $WANT. Nothing was submitted."
+            exit 1
+          fi
+          echo "Draft in the store is $draft — matches the requested version."
+
+      # Chrome's own update service is what real browsers ask, so it is the
+      # honest answer to "what do users have today", unlike the dashboard draft.
+      - name: Refuse to publish a version the store already serves
+        env:
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          WANT: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          xml=$(curl -sS \
+            "https://clients2.google.com/service/update2/crx?response=updatecheck&prodversion=999.0&acceptformat=crx3&x=id%3D${CHROME_EXTENSION_ID}%26uc")
+          published=$(printf '%s' "$xml" | grep -o 'version="[0-9.]*"' | head -1 | cut -d'"' -f2 || true)
+          if [ -z "$published" ]; then
+            echo "::warning::Chrome update service reported no published version; continuing on the draft check alone."
+            exit 0
+          fi
+          highest=$(printf '%s\n%s\n' "$published" "$WANT" | sort -V | tail -1)
+          if [ "$published" = "$WANT" ] || [ "$highest" != "$WANT" ]; then
+            echo "::error::Store already publishes $published; $WANT is not higher. Nothing was submitted."
+            exit 1
+          fi
+          echo "Store publishes $published → submitting $WANT."
+
+      - name: Publish
+        id: publish
+        env:
+          TOKEN: ${{ steps.creds.outputs.token }}
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+        run: |
+          set -euo pipefail
+          out=$(mktemp)
+          http=$(curl -sS -o "$out" -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "x-goog-api-version: 2" \
+            -H "Content-Length: 0" \
+            "https://www.googleapis.com/chromewebstore/v1.1/items/${CHROME_EXTENSION_ID}/publish")
+          cat "$out"
+          if [ "$http" != "200" ]; then
+            echo "::error::Chrome Web Store publish returned HTTP $http."
+            exit 1
+          fi
+          # The endpoint answers 200 even when it refused the item, with the
+          # reason in status[] — treat anything but OK as a failure so this
+          # cannot report success while the store keeps the old version.
+          status=$(jq -r '.status // [] | join(",")' < "$out")
+          detail=$(jq -r '.statusDetail // [] | join(" | ")' < "$out")
+          case "$status" in
+            OK|ITEM_PENDING_REVIEW|OK,ITEM_PENDING_REVIEW)
+              echo "status=$status" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::Chrome Web Store refused the publish: status=$status detail=$detail"
+              exit 1
+              ;;
+          esac
+
+      - name: Summarize
+        env:
+          WANT: ${{ inputs.version }}
+          STATUS: ${{ steps.publish.outputs.status }}
+        run: |
+          {
+            echo "### Chrome Web Store"
+            echo ""
+            echo "Submitted \`$WANT\` for review — API status \`$STATUS\`."
+            echo ""
+            echo "Google's human review still has to pass before users receive it."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
The release workflow uploads to the Chrome Web Store with `publish: false`, so a released version sits as a **draft** until a human opens the dashboard and clicks submit. That gap is exactly how the listing froze at **1.1.0** for months while ~3,000 users kept getting the old build — the release ran green, nobody clicked.

`v1.3.0` is in that state right now.

## What this adds

`.github/workflows/submit-extension-chrome.yml` — **`workflow_dispatch` only**. It never fires on a tag, a merge, or a schedule. The operator types the exact version and the literal word `PUBLISH`.

Then it refuses to proceed unless all of these hold:

1. `confirm` is exactly `PUBLISH`
2. all four `CHROME_*` secrets are set **and** exchange for a live access token
3. the **draft already in the store** is exactly the requested version — it will not publish "whatever happens to be sitting there"
4. the **currently published** version (from Chrome's own update service, the same source the release freeze-guard trusts) is strictly lower

Only then does it `POST …/items/{id}/publish`.

## Why the status check matters

That endpoint answers **HTTP 200 even when it refuses the item**, putting the reason in `status[]`. Treating 200 as success would let this report a green submit while the store quietly keeps serving the old version — the precise failure mode this workflow exists to end. So anything outside `OK` / `ITEM_PENDING_REVIEW` fails the run and prints `statusDetail`.

The access token is `::add-mask::`ed before it can reach a log.

## Scope

This submits for review. Google's human review still gates whether users receive it.