### PR TITLE
fix(api): the rate limiter put every visitor in ONE shared bucket

### DIFF
--- a/apps/caramel-app/src/lib/rateLimit.ts
+++ b/apps/caramel-app/src/lib/rateLimit.ts
@@ -40,18 +40,35 @@ const limiters: Record<LimitKind, RateLimiterMemory> = {
 }
 const burstLimiter = new RateLimiterMemory(BURST)
 
-function getClientIp(req: NextRequest): string {
-    // Trusted in order: our own proxy (X-Real-IP), then the first
-    // public IP in X-Forwarded-For. Fall back to a constant so that
-    // when no headers are present (edge runtime, direct hits) we still
-    // apply a global cap instead of silently letting everything through.
-    const realIp = req.headers.get('x-real-ip')
+export function getClientIp(req: NextRequest): string {
+    // CF-Connecting-IP FIRST, and this ordering is load-bearing.
+    //
+    // grabcaramel.com is proxied by Cloudflare, and Traefik behind it sets
+    // X-Real-IP to ITS OWN peer — the Cloudflare edge — not to the visitor.
+    // Preferring X-Real-IP therefore handed every visitor on earth the SAME
+    // rate-limit key, i.e. one global bucket. Measured on dev 2026-08-08 with
+    // a clean 75s window: a 30-request burst from a proxy exit returned 429s,
+    // and the very next request from a DIFFERENT machine that had been idle
+    // was also 429. Both directions of that are bad — 20 requests in 2s from
+    // one host could 429 the API for every real user (a trivial DoS), while a
+    // scraper rotating IPs got no per-client throttle at all.
+    //
+    // Cloudflare always sets CF-Connecting-IP to the true client and strips
+    // any client-supplied copy, so it is the only header here a caller cannot
+    // forge through the edge. X-Real-IP / X-Forwarded-For stay as fallbacks
+    // for topologies without Cloudflare (local dev, direct origin hits), where
+    // the old behaviour is unchanged.
+    const cfIp = req.headers.get('cf-connecting-ip')?.trim()
+    if (cfIp) return cfIp
+    const realIp = req.headers.get('x-real-ip')?.trim()
     if (realIp) return realIp
     const xff = req.headers.get('x-forwarded-for')
     if (xff) {
         const first = xff.split(',')[0]?.trim()
         if (first) return first
     }
+    // No headers at all (edge runtime, direct hits): a shared bucket is still
+    // better than letting everything through unmetered.
     return 'unknown'
 }
 

--- a/apps/caramel-app/tests/unit/rate-limit-client-ip.test.ts
+++ b/apps/caramel-app/tests/unit/rate-limit-client-ip.test.ts
@@ -1,0 +1,74 @@
+import type { NextRequest } from 'next/server'
+import { describe, expect, it } from 'vitest'
+
+import { getClientIp } from '@/lib/rateLimit'
+
+function reqWith(headers: Record<string, string>): NextRequest {
+    return {
+        headers: new Headers(headers),
+        url: 'https://grabcaramel.com/api/coupons',
+    } as unknown as NextRequest
+}
+
+/**
+ * These pin the ORDER, not just the parsing. The production defect was purely
+ * an ordering one: X-Real-IP was consulted first, and behind Cloudflare that
+ * header carries the Traefik peer (the Cloudflare edge), identical for every
+ * visitor — so the whole internet shared one rate-limit bucket. Measured on
+ * dev: a burst from one host 429'd a different, idle host's very next request.
+ */
+describe('getClientIp', () => {
+    it('prefers CF-Connecting-IP over the proxy headers', () => {
+        // The real shape behind Cloudflare + Traefik: x-real-ip is the edge,
+        // cf-connecting-ip is the visitor. Picking the edge is the bug.
+        expect(
+            getClientIp(
+                reqWith({
+                    'cf-connecting-ip': '203.0.113.7',
+                    'x-real-ip': '172.71.150.4',
+                    'x-forwarded-for': '203.0.113.7, 172.71.150.4',
+                }),
+            ),
+        ).toBe('203.0.113.7')
+    })
+
+    it('gives two visitors behind the same edge different keys', () => {
+        const edge = { 'x-real-ip': '172.71.150.4' }
+        const a = getClientIp(
+            reqWith({ ...edge, 'cf-connecting-ip': '198.51.100.1' }),
+        )
+        const b = getClientIp(
+            reqWith({ ...edge, 'cf-connecting-ip': '198.51.100.2' }),
+        )
+        expect(a).not.toBe(b)
+    })
+
+    it('falls back to X-Real-IP when Cloudflare is not in front', () => {
+        expect(getClientIp(reqWith({ 'x-real-ip': '198.51.100.9' }))).toBe(
+            '198.51.100.9',
+        )
+    })
+
+    it('falls back to the first X-Forwarded-For entry', () => {
+        expect(
+            getClientIp(
+                reqWith({ 'x-forwarded-for': '198.51.100.9, 10.0.0.1' }),
+            ),
+        ).toBe('198.51.100.9')
+    })
+
+    it('ignores a whitespace-only header rather than keying on empty', () => {
+        expect(
+            getClientIp(
+                reqWith({
+                    'cf-connecting-ip': '   ',
+                    'x-real-ip': '198.51.100.9',
+                }),
+            ),
+        ).toBe('198.51.100.9')
+    })
+
+    it('meters under one shared key when no header identifies the caller', () => {
+        expect(getClientIp(reqWith({}))).toBe('unknown')
+    })
+})


### PR DESCRIPTION
Found while hardening the coupon API. **This is live on prod today and cuts both ways: it is a trivial denial-of-service against every user, and it gives a scraper no per-client throttle at all.**

## The defect

`getClientIp()` consulted `X-Real-IP` first. `grabcaramel.com` is proxied by Cloudflare, and the Traefik in front of the app sets `X-Real-IP` to **its own peer — the Cloudflare edge** — not to the visitor. So every request on earth resolved to the same rate-limit key.

The limits are `read` 120/min, `mutation` 30/min, burst **20 per 2s** — all of that was global, not per client.

## Measured, not assumed

On **dev** (never prod), after a clean 75-second window:

| step | result |
| --- | --- |
| baseline from my IP | `200` |
| baseline via a proxy exit (different IP) | `200` |
| 30-request burst through **the proxy IP** | `429`s |
| next single request from **my IP**, which had been idle | **`429`** |

Two unrelated clients, one bucket. That means **20 requests in 2 seconds from a single host 429s the coupon API for every real user** — including the ~3,000 Chrome and ~829 Firefox extension installs.

## The fix

Prefer `CF-Connecting-IP`, which Cloudflare sets to the true client and **strips any client-supplied copy**, so it is the only header here a caller cannot forge through the edge. `X-Real-IP` and `X-Forwarded-For` remain as fallbacks for topologies without Cloudflare (local dev, direct origin hits), where behaviour is unchanged.

## The check

`tests/unit/rate-limit-client-ip.test.ts` pins the **ordering**, which is the whole defect — including "two visitors behind the same edge get different keys", the property that was false in production.

Red-proofed: removing the `cf-connecting-ip` branch fails exactly those two tests; restoring it goes green.

## Gates

`tsc --noEmit` clean · `eslint .` clean · `prettier` clean · `vitest run` **533 passed / 63 files**