### PR TITLE
feat(auth): modern split-screen login/signup + the missing password reset flow

### DIFF
--- a/apps/caramel-app/e2e/auth-flows.spec.ts
+++ b/apps/caramel-app/e2e/auth-flows.spec.ts
@@ -34,12 +34,12 @@ test.describe('Auth Flows — Login (real session)', () => {
         page,
     }) => {
         await page.goto('/login')
-        await page.getByPlaceholder('Enter your email').fill(REAL_LOGIN_EMAIL)
+        await page.getByPlaceholder('you@example.com').fill(REAL_LOGIN_EMAIL)
         await page
             .getByPlaceholder('Enter your password')
             .fill(REAL_LOGIN_PASSWORD)
 
-        await page.getByRole('button', { name: /login/i }).click()
+        await page.getByRole('button', { name: 'Sign in', exact: true }).click()
 
         // On success the client sets a real session cookie then does
         // window.location.href = '/', so we land on the homepage.
@@ -61,7 +61,7 @@ test.describe('Auth Flows — Login', () => {
         page,
     }) => {
         await page.goto('/login')
-        await page.getByPlaceholder('Enter your email').fill('bad@example.com')
+        await page.getByPlaceholder('you@example.com').fill('bad@example.com')
         await page.getByPlaceholder('Enter your password').fill('WrongPass1!')
 
         // Intercept the auth API to return an error without hitting real server
@@ -76,7 +76,7 @@ test.describe('Auth Flows — Login', () => {
             }),
         )
 
-        await page.getByRole('button', { name: /login/i }).click()
+        await page.getByRole('button', { name: 'Sign in', exact: true }).click()
 
         // Sonner toast with error message
         await expect(
@@ -91,7 +91,7 @@ test.describe('Auth Flows — Login', () => {
     }) => {
         await page.goto('/login')
         await page
-            .getByPlaceholder('Enter your email')
+            .getByPlaceholder('you@example.com')
             .fill('unverified@example.com')
         await page.getByPlaceholder('Enter your password').fill('Test@12345')
 
@@ -106,7 +106,7 @@ test.describe('Auth Flows — Login', () => {
             }),
         )
 
-        await page.getByRole('button', { name: /login/i }).click()
+        await page.getByRole('button', { name: 'Sign in', exact: true }).click()
         await expect(page).toHaveURL(/\/verify/, { timeout: 10000 })
     })
 
@@ -160,9 +160,9 @@ test.describe('Auth Flows — Signup', () => {
         await page.goto('/signup')
 
         await page.getByPlaceholder('@nickname').fill('testuser')
-        await page.getByPlaceholder('Enter your email').fill('new@example.com')
+        await page.getByPlaceholder('you@example.com').fill('new@example.com')
         await page.getByPlaceholder('Create a password').fill('Test@12345')
-        await page.getByPlaceholder('Re-type Password').fill('Test@12345')
+        await page.getByPlaceholder('Re-type your password').fill('Test@12345')
 
         // Intercept signup API to return success
         await page.route('**/api/auth/sign-up/email', route =>
@@ -176,7 +176,9 @@ test.describe('Auth Flows — Signup', () => {
             }),
         )
 
-        await page.getByRole('button', { name: 'Sign Up', exact: true }).click()
+        await page
+            .getByRole('button', { name: 'Create account', exact: true })
+            .click()
 
         // Uses window.location.href so wait for navigation
         await page.waitForURL('**/verify?signup=success', { timeout: 10000 })
@@ -186,11 +188,9 @@ test.describe('Auth Flows — Signup', () => {
         await page.goto('/signup')
 
         await page.getByPlaceholder('@nickname').fill('testuser')
-        await page
-            .getByPlaceholder('Enter your email')
-            .fill('taken@example.com')
+        await page.getByPlaceholder('you@example.com').fill('taken@example.com')
         await page.getByPlaceholder('Create a password').fill('Test@12345')
-        await page.getByPlaceholder('Re-type Password').fill('Test@12345')
+        await page.getByPlaceholder('Re-type your password').fill('Test@12345')
 
         await page.route('**/api/auth/sign-up/email', route =>
             route.fulfill({
@@ -203,7 +203,9 @@ test.describe('Auth Flows — Signup', () => {
             }),
         )
 
-        await page.getByRole('button', { name: 'Sign Up', exact: true }).click()
+        await page
+            .getByRole('button', { name: 'Create account', exact: true })
+            .click()
 
         await expect(
             page.getByText(/unable to create your account/i),
@@ -217,12 +219,12 @@ test.describe('Auth Flows — Signup', () => {
         await nickname.fill('ab')
         await nickname.blur()
 
-        await page.getByPlaceholder('Enter your email').click()
+        await page.getByPlaceholder('you@example.com').click()
 
         // Formik shows error after blur
-        await expect(
-            page.getByText(/must be at least 4 characters/i),
-        ).toBeVisible({ timeout: 5000 })
+        await expect(page.getByText(/at least 4 characters/i)).toBeVisible({
+            timeout: 5000,
+        })
     })
 })
 
@@ -273,9 +275,9 @@ test.describe('Auth Flows — before any JavaScript runs', () => {
         await page.goto('/verify?signup=success')
 
         await expect(
-            page.getByText(/we've sent a verification email/i),
+            page.getByText(/we've sent a verification link/i),
         ).toBeVisible()
-        await expect(page.getByText(/didn't receive it/i)).toBeVisible()
+        await expect(page.getByText(/didn't get it/i)).toBeVisible()
     })
 
     test('so is the message for someone arriving without params', async ({
@@ -296,9 +298,9 @@ test.describe('Auth Flows — Verify Page', () => {
         await page.goto('/verify?signup=success')
 
         await expect(
-            page.getByText(/we've sent a verification email/i),
+            page.getByText(/we've sent a verification link/i),
         ).toBeVisible()
-        await expect(page.getByText(/didn't receive it/i)).toBeVisible()
+        await expect(page.getByText(/didn't get it/i)).toBeVisible()
     })
 
     test('verify page without params shows default messaging', async ({
@@ -319,7 +321,7 @@ test.describe('Auth Flows — Verify Page', () => {
     test('verify page has email input and send button', async ({ page }) => {
         await page.goto('/verify')
 
-        await expect(page.getByPlaceholder('Enter your email')).toBeVisible()
+        await expect(page.getByPlaceholder('you@example.com')).toBeVisible()
         await expect(
             page.getByRole('button', { name: /send verification email/i }),
         ).toBeVisible()

--- a/apps/caramel-app/e2e/auth.spec.ts
+++ b/apps/caramel-app/e2e/auth.spec.ts
@@ -1,15 +1,32 @@
 import { expect, test } from '@playwright/test'
 
+/* Copy updated with the 2026-08-09 auth redesign. The assertions are the same
+ * ones as before — fields render, providers are offered, the cross-links
+ * navigate, validation fires — retargeted at the new wording, plus coverage for
+ * what the redesign added (the password reveal toggle and the forgot-password
+ * entry point, which did not exist at all). */
+
 test.describe('Login Page', () => {
     test.beforeEach(async ({ page }) => {
         await page.goto('/login')
-        await expect(page.getByRole('button', { name: /login/i })).toBeVisible()
+        await expect(
+            page.getByRole('button', { name: 'Sign in', exact: true }),
+        ).toBeVisible()
     })
 
     test('login form renders with all fields', async ({ page }) => {
-        await expect(page.getByPlaceholder('Enter your email')).toBeVisible()
+        await expect(page.getByPlaceholder('you@example.com')).toBeVisible()
         await expect(page.getByPlaceholder('Enter your password')).toBeVisible()
-        await expect(page.getByRole('button', { name: /login/i })).toBeVisible()
+        await expect(
+            page.getByRole('button', { name: 'Sign in', exact: true }),
+        ).toBeVisible()
+    })
+
+    test('page exposes exactly one h1 for the form', async ({ page }) => {
+        // Every auth page used to open at h2 with no h1 in the document.
+        const headings = page.getByRole('heading', { level: 1 })
+        await expect(headings).toHaveCount(1)
+        await expect(headings).toHaveText(/welcome back/i)
     })
 
     test('social login buttons are present', async ({ page }) => {
@@ -22,16 +39,42 @@ test.describe('Login Page', () => {
     })
 
     test('has link to signup page', async ({ page }) => {
-        const signupLink = page.getByRole('link', { name: /sign up/i })
+        const signupLink = page.getByRole('link', { name: /create one free/i })
         await expect(signupLink).toBeVisible()
         await signupLink.click()
         await expect(page).toHaveURL(/\/signup/)
     })
 
+    test('offers a password reset route', async ({ page }) => {
+        /* There was no way to recover an account before this shipped: no link,
+         * no route, and no sendResetPassword on the server. */
+        const forgot = page.getByRole('link', { name: /forgot password/i })
+        await expect(forgot).toBeVisible()
+        await forgot.click()
+        // Generous: in `next dev` this is the route's first compile.
+        await expect(page).toHaveURL(/\/forgot-password/, { timeout: 30000 })
+        await expect(
+            page.getByRole('button', { name: /send reset link/i }),
+        ).toBeVisible()
+    })
+
+    test('password can be revealed and re-hidden', async ({ page }) => {
+        const password = page.getByPlaceholder('Enter your password')
+        await password.fill('hunter2')
+        await expect(password).toHaveAttribute('type', 'password')
+
+        const toggle = page.getByRole('button', { name: /show password/i })
+        await toggle.click()
+        await expect(password).toHaveAttribute('type', 'text')
+
+        await page.getByRole('button', { name: /hide password/i }).click()
+        await expect(password).toHaveAttribute('type', 'password')
+    })
+
     test('shows validation on empty submit', async ({ page }) => {
-        await page.getByRole('button', { name: /login/i }).click()
+        await page.getByRole('button', { name: 'Sign in', exact: true }).click()
         // HTML5 form validation should prevent submission
-        const emailInput = page.getByPlaceholder('Enter your email')
+        const emailInput = page.getByPlaceholder('you@example.com')
         const isInvalid = await emailInput.evaluate(
             (el: HTMLInputElement) => !el.validity.valid,
         )
@@ -43,17 +86,19 @@ test.describe('Signup Page', () => {
     test.beforeEach(async ({ page }) => {
         await page.goto('/signup')
         await expect(
-            page.getByRole('button', { name: 'Sign Up', exact: true }),
+            page.getByRole('button', { name: 'Create account', exact: true }),
         ).toBeVisible()
     })
 
     test('signup form renders with all fields', async ({ page }) => {
         await expect(page.getByPlaceholder('@nickname')).toBeVisible()
-        await expect(page.getByPlaceholder('Enter your email')).toBeVisible()
+        await expect(page.getByPlaceholder('you@example.com')).toBeVisible()
         await expect(page.getByPlaceholder('Create a password')).toBeVisible()
-        await expect(page.getByPlaceholder('Re-type Password')).toBeVisible()
         await expect(
-            page.getByRole('button', { name: 'Sign Up', exact: true }),
+            page.getByPlaceholder('Re-type your password'),
+        ).toBeVisible()
+        await expect(
+            page.getByRole('button', { name: 'Create account', exact: true }),
         ).toBeVisible()
     })
 
@@ -67,7 +112,7 @@ test.describe('Signup Page', () => {
     })
 
     test('has link to login page', async ({ page }) => {
-        const loginLink = page.getByRole('link', { name: /login/i })
+        const loginLink = page.getByRole('link', { name: /sign in/i })
         await expect(loginLink).toBeVisible()
         await loginLink.click()
         await expect(page).toHaveURL(/\/login/)
@@ -108,7 +153,7 @@ test.describe('Signup Page', () => {
          * wrong with the reasons still hidden. Tab from the field above
          * rather than calling focus(), so this fails if the panel ever goes
          * back to needing a pointer. */
-        await page.getByPlaceholder('Enter your email').click()
+        await page.getByPlaceholder('you@example.com').click()
         await page.keyboard.press('Tab')
 
         await expect(page.getByPlaceholder('Create a password')).toBeFocused()
@@ -117,14 +162,24 @@ test.describe('Signup Page', () => {
         ).toBeVisible({ timeout: 5000 })
     })
 
+    test('states the real minimum password length', async ({ page }) => {
+        /* The checklist used to hard-code its own policy and ticked "minimum
+         * length reached" at 5 while the schema demanded more. Both now read
+         * from lib/passwordRules, so this pins the number a shopper is shown. */
+        await page.getByPlaceholder('Create a password').focus()
+        await expect(
+            page.getByText(/at least 8 characters/i).first(),
+        ).toBeVisible({ timeout: 5000 })
+    })
+
     test('shows validation errors for weak password', async ({ page }) => {
         await page.getByPlaceholder('@nickname').fill('testuser')
-        await page.getByPlaceholder('Enter your email').fill('test@example.com')
+        await page.getByPlaceholder('you@example.com').fill('test@example.com')
         await page.getByPlaceholder('Create a password').fill('weak')
-        await page.getByPlaceholder('Re-type Password').fill('weak')
+        await page.getByPlaceholder('Re-type your password').fill('weak')
 
         await page
-            .getByRole('button', { name: 'Sign Up', exact: true })
+            .getByRole('button', { name: 'Create account', exact: true })
             .click({ force: true })
 
         // Should show password validation errors
@@ -134,18 +189,105 @@ test.describe('Signup Page', () => {
         await expect(errorText.first()).toBeVisible({ timeout: 5000 })
     })
 
+    test('never shows a raw regex as a validation message', async ({
+        page,
+    }) => {
+        /* yup prints the constraint itself when a rule carries no message, so
+         * the old schema told shoppers "password must match the following:
+         * /[A-Z]/". */
+        await page.getByPlaceholder('@nickname').fill('testuser')
+        await page.getByPlaceholder('you@example.com').fill('test@example.com')
+        await page.getByPlaceholder('Create a password').fill('lowercase1!')
+        await page.getByPlaceholder('Re-type your password').fill('lowercase1!')
+        await page
+            .getByRole('button', { name: 'Create account', exact: true })
+            .click({ force: true })
+
+        await expect(page.getByText(/must match the following/i)).toHaveCount(0)
+        await expect(page.locator('body')).not.toContainText('/[A-Z]/')
+    })
+
     test('shows mismatch error when passwords differ', async ({ page }) => {
         // Click password field to trigger PasswordChecker visibility
         const passwordInput = page.getByPlaceholder('Create a password')
         await passwordInput.click()
         await passwordInput.fill('Test@12345')
 
-        const confirmInput = page.getByPlaceholder('Re-type Password')
+        const confirmInput = page.getByPlaceholder('Re-type your password')
         await confirmInput.click()
         await confirmInput.fill('Different@123')
 
         // PasswordChecker shows "Passwords must match" when passwords differ
         const mismatch = page.getByText('Passwords must match')
         await expect(mismatch).toBeVisible({ timeout: 5000 })
+    })
+})
+
+test.describe('Auth shell', () => {
+    /* The (auth) group renders its own full-screen shell. When a route is
+     * missing from providers.tsx's pagesLayoutless list it ALSO gets the
+     * marketing Layout, so the page ships two headers, two theme toggles and a
+     * site footer wrapped around the form. /forgot-password and
+     * /reset-password did exactly that when first added. */
+    for (const route of [
+        '/login',
+        '/signup',
+        '/verify',
+        '/forgot-password',
+        '/reset-password',
+    ]) {
+        test(`${route} renders without the marketing header and footer`, async ({
+            page,
+        }) => {
+            await page.goto(route)
+            await expect(page.getByRole('heading', { level: 1 })).toBeVisible({
+                timeout: 30000,
+            })
+
+            await expect(page.getByRole('banner')).toHaveCount(0)
+            await expect(page.getByRole('contentinfo')).toHaveCount(0)
+            // One theme toggle, not the auth shell's plus the site header's.
+            await expect(
+                page.getByRole('button', { name: /light|dark/i }),
+            ).toHaveCount(1)
+        })
+    }
+})
+
+test.describe('Password reset', () => {
+    test('reset page refuses a request with no token', async ({ page }) => {
+        await page.goto('/reset-password')
+        await expect(
+            page.getByRole('heading', { level: 1, name: /expired/i }),
+        ).toBeVisible()
+        await expect(
+            page.getByRole('link', { name: /request a new link/i }),
+        ).toBeVisible()
+    })
+
+    test('reset pages are not indexable', async ({ page }) => {
+        /* The reset URL carries a single-use token as a query parameter, so an
+         * indexed copy would publish it. */
+        await page.goto('/reset-password?token=example')
+        await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
+            'content',
+            /noindex/,
+        )
+    })
+
+    test('forgot-password does not reveal whether an account exists', async ({
+        page,
+    }) => {
+        await page.goto('/forgot-password')
+        await page
+            .getByPlaceholder('you@example.com')
+            .fill('definitely-not-a-user@example.com')
+        await page.getByRole('button', { name: /send reset link/i }).click()
+
+        // Same confirmation regardless of whether the address is registered:
+        // branching here would make this form an account-enumeration oracle.
+        await expect(
+            page.getByRole('heading', { level: 1, name: /check your inbox/i }),
+        ).toBeVisible({ timeout: 15000 })
     })
 })

--- a/apps/caramel-app/e2e/seo-a11y.spec.ts
+++ b/apps/caramel-app/e2e/seo-a11y.spec.ts
@@ -168,8 +168,16 @@ test.describe('Responsive - Mobile Viewport', () => {
     test('login page is usable on mobile', async ({ page }) => {
         await page.goto('/login')
 
-        await expect(page.getByPlaceholder('Enter your email')).toBeVisible()
+        await expect(page.getByPlaceholder('you@example.com')).toBeVisible()
         await expect(page.getByPlaceholder('Enter your password')).toBeVisible()
-        await expect(page.getByRole('button', { name: /login/i })).toBeVisible()
+        await expect(
+            page.getByRole('button', { name: 'Sign in', exact: true }),
+        ).toBeVisible()
+
+        // The desktop brand panel is removed below 1024px, so the compact
+        // header is what tells a phone visitor whose sign-in page this is.
+        await expect(
+            page.getByRole('link', { name: /back to home/i }),
+        ).toBeVisible()
     })
 })

--- a/apps/caramel-app/emails/ResetPasswordTemplate.tsx
+++ b/apps/caramel-app/emails/ResetPasswordTemplate.tsx
@@ -1,0 +1,44 @@
+import EmailLayout, { EmailButton, EmailNotice, text } from './EmailLayout'
+
+interface ResetPasswordEmailProps {
+    url: string
+}
+
+export default function ResetPasswordTemplate({
+    url,
+}: ResetPasswordEmailProps) {
+    return (
+        <EmailLayout previewText="Reset your Caramel password">
+            <h1 style={text.heading}>Reset your password</h1>
+            <p style={text.body}>
+                We received a request to reset the password for your Caramel
+                account. Click the button below to choose a new one.
+            </p>
+
+            <EmailButton href={url}>Reset Password</EmailButton>
+
+            <EmailNotice>
+                This link expires in <strong>1 hour</strong> and can only be
+                used once. If you didn&apos;t request a password reset, you can
+                safely ignore this email — your password will not change.
+            </EmailNotice>
+
+            <div style={text.divider} />
+
+            <p style={text.small}>
+                If the button doesn&apos;t work, copy and paste this link into
+                your browser:
+            </p>
+            <p
+                style={{
+                    ...text.small,
+                    wordBreak: 'break-all' as const,
+                    color: '#ea6925',
+                    marginTop: '6px',
+                }}
+            >
+                {url}
+            </p>
+        </EmailLayout>
+    )
+}

--- a/apps/caramel-app/src/app/(auth)/forgot-password/ForgotPasswordPageClient.tsx
+++ b/apps/caramel-app/src/app/(auth)/forgot-password/ForgotPasswordPageClient.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import AuthCard from '@/components/auth/AuthCard'
+import {
+    inputClasses,
+    labelClasses,
+    linkClasses,
+    primaryButtonClasses,
+} from '@/components/auth/authStyles'
+import { requestPasswordReset } from '@/lib/auth/client'
+import Link from 'next/link'
+import { FormEvent, useState } from 'react'
+import { HiOutlineMail } from 'react-icons/hi'
+import { toast } from 'sonner'
+
+export default function ForgotPasswordPageClient() {
+    const [email, setEmail] = useState('')
+    const [loading, setLoading] = useState(false)
+    const [sent, setSent] = useState(false)
+
+    const handleSubmit = async (event: FormEvent) => {
+        event.preventDefault()
+        setLoading(true)
+
+        const result = await requestPasswordReset({
+            email: email.trim().toLowerCase(),
+            redirectTo: '/reset-password',
+        })
+
+        setLoading(false)
+
+        /* Deliberately the same screen whether or not the address has an
+         * account. Branching here would turn this form into an account
+         * enumeration oracle: anyone could type addresses and learn which ones
+         * are registered. A transport-level failure is still surfaced, because
+         * that one is about us, not about who exists. */
+        if (result?.error) {
+            toast.error('We could not send that email. Please try again.')
+            return
+        }
+        setSent(true)
+    }
+
+    if (sent) {
+        return (
+            <AuthCard
+                title="Check your inbox"
+                subtitle={
+                    <>
+                        If an account exists for{' '}
+                        <span className="font-medium text-gray-900 dark:text-gray-200">
+                            {email.trim().toLowerCase()}
+                        </span>
+                        , we&apos;ve sent it a link to choose a new password.
+                        The link expires in one hour.
+                    </>
+                }
+                footer={
+                    <p className="text-center text-sm text-gray-600 dark:text-gray-400">
+                        <Link className={linkClasses} href="/login">
+                            Back to sign in
+                        </Link>
+                    </p>
+                }
+            >
+                <div className="flex items-start gap-3 rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm text-gray-600 dark:border-gray-800 dark:bg-darkerBg dark:text-gray-400">
+                    <HiOutlineMail
+                        aria-hidden="true"
+                        className="mt-0.5 h-5 w-5 shrink-0 text-caramel"
+                    />
+                    <p>
+                        Nothing after a few minutes? Check your spam folder, or{' '}
+                        <button
+                            type="button"
+                            onClick={() => setSent(false)}
+                            className={linkClasses}
+                        >
+                            try a different address
+                        </button>
+                        .
+                    </p>
+                </div>
+            </AuthCard>
+        )
+    }
+
+    return (
+        <AuthCard
+            title="Forgot your password?"
+            subtitle="Enter the email you signed up with and we'll send you a link to set a new password."
+            footer={
+                <p className="text-center text-sm text-gray-600 dark:text-gray-400">
+                    Remembered it?{' '}
+                    <Link className={linkClasses} href="/login">
+                        Back to sign in
+                    </Link>
+                </p>
+            }
+        >
+            <form onSubmit={handleSubmit} className="space-y-5">
+                <div>
+                    <label htmlFor="forgot-email" className={labelClasses}>
+                        Email
+                    </label>
+                    <input
+                        id="forgot-email"
+                        type="email"
+                        required
+                        autoComplete="email"
+                        autoFocus
+                        placeholder="you@example.com"
+                        value={email}
+                        onChange={event => setEmail(event.target.value)}
+                        className={inputClasses}
+                    />
+                </div>
+                <button
+                    type="submit"
+                    disabled={loading}
+                    className={primaryButtonClasses}
+                >
+                    {loading ? 'Sending…' : 'Send reset link'}
+                </button>
+            </form>
+        </AuthCard>
+    )
+}

--- a/apps/caramel-app/src/app/(auth)/forgot-password/page.tsx
+++ b/apps/caramel-app/src/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next'
+import ForgotPasswordPageClient from './ForgotPasswordPageClient'
+
+const title = 'Reset your password | Caramel'
+const description =
+    'Request a link to reset the password on your Caramel account.'
+
+export const metadata: Metadata = {
+    title,
+    description,
+    alternates: {
+        canonical: 'https://grabcaramel.com/forgot-password',
+    },
+    /* Deliberately not indexed, unlike /login and /signup. This is a
+     * transactional utility page with nothing a searcher wants; indexing it
+     * only adds a thin, near-duplicate result competing with the pages that
+     * should rank. `follow` is kept so its link equity still flows to /login. */
+    robots: { index: false, follow: true },
+}
+
+export default function ForgotPassword() {
+    return <ForgotPasswordPageClient />
+}

--- a/apps/caramel-app/src/app/(auth)/layout.tsx
+++ b/apps/caramel-app/src/app/(auth)/layout.tsx
@@ -3,8 +3,9 @@
 import ThemeToggle from '@/components/ThemeToggle'
 import { ThemeContext } from '@/lib/contexts'
 import Image from 'next/image'
+import Link from 'next/link'
 import { useContext } from 'react'
-import { HiCheckCircle } from 'react-icons/hi'
+import { HiArrowLeft, HiCheckCircle } from 'react-icons/hi'
 
 // Claim-safe brand copy only (claim-integrity sweep 2026-07-28): no store
 // counts we can't prove, no "zero tracking" phrasing — the analytics stack is
@@ -19,7 +20,18 @@ const brandPoints = [
 // Auth routes are deliberately layoutless (no Header/Footer — see
 // providers.tsx `pagesLayoutless`), so this shell owns what Layout.tsx owns
 // everywhere else: the `dark` class scope, the page background, and a theme
-// toggle. Pages render only their card.
+// toggle. Pages render only their form column.
+//
+// LAYOUT NOTE: this repo's Tailwind is DESKTOP-FIRST (tailwind.config.ts uses
+// `max` screens) — unprefixed = desktop, and `lg:` is a MAX-width override
+// applying at ≤1023px. So `lg:hidden` removes the brand panel on tablet/mobile.
+//
+// The previous shell centered two separately-rounded cards side by side inside
+// a mostly empty viewport: they were different heights, visibly misaligned, and
+// the whole composition floated in a large field of background at any desktop
+// height. This is a full-bleed split instead — brand panel owns the left edge,
+// the form owns an honest column of its own — which is both calmer and gives
+// the form room to grow (the reset-password flow adds pages to this group).
 export default function AuthLayout({
     children,
 }: {
@@ -33,69 +45,108 @@ export default function AuthLayout({
         // so this needs no hydration suppression. <html> already carries the
         // real theme pre-paint — see app/layout.tsx.
         <div className={isDarkMode ? 'dark' : 'light'}>
-            <div className="relative flex min-h-screen items-center justify-center gap-10 overflow-hidden bg-gray-50 px-4 py-12 dark:bg-darkBg sm:py-8 xs:px-3">
-                <div
-                    aria-hidden="true"
-                    className="pointer-events-none absolute -top-32 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-caramel/10 blur-3xl dark:bg-caramel/15"
-                />
-                <div
-                    aria-hidden="true"
-                    className="pointer-events-none absolute -bottom-40 -right-32 h-96 w-96 rounded-full bg-caramel/[0.07] blur-3xl dark:bg-caramel/10"
-                />
-                <ThemeToggle className="absolute right-6 top-6 sm:right-4 sm:top-4" />
-
-                {/* Brand side panel — desktop only (this repo's Tailwind is
-                    desktop-first: unprefixed = desktop, lg: is a MAX-width
-                    override, so lg:hidden removes it ≤1023px). Static markup,
-                    no client-only branching → hydration-safe. The gradient
-                    pair matches the AA-fixed footer slab (#c14e14/#a63f10:
-                    white text ≥4.5:1 at both stops — from-caramel fails). */}
-                <aside className="relative w-full max-w-md overflow-hidden rounded-2xl border border-transparent bg-gradient-to-br from-[#c14e14] to-[#a63f10] p-10 text-white shadow-xl ring-1 ring-inset ring-white/20 dark:border-caramel/30 dark:bg-caramel/[0.12] dark:bg-none dark:ring-0 lg:hidden">
-                    <Image
-                        src="/full-logo.png"
-                        alt="Caramel"
-                        width={140}
-                        height={45}
-                        className="brightness-0 invert"
+            <div className="flex min-h-screen bg-white dark:bg-darkBg">
+                {/* Brand panel — desktop only. Static markup, no client-only
+                    branching → hydration-safe. The gradient pair matches the
+                    AA-fixed footer slab (#c14e14/#a63f10: white text ≥4.5:1 at
+                    both stops — from-caramel fails). */}
+                <aside className="relative flex w-[44%] shrink-0 flex-col justify-between overflow-hidden bg-gradient-to-br from-[#c14e14] to-[#a63f10] p-12 text-white xl:w-[42%] lg:hidden">
+                    <div
+                        aria-hidden="true"
+                        className="pointer-events-none absolute -right-24 -top-24 h-80 w-80 rounded-full bg-white/10 blur-3xl"
                     />
-                    <p className="mt-6 text-2xl font-bold leading-snug">
-                        The open-source, privacy-first way to save at checkout.
-                    </p>
+                    <div
+                        aria-hidden="true"
+                        className="pointer-events-none absolute -bottom-32 -left-20 h-80 w-80 rounded-full bg-black/10 blur-3xl"
+                    />
 
-                    {/* Coupon perforation: dashed tear line + two side punch
-                        holes, same ticket motif as the pricing card. Notches
-                        straddle the panel edge and are filled with the page
-                        background so overflow-hidden clips them into bites. */}
-                    <div aria-hidden="true" className="relative -mx-10 my-8">
-                        <div className="border-t-2 border-dashed border-white/30 dark:border-caramel/30" />
-                        <div className="absolute left-0 top-1/2 h-8 w-8 -translate-x-1/2 -translate-y-1/2 rounded-full bg-gray-50 dark:bg-darkBg" />
-                        <div className="absolute right-0 top-1/2 h-8 w-8 -translate-y-1/2 translate-x-1/2 rounded-full bg-gray-50 dark:bg-darkBg" />
+                    <div className="relative">
+                        <Link
+                            href="/"
+                            className="inline-flex items-center gap-2 rounded-sm text-sm font-medium text-white/80 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                        >
+                            <HiArrowLeft aria-hidden="true" />
+                            Back to grabcaramel.com
+                        </Link>
                     </div>
 
-                    <ul className="space-y-3">
-                        {brandPoints.map(point => (
-                            <li
-                                key={point}
-                                className="flex items-start gap-3 text-[15px] font-medium"
-                            >
-                                <HiCheckCircle
-                                    aria-hidden="true"
-                                    className="mt-0.5 shrink-0 text-xl text-white/90 dark:text-caramel"
-                                />
-                                {point}
-                            </li>
-                        ))}
-                    </ul>
+                    <div className="relative">
+                        <Image
+                            src="/full-logo.png"
+                            alt="Caramel"
+                            width={150}
+                            height={48}
+                            className="brightness-0 invert"
+                        />
+                        <p className="mt-7 max-w-sm text-[28px] font-bold leading-[1.25] 3xl:text-2xl">
+                            The open-source, privacy-first way to save at
+                            checkout.
+                        </p>
+
+                        {/* Coupon perforation: dashed tear line + two side punch
+                            holes, same ticket motif as the pricing card. The
+                            notches straddle the panel edge; the left one is
+                            clipped by overflow-hidden, the right one bites into
+                            the form column, so it reads as a torn stub. */}
+                        <div
+                            aria-hidden="true"
+                            className="relative -mx-12 my-9"
+                        >
+                            <div className="border-t-2 border-dashed border-white/30" />
+                            <div className="absolute left-0 top-1/2 h-9 w-9 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white dark:bg-darkBg" />
+                            <div className="absolute right-0 top-1/2 h-9 w-9 -translate-y-1/2 translate-x-1/2 rounded-full bg-white dark:bg-darkBg" />
+                        </div>
+
+                        <ul className="space-y-3.5">
+                            {brandPoints.map(point => (
+                                <li
+                                    key={point}
+                                    className="flex items-start gap-3 text-[15px] font-medium"
+                                >
+                                    <HiCheckCircle
+                                        aria-hidden="true"
+                                        className="mt-0.5 shrink-0 text-xl text-white/90"
+                                    />
+                                    {point}
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
 
                     <p
                         aria-hidden="true"
-                        className="mt-8 font-mono text-xs tracking-[0.35em] text-white/70 dark:text-gray-400"
+                        className="relative font-mono text-xs tracking-[0.35em] text-white/60"
                     >
                         CARAMEL-FREE-FOREVER
                     </p>
                 </aside>
 
-                {children}
+                {/* Form column */}
+                <main className="relative flex flex-1 flex-col items-center justify-center px-8 py-14 sm:px-5 sm:py-10 xs:px-4">
+                    <ThemeToggle className="absolute right-6 top-6 sm:right-4 sm:top-4" />
+
+                    {/* Compact brand header, mobile/tablet only — the panel is
+                        gone there, and a form with no logo above it reads as a
+                        stray page rather than as Caramel. */}
+                    <div className="mb-9 hidden w-full max-w-[26rem] lg:block sm:mb-7">
+                        <Link
+                            href="/"
+                            className="inline-flex items-center gap-2 rounded-sm text-sm font-medium text-gray-500 transition hover:text-caramel focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/50 dark:text-gray-400"
+                        >
+                            <HiArrowLeft aria-hidden="true" />
+                            Back to home
+                        </Link>
+                        <Image
+                            src="/full-logo.png"
+                            alt="Caramel"
+                            width={132}
+                            height={42}
+                            className="mt-5 dark:brightness-0 dark:invert"
+                        />
+                    </div>
+
+                    {children}
+                </main>
             </div>
         </div>
     )

--- a/apps/caramel-app/src/app/(auth)/login/LoginPageClient.tsx
+++ b/apps/caramel-app/src/app/(auth)/login/LoginPageClient.tsx
@@ -1,22 +1,19 @@
 'use client'
 
+import AuthCard, { AuthDivider } from '@/components/auth/AuthCard'
+import {
+    inputClasses,
+    labelClasses,
+    linkClasses,
+    primaryButtonClasses,
+} from '@/components/auth/authStyles'
+import PasswordField from '@/components/auth/PasswordField'
+import SocialSignIn from '@/components/auth/SocialSignIn'
 import { signIn } from '@/lib/auth/client'
-import { motion } from 'framer-motion'
-import Image from 'next/image'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { FormEvent, useEffect, useState } from 'react'
-import { FaApple, FaGoogle } from 'react-icons/fa'
 import { toast } from 'sonner'
-
-const inputClasses =
-    'w-full rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-gray-900 shadow-sm placeholder:text-gray-400 transition duration-200 hover:border-gray-400 focus:border-caramel focus:outline-none focus:ring-2 focus:ring-caramel/30 dark:border-gray-600 dark:bg-darkBg dark:text-gray-100 dark:shadow-none dark:placeholder:text-gray-500 dark:hover:border-gray-500 dark:focus:border-caramel'
-const labelClasses =
-    'mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300'
-const socialButtonClasses =
-    'flex w-full items-center justify-center gap-3 rounded-lg border border-caramel/40 bg-white px-4 py-2.5 font-medium text-gray-700 shadow-sm transition duration-200 hover:border-caramel hover:bg-caramel/5 active:bg-caramel/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/50 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-caramel/50 dark:bg-darkBg dark:text-gray-200 dark:shadow-none dark:hover:bg-caramel/10 dark:active:bg-caramel/15 dark:focus-visible:ring-offset-darkerBg'
-const linkClasses =
-    'rounded-sm font-semibold text-caramel underline-offset-2 transition hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/50'
 
 export default function LoginPageClient({
     verified,
@@ -28,7 +25,7 @@ export default function LoginPageClient({
     const [email, setEmail] = useState('')
     const [password, setPassword] = useState('')
     const [loading, setLoading] = useState(false)
-    const [oauthLoading, setOauthLoading] = useState<string | null>(null)
+    const [formError, setFormError] = useState('')
     const router = useRouter()
 
     /* Derived, not state: the alert is a function of the URL, and as state it
@@ -53,16 +50,12 @@ export default function LoginPageClient({
             if (error === 'token_expired' || error === 'invalid_token') {
                 toast.error(
                     'Verification link has expired or is invalid. Please request a new one.',
-                    {
-                        duration: 5000,
-                    },
+                    { duration: 5000 },
                 )
             } else if (verified === 'true' && !error) {
                 toast.success(
                     'Email verified successfully! You can now sign in.',
-                    {
-                        duration: 5000,
-                    },
+                    { duration: 5000 },
                 )
             }
         }, 100)
@@ -73,6 +66,7 @@ export default function LoginPageClient({
     const handleSubmit = async (event: FormEvent) => {
         event.preventDefault()
         setLoading(true)
+        setFormError('')
 
         const result = await signIn.email({
             email: email.trim().toLowerCase(),
@@ -83,6 +77,12 @@ export default function LoginPageClient({
             if (result.error.code === 'EMAIL_NOT_VERIFIED') {
                 router.push('/verify')
             } else {
+                // Shown in the form as well as the toast: a toast that has
+                // already auto-dismissed leaves a shopper staring at a form
+                // with no indication of what went wrong.
+                setFormError(
+                    'That email and password combination did not work. Check them and try again.',
+                )
                 toast.error(
                     'Unable to sign in. Please check your email and password.',
                 )
@@ -95,67 +95,34 @@ export default function LoginPageClient({
         setLoading(false)
     }
 
-    const handleSocialSignIn = async (provider: 'google' | 'apple') => {
-        setOauthLoading(provider)
-        try {
-            const result = await signIn.social({
-                provider,
-                callbackURL: '/',
-            })
-
-            if (result?.error) {
-                toast.error(
-                    `Unable to sign in with ${provider === 'google' ? 'Google' : 'Apple'}. Please try again.`,
-                )
-                setOauthLoading(null)
-                return
-            }
-
-            // signIn.social automatically redirects to OAuth provider
-            // The callback will handle redirecting back to callbackURL
-        } catch {
-            toast.error('Something went wrong. Please try again later.')
-            setOauthLoading(null)
-        }
-    }
-
     return (
-        <motion.div
-            className="w-full min-w-0 max-w-md rounded-2xl border border-gray-200/70 bg-white p-8 shadow-xl shadow-gray-300/40 dark:border-gray-800 dark:bg-darkerBg dark:shadow-black/40 sm:p-6 xs:p-5"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5 }}
+        <AuthCard
+            title="Welcome back"
+            subtitle="Sign in to sync your savings across every browser you use Caramel in."
+            footer={
+                <p className="text-center text-sm text-gray-600 dark:text-gray-400">
+                    Don&apos;t have an account?{' '}
+                    <Link className={linkClasses} href="/signup">
+                        Create one free
+                    </Link>
+                </p>
+            }
         >
-            <h2 className="mb-6 flex flex-wrap items-center justify-center gap-2 text-center text-2xl font-bold text-caramel">
-                <div className="my-auto whitespace-nowrap">Sign in to</div>
-                <Image
-                    src="/full-logo.png"
-                    alt="Caramel"
-                    height={90}
-                    width={90}
-                    className="my-auto mt-2"
-                />
-            </h2>
-
             {showVerificationAlert && (
                 <div
                     role="alert"
-                    className="mb-4 rounded-lg border border-orange-300 bg-orange-50 p-4 dark:border-caramel/40 dark:bg-caramel/10"
+                    className="mb-6 rounded-xl border border-orange-300 bg-orange-50 p-4 dark:border-caramel/40 dark:bg-caramel/10"
                 >
-                    <div className="flex items-start">
-                        <div className="flex-1">
-                            <p className="text-sm font-medium text-orange-800 dark:text-orange-200">
-                                {isTokenExpired
-                                    ? 'Verification link expired'
-                                    : 'Email verification required'}
-                            </p>
-                            <p className="mt-1 text-sm text-orange-700 dark:text-orange-300">
-                                {isTokenExpired
-                                    ? 'Your verification link has expired. Please request a new one to continue.'
-                                    : 'Please verify your email address to continue.'}
-                            </p>
-                        </div>
-                    </div>
+                    <p className="text-sm font-semibold text-orange-800 dark:text-orange-200">
+                        {isTokenExpired
+                            ? 'Verification link expired'
+                            : 'Email verification required'}
+                    </p>
+                    <p className="mt-1 text-sm text-orange-700 dark:text-orange-300">
+                        {isTokenExpired
+                            ? 'Your verification link has expired. Please request a new one to continue.'
+                            : 'Please verify your email address to continue.'}
+                    </p>
                     <button
                         type="button"
                         onClick={() => router.push('/verify')}
@@ -168,47 +135,14 @@ export default function LoginPageClient({
                 </div>
             )}
 
-            <div className="mb-4 space-y-3">
-                <button
-                    type="button"
-                    onClick={() => handleSocialSignIn('google')}
-                    disabled={!!oauthLoading}
-                    className={socialButtonClasses}
-                >
-                    <FaGoogle className="h-5 w-5 text-caramel" />
-                    <span>
-                        {oauthLoading === 'google'
-                            ? 'Redirecting...'
-                            : 'Sign in with Google'}
-                    </span>
-                </button>
-                <button
-                    type="button"
-                    onClick={() => handleSocialSignIn('apple')}
-                    disabled={!!oauthLoading}
-                    className={socialButtonClasses}
-                >
-                    <FaApple className="h-5 w-5 text-caramel" />
-                    <span>
-                        {oauthLoading === 'apple'
-                            ? 'Redirecting...'
-                            : 'Sign in with Apple'}
-                    </span>
-                </button>
-            </div>
+            <SocialSignIn verb="Sign in" />
+            <AuthDivider />
 
-            <div className="relative my-6">
-                <div className="absolute inset-0 flex items-center">
-                    <div className="w-full border-t border-gray-200 dark:border-gray-700"></div>
-                </div>
-                <div className="relative flex justify-center text-sm">
-                    <span className="bg-white px-3 text-gray-500 dark:bg-darkerBg dark:text-gray-400">
-                        or
-                    </span>
-                </div>
-            </div>
-
-            <form onSubmit={handleSubmit} className="space-y-4">
+            {/* No noValidate here, unlike signup: this form has no client-side
+                validation of its own, so the browser's own required-field
+                blocking is the only thing stopping an empty submit from firing
+                a pointless sign-in request. */}
+            <form onSubmit={handleSubmit} className="space-y-5">
                 <div>
                     <label htmlFor="login-email" className={labelClasses}>
                         Email
@@ -218,41 +152,48 @@ export default function LoginPageClient({
                         type="email"
                         required
                         autoComplete="email"
-                        placeholder="Enter your email"
+                        placeholder="you@example.com"
                         value={email}
                         onChange={event => setEmail(event.target.value)}
                         className={inputClasses}
                     />
                 </div>
-                <div>
-                    <label htmlFor="login-password" className={labelClasses}>
-                        Password
-                    </label>
-                    <input
-                        id="login-password"
-                        type="password"
-                        required
-                        autoComplete="current-password"
-                        placeholder="Enter your password"
-                        value={password}
-                        onChange={event => setPassword(event.target.value)}
-                        className={inputClasses}
-                    />
-                </div>
+
+                <PasswordField
+                    label="Password"
+                    name="password"
+                    autoComplete="current-password"
+                    placeholder="Enter your password"
+                    required
+                    value={password}
+                    onChange={event => setPassword(event.target.value)}
+                    trailingLabel={
+                        <Link
+                            href="/forgot-password"
+                            className="text-sm font-medium text-caramel underline-offset-2 transition hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/50"
+                        >
+                            Forgot password?
+                        </Link>
+                    }
+                />
+
+                {formError ? (
+                    <p
+                        role="alert"
+                        className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-950/40 dark:text-red-300"
+                    >
+                        {formError}
+                    </p>
+                ) : null}
+
                 <button
                     type="submit"
                     disabled={loading}
-                    className="w-full rounded-lg bg-caramel py-2.5 font-semibold text-white shadow-sm transition duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel focus-visible:ring-offset-2 enabled:hover:bg-caramel/90 enabled:hover:shadow-caramel-sm enabled:active:bg-caramel disabled:cursor-not-allowed disabled:opacity-60 dark:focus-visible:ring-offset-darkerBg"
+                    className={primaryButtonClasses}
                 >
-                    {loading ? 'Logging in...' : 'Login'}
+                    {loading ? 'Signing in…' : 'Sign in'}
                 </button>
             </form>
-            <p className="mt-6 text-center text-sm text-gray-600 dark:text-gray-400">
-                Don&apos;t have an account?{' '}
-                <Link className={linkClasses} href="/signup">
-                    Sign Up
-                </Link>
-            </p>
-        </motion.div>
+        </AuthCard>
     )
 }

--- a/apps/caramel-app/src/app/(auth)/login/page.tsx
+++ b/apps/caramel-app/src/app/(auth)/login/page.tsx
@@ -2,9 +2,13 @@ import { BASE_URL } from '@/lib/env.client'
 import type { Metadata } from 'next'
 import LoginPageClient from './LoginPageClient'
 
-const title = 'Caramel | Login'
+/* Brand-first title: the query this page can realistically win is "caramel
+ * login", and Google renders roughly the first 60 characters, so the
+ * distinguishing words go at the front rather than after a "Caramel |" prefix
+ * that every other page also carries. */
+const title = 'Sign in to Caramel | Coupon Extension Login'
 const description =
-    'Log in to your Caramel account to access exclusive features and start saving with our coupon extension.'
+    'Sign in to your Caramel account to sync saved coupons across browsers and manage the free, open-source coupon extension.'
 const canonicalUrl = 'https://grabcaramel.com/login'
 const base = BASE_URL
 const banner = `${base}/caramel_banner.png`

--- a/apps/caramel-app/src/app/(auth)/reset-password/ResetPasswordPageClient.tsx
+++ b/apps/caramel-app/src/app/(auth)/reset-password/ResetPasswordPageClient.tsx
@@ -1,0 +1,151 @@
+'use client'
+
+import AuthCard from '@/components/auth/AuthCard'
+import { linkClasses, primaryButtonClasses } from '@/components/auth/authStyles'
+import PasswordField from '@/components/auth/PasswordField'
+import { resetPassword } from '@/lib/auth/client'
+import { firstPasswordFailure } from '@/lib/passwordRules'
+import dynamic from 'next/dynamic'
+import Link from 'next/link'
+import { FormEvent, useState } from 'react'
+import { toast } from 'sonner'
+
+const PasswordChecker = dynamic(
+    () => import('@/components/PasswordStrength/PasswordChecker'),
+    { ssr: false },
+)
+
+export default function ResetPasswordPageClient({
+    token,
+    error,
+}: {
+    token?: string
+    error?: string
+}) {
+    const [password, setPassword] = useState('')
+    const [confirmPassword, setConfirmPassword] = useState('')
+    const [formError, setFormError] = useState('')
+    const [loading, setLoading] = useState(false)
+    const [done, setDone] = useState(false)
+
+    /* A missing or rejected token is the common case here, not an edge case:
+     * these links expire in an hour and are single-use, so anyone who opens an
+     * old email lands in this branch. It gets a real screen with a way
+     * forward rather than a form that can only fail on submit. */
+    if (!token || error) {
+        return (
+            <AuthCard
+                title="This link has expired"
+                subtitle="Password reset links last one hour and can only be used once. Request a fresh one and we'll email it straight over."
+                footer={
+                    <p className="text-center text-sm text-gray-600 dark:text-gray-400">
+                        <Link className={linkClasses} href="/login">
+                            Back to sign in
+                        </Link>
+                    </p>
+                }
+            >
+                <Link
+                    href="/forgot-password"
+                    className={`${primaryButtonClasses} block text-center`}
+                >
+                    Request a new link
+                </Link>
+            </AuthCard>
+        )
+    }
+
+    if (done) {
+        return (
+            <AuthCard
+                title="Password updated"
+                subtitle="Your new password is saved. You can sign in with it now."
+            >
+                <Link
+                    href="/login"
+                    className={`${primaryButtonClasses} block text-center`}
+                >
+                    Continue to sign in
+                </Link>
+            </AuthCard>
+        )
+    }
+
+    const handleSubmit = async (event: FormEvent) => {
+        event.preventDefault()
+        setFormError('')
+
+        const policyFailure = firstPasswordFailure(password)
+        if (policyFailure) {
+            setFormError(policyFailure)
+            return
+        }
+        if (password !== confirmPassword) {
+            setFormError('Both passwords need to match')
+            return
+        }
+
+        setLoading(true)
+        const result = await resetPassword({ newPassword: password, token })
+        setLoading(false)
+
+        if (result?.error) {
+            setFormError(
+                'We could not reset your password with that link. It may have expired — request a new one.',
+            )
+            toast.error('Unable to reset your password.')
+            return
+        }
+        setDone(true)
+    }
+
+    return (
+        <AuthCard
+            title="Choose a new password"
+            subtitle="Pick something you haven't used on Caramel before."
+        >
+            <form onSubmit={handleSubmit} className="space-y-5" noValidate>
+                <PasswordField
+                    label="New password"
+                    name="password"
+                    autoComplete="new-password"
+                    placeholder="Create a password"
+                    required
+                    value={password}
+                    onChange={event => setPassword(event.target.value)}
+                />
+                <PasswordField
+                    label="Re-type new password"
+                    name="confirmPassword"
+                    autoComplete="new-password"
+                    placeholder="Re-type your password"
+                    required
+                    value={confirmPassword}
+                    onChange={event => setConfirmPassword(event.target.value)}
+                />
+
+                <PasswordChecker
+                    password={password}
+                    confirmPassword={confirmPassword}
+                />
+
+                {formError ? (
+                    <p
+                        role="alert"
+                        className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-950/40 dark:text-red-300"
+                    >
+                        {formError}
+                    </p>
+                ) : null}
+
+                <button
+                    type="submit"
+                    disabled={loading}
+                    className={primaryButtonClasses}
+                >
+                    {loading ? 'Saving…' : 'Save new password'}
+                </button>
+            </form>
+        </AuthCard>
+    )
+}

--- a/apps/caramel-app/src/app/(auth)/reset-password/page.tsx
+++ b/apps/caramel-app/src/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from 'next'
+import ResetPasswordPageClient from './ResetPasswordPageClient'
+
+const title = 'Choose a new password | Caramel'
+const description = 'Set a new password for your Caramel account.'
+
+export const metadata: Metadata = {
+    title,
+    description,
+    /* noindex is not optional here: the URL carries a single-use reset token as
+     * a query parameter, and an indexed copy would publish it. `nofollow` too —
+     * there is nothing on this page worth crawling. */
+    robots: { index: false, follow: false },
+}
+
+/* The token arrives as a query parameter on the emailed link and is read on the
+ * server, like /login and /verify — a client-side read would leave the page
+ * unable to distinguish "no token" from "not hydrated yet" and flash the
+ * expired-link screen at every visitor before settling. */
+export default async function ResetPassword({
+    searchParams,
+}: {
+    searchParams: Promise<{ token?: string; error?: string }>
+}) {
+    const { token, error } = await searchParams
+    return <ResetPasswordPageClient token={token} error={error} />
+}

--- a/apps/caramel-app/src/app/(auth)/signup/SignupPageClient.tsx
+++ b/apps/caramel-app/src/app/(auth)/signup/SignupPageClient.tsx
@@ -1,13 +1,21 @@
 'use client'
 
-import { signIn, signUp } from '@/lib/auth/client'
+import AuthCard, { AuthDivider } from '@/components/auth/AuthCard'
+import {
+    fieldErrorClasses,
+    inputClasses,
+    labelClasses,
+    linkClasses,
+    primaryButtonClasses,
+} from '@/components/auth/authStyles'
+import PasswordField from '@/components/auth/PasswordField'
+import SocialSignIn from '@/components/auth/SocialSignIn'
+import { signUp } from '@/lib/auth/client'
+import { firstPasswordFailure } from '@/lib/passwordRules'
 import { useFormik } from 'formik'
-import { motion } from 'framer-motion'
 import dynamic from 'next/dynamic'
-import Image from 'next/image'
 import Link from 'next/link'
 import { useState } from 'react'
-import { FaApple, FaGoogle } from 'react-icons/fa'
 import { toast } from 'sonner'
 import { object, ref, string } from 'yup'
 
@@ -16,35 +24,39 @@ const PasswordChecker = dynamic(
     { ssr: false },
 )
 
+/* The password branch is built from `@/lib/passwordRules`, the same source the
+ * on-screen checklist renders, so the two cannot disagree about what a valid
+ * password is.
+ *
+ * Every rule also carries an explicit message. Without one, yup falls back to
+ * printing the constraint itself, so a shopper who typed a lowercase-only
+ * password was previously shown the literal regex
+ * ("password must match the following: /[A-Z]/"). */
 const validationSchema = object().shape({
-    username: string().min(4).required('Please enter your username'),
-    email: string().email().required('Please enter your email'),
+    username: string()
+        .min(4, 'Nicknames need at least 4 characters')
+        .required('Please choose a nickname'),
+    email: string()
+        .email('That does not look like an email address')
+        .required('Please enter your email'),
     password: string()
-        .min(5)
-        .matches(/[A-Z]/)
-        .matches(/[0-9]/)
-        .matches(/[!@#$%^&*+-]/)
-        .required(
-            'Password must contain at least 5 characters, 1 uppercase, 1 number and 1 special character',
+        .required('Please create a password')
+        .test(
+            'password-policy',
+            'Password does not meet the requirements',
+            function (value) {
+                const failure = firstPasswordFailure(value ?? '')
+                return failure ? this.createError({ message: failure }) : true
+            },
         ),
     confirmPassword: string()
-        .oneOf([ref('password')])
-        .required("Password doesn't match"),
+        .oneOf([ref('password')], 'Both passwords need to match')
+        .required('Please re-type your password'),
 })
-
-const inputClasses =
-    'w-full rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-gray-900 shadow-sm placeholder:text-gray-400 transition duration-200 hover:border-gray-400 focus:border-caramel focus:outline-none focus:ring-2 focus:ring-caramel/30 dark:border-gray-600 dark:bg-darkBg dark:text-gray-100 dark:shadow-none dark:placeholder:text-gray-500 dark:hover:border-gray-500 dark:focus:border-caramel'
-const labelClasses =
-    'mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300'
-const socialButtonClasses =
-    'flex w-full items-center justify-center gap-3 rounded-lg border border-caramel/40 bg-white px-4 py-2.5 font-medium text-gray-700 shadow-sm transition duration-200 hover:border-caramel hover:bg-caramel/5 active:bg-caramel/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/50 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-caramel/50 dark:bg-darkBg dark:text-gray-200 dark:shadow-none dark:hover:bg-caramel/10 dark:active:bg-caramel/15 dark:focus-visible:ring-offset-darkerBg'
-const linkClasses =
-    'rounded-sm font-semibold text-caramel underline-offset-2 transition hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/50'
 
 export default function SignupPageClient() {
     const [showPasswordChecker, setShowPasswordChecker] = useState(false)
     const [loading, setLoading] = useState(false)
-    const [oauthLoading, setOauthLoading] = useState<string | null>(null)
     const [error, setError] = useState('')
 
     const formik = useFormik({
@@ -70,7 +82,9 @@ export default function SignupPageClient() {
                     toast.error(
                         'Unable to create your account. Please try again or use a different email.',
                     )
-                    setError('Unable to create account')
+                    setError(
+                        'We could not create that account. Try a different email, or sign in if you already have one.',
+                    )
                     return
                 }
 
@@ -78,223 +92,142 @@ export default function SignupPageClient() {
                 window.location.href = '/verify?signup=success'
             } catch {
                 toast.error('Something went wrong. Please try again later.')
-                setError('Something went wrong')
+                setError('Something went wrong. Please try again later.')
             } finally {
                 setLoading(false)
             }
         },
     })
 
-    const handleSocialSignIn = async (provider: 'google' | 'apple') => {
-        setOauthLoading(provider)
-        try {
-            const result = await signIn.social({
-                provider,
-                callbackURL: '/',
-            })
-
-            if (result?.error) {
-                toast.error(
-                    `Unable to sign up with ${provider === 'google' ? 'Google' : 'Apple'}. Please try again.`,
-                )
-                setOauthLoading(null)
-                return
-            }
-
-            // signIn.social automatically redirects to OAuth provider
-            // The callback will handle redirecting back to callbackURL
-        } catch {
-            toast.error('Something went wrong. Please try again later.')
-            setOauthLoading(null)
-        }
-    }
-
     const { handleSubmit, errors, touched, handleChange, handleBlur, values } =
         formik
 
+    const fieldError = (name: keyof typeof values) =>
+        touched[name] && errors[name] ? errors[name] : undefined
+
     return (
-        <motion.div
-            className="w-full min-w-0 max-w-md rounded-2xl border border-gray-200/70 bg-white p-8 shadow-xl shadow-gray-300/40 dark:border-gray-800 dark:bg-darkerBg dark:shadow-black/40 sm:p-6 xs:p-5"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5 }}
+        <AuthCard
+            title="Create your account"
+            subtitle="Free forever. Caramel finds and applies coupon codes for you at checkout."
+            footer={
+                <p className="text-center text-sm text-gray-600 dark:text-gray-400">
+                    Already have an account?{' '}
+                    <Link href="/login" className={linkClasses}>
+                        Sign in
+                    </Link>
+                </p>
+            }
         >
-            <h2 className="mb-6 flex flex-wrap items-center justify-center gap-2 text-center text-2xl font-bold text-caramel">
-                <div className="my-auto whitespace-nowrap">Create your</div>
-                <Image
-                    src="/full-logo.png"
-                    alt="Caramel"
-                    height={90}
-                    width={90}
-                    className="my-auto mt-2"
-                />
-                <div className="my-auto whitespace-nowrap">account</div>
-            </h2>
-            <div className="mb-4 space-y-3">
-                <button
-                    type="button"
-                    onClick={() => handleSocialSignIn('google')}
-                    disabled={!!oauthLoading}
-                    className={socialButtonClasses}
-                >
-                    <FaGoogle className="h-5 w-5 text-caramel" />
-                    <span>
-                        {oauthLoading === 'google'
-                            ? 'Redirecting...'
-                            : 'Sign up with Google'}
-                    </span>
-                </button>
-                <button
-                    type="button"
-                    onClick={() => handleSocialSignIn('apple')}
-                    disabled={!!oauthLoading}
-                    className={socialButtonClasses}
-                >
-                    <FaApple className="h-5 w-5 text-caramel" />
-                    <span>
-                        {oauthLoading === 'apple'
-                            ? 'Redirecting...'
-                            : 'Sign up with Apple'}
-                    </span>
-                </button>
-            </div>
+            <SocialSignIn verb="Sign up" />
+            <AuthDivider />
 
-            <div className="relative my-6">
-                <div className="absolute inset-0 flex items-center">
-                    <div className="w-full border-t border-gray-200 dark:border-gray-700"></div>
-                </div>
-                <div className="relative flex justify-center text-sm">
-                    <span className="bg-white px-3 text-gray-500 dark:bg-darkerBg dark:text-gray-400">
-                        or
-                    </span>
-                </div>
-            </div>
-
-            <form onSubmit={handleSubmit} className="space-y-4">
+            <form onSubmit={handleSubmit} className="space-y-5" noValidate>
                 <div>
                     <label htmlFor="signup-username" className={labelClasses}>
-                        Choose a nickname
+                        Nickname
                     </label>
                     <input
                         id="signup-username"
                         type="text"
-                        onBlur={handleBlur}
+                        name="username"
                         required
-                        name={'username'}
-                        onChange={handleChange}
+                        autoComplete="nickname"
                         placeholder="@nickname"
+                        value={values.username}
+                        onBlur={handleBlur}
+                        onChange={handleChange}
+                        aria-invalid={fieldError('username') ? true : undefined}
                         className={inputClasses}
                     />
-                    <div className="ml-1 mt-1 min-h-[1.25rem]">
-                        {errors.username && touched.username && (
-                            <div
-                                role="alert"
-                                className="text-sm text-red-500 dark:text-red-400"
-                            >
-                                {errors.username}
-                            </div>
-                        )}
-                    </div>
+                    {fieldError('username') ? (
+                        <p role="alert" className={fieldErrorClasses}>
+                            {errors.username}
+                        </p>
+                    ) : null}
                 </div>
+
                 <div>
                     <label htmlFor="signup-email" className={labelClasses}>
                         Email
                     </label>
                     <input
                         id="signup-email"
-                        onBlur={handleBlur}
                         type="email"
-                        name={'email'}
+                        name="email"
                         required
                         autoComplete="email"
+                        placeholder="you@example.com"
+                        value={values.email}
+                        onBlur={handleBlur}
                         onChange={handleChange}
-                        placeholder="Enter your email"
+                        aria-invalid={fieldError('email') ? true : undefined}
                         className={inputClasses}
                     />
-                    <div className="ml-1 mt-1 min-h-[1.25rem]">
-                        {errors.email && touched.email && (
-                            <div
-                                role="alert"
-                                className="text-sm text-red-500 dark:text-red-400"
-                            >
-                                {errors.email}
-                            </div>
-                        )}
-                    </div>
+                    {fieldError('email') ? (
+                        <p role="alert" className={fieldErrorClasses}>
+                            {errors.email}
+                        </p>
+                    ) : null}
                 </div>
-                <div>
-                    <label htmlFor="signup-password" className={labelClasses}>
-                        Password
-                    </label>
-                    <input
-                        id="signup-password"
-                        onBlur={handleBlur}
-                        /* onFocus, not onClick: a shopper who reaches this
-                         * field with Tab, or whose password manager fills it,
-                         * never clicks it — and on `onClick` alone they got
-                         * their password rejected with the requirements list
-                         * still hidden, which is the one thing that would have
-                         * told them why. Focus covers clicking too. */
-                        onFocus={() => setShowPasswordChecker(true)}
-                        type="password"
-                        name={'password'}
-                        required
-                        autoComplete="new-password"
-                        onChange={handleChange}
-                        placeholder="Create a password"
-                        className={`mb-2 ${inputClasses}`}
-                    />
-                </div>
-                <div>
-                    <label
-                        htmlFor="signup-confirm-password"
-                        className={labelClasses}
-                    >
-                        Re-type Password
-                    </label>
-                    <input
-                        id="signup-confirm-password"
-                        onBlur={handleBlur}
-                        onFocus={() => setShowPasswordChecker(true)}
-                        type="password"
-                        name={'confirmPassword'}
-                        required
-                        autoComplete="new-password"
-                        onChange={handleChange}
-                        placeholder="Re-type Password"
-                        className={inputClasses}
-                    />
-                </div>
-                <div className="col-span-2 flex justify-end">
-                    {showPasswordChecker && (
+
+                <PasswordField
+                    label="Password"
+                    name="password"
+                    autoComplete="new-password"
+                    placeholder="Create a password"
+                    required
+                    value={values.password}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    /* onFocus, not onClick: a shopper who reaches this field
+                     * with Tab, or whose password manager fills it, never
+                     * clicks it — and on `onClick` alone they got their
+                     * password rejected with the requirements list still
+                     * hidden, which is the one thing that would have told them
+                     * why. Focus covers clicking too. */
+                    onFocus={() => setShowPasswordChecker(true)}
+                    error={fieldError('password')}
+                />
+
+                <PasswordField
+                    label="Re-type password"
+                    name="confirmPassword"
+                    autoComplete="new-password"
+                    placeholder="Re-type your password"
+                    required
+                    value={values.confirmPassword}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    onFocus={() => setShowPasswordChecker(true)}
+                    error={fieldError('confirmPassword')}
+                />
+
+                {showPasswordChecker && (
+                    <div className="flex justify-end">
                         <PasswordChecker
                             password={values.password}
                             confirmPassword={values.confirmPassword}
                         />
-                    )}
-                </div>
+                    </div>
+                )}
+
                 <button
-                    disabled={loading || Object.keys(errors).length > 0}
+                    disabled={loading}
                     type="submit"
-                    className="w-full rounded-lg bg-caramel py-2.5 font-semibold text-white shadow-sm transition duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel focus-visible:ring-offset-2 enabled:hover:bg-caramel/90 enabled:hover:shadow-caramel-sm enabled:active:bg-caramel disabled:cursor-not-allowed disabled:opacity-60 dark:focus-visible:ring-offset-darkerBg"
+                    className={primaryButtonClasses}
                 >
-                    {loading ? 'Loading...' : 'Sign Up'}
+                    {loading ? 'Creating your account…' : 'Create account'}
                 </button>
+
+                {error ? (
+                    <p
+                        role="alert"
+                        className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-950/40 dark:text-red-300"
+                    >
+                        {error}
+                    </p>
+                ) : null}
             </form>
-            <p className="mt-6 text-center text-sm text-gray-600 dark:text-gray-400">
-                Already have an account?{' '}
-                <Link href="/login" className={linkClasses}>
-                    Login
-                </Link>
-            </p>
-            {error ? (
-                <p
-                    role="alert"
-                    className="mt-4 text-center text-sm text-red-500 dark:text-red-400"
-                >
-                    {error}
-                </p>
-            ) : null}
-        </motion.div>
+        </AuthCard>
     )
 }

--- a/apps/caramel-app/src/app/(auth)/signup/page.tsx
+++ b/apps/caramel-app/src/app/(auth)/signup/page.tsx
@@ -2,8 +2,13 @@ import { BASE_URL } from '@/lib/env.client'
 import type { Metadata } from 'next'
 import SignupPageClient from './SignupPageClient'
 
-const title = 'Caramel | Sign Up'
-const description = 'Join Caramel and start enjoying our services. Sign up now!'
+/* "Join Caramel and start enjoying our services" said nothing about what
+ * Caramel is or costs — it was boilerplate that could describe any product, and
+ * it is the snippet a searcher decides on. This one names the product category,
+ * the price, and the differentiator. */
+const title = 'Create a free Caramel account | Coupon Extension Sign Up'
+const description =
+    'Create a free Caramel account to automatically apply coupon codes at checkout. Open source, no ads, and it never hijacks affiliate commissions.'
 const canonicalUrl = 'https://grabcaramel.com/signup'
 const base = BASE_URL
 const banner = `${base}/caramel_banner.png`

--- a/apps/caramel-app/src/app/(auth)/verify/VerifyPageClient.tsx
+++ b/apps/caramel-app/src/app/(auth)/verify/VerifyPageClient.tsx
@@ -1,14 +1,16 @@
 'use client'
 
+import AuthCard from '@/components/auth/AuthCard'
+import {
+    inputClasses,
+    labelClasses,
+    linkClasses,
+    primaryButtonClasses,
+} from '@/components/auth/authStyles'
 import { authClient } from '@/lib/auth/client'
-import { motion } from 'framer-motion'
-import Image from 'next/image'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
-
-const inputClasses =
-    'w-full rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-gray-900 shadow-sm placeholder:text-gray-400 transition duration-200 hover:border-gray-400 focus:border-caramel focus:outline-none focus:ring-2 focus:ring-caramel/30 dark:border-gray-600 dark:bg-darkBg dark:text-gray-100 dark:shadow-none dark:placeholder:text-gray-500 dark:hover:border-gray-500 dark:focus:border-caramel'
 
 export default function VerifyPageClient({
     signup,
@@ -27,16 +29,12 @@ export default function VerifyPageClient({
             if (signup === 'success') {
                 toast.success(
                     'Account created! Please check your email to verify your account.',
-                    {
-                        duration: 6000,
-                    },
+                    { duration: 6000 },
                 )
             } else if (error === 'token_expired') {
                 toast.error(
                     'Verification link has expired. Please request a new one.',
-                    {
-                        duration: 5000,
-                    },
+                    { duration: 5000 },
                 )
             }
         }, 100)
@@ -52,10 +50,21 @@ export default function VerifyPageClient({
 
         setResendingEmail(true)
         try {
-            await authClient.sendVerificationEmail({
+            const result = await authClient.sendVerificationEmail({
                 email: email.trim().toLowerCase(),
                 callbackURL: '/login?verified=true',
             })
+            // The Better Auth client RETURNS { error } instead of throwing, so
+            // the try/catch alone never saw a failure: every call reported
+            // "Verification email sent!" including the ones that did not send.
+            // That is precisely the failure mode the 2026-08-08 cutover hid on
+            // the server side, repeated on the client.
+            if (result?.error) {
+                toast.error(
+                    'Failed to send verification email. Please try again.',
+                )
+                return
+            }
             toast.success(
                 'Verification email sent! Please check your inbox and spam folder.',
                 { duration: 5000 },
@@ -68,43 +77,25 @@ export default function VerifyPageClient({
     }
 
     return (
-        <motion.div
-            className="w-full min-w-0 max-w-md rounded-2xl border border-gray-200/70 bg-white p-8 shadow-xl shadow-gray-300/40 dark:border-gray-800 dark:bg-darkerBg dark:shadow-black/40 sm:p-6 xs:p-5"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5 }}
+        <AuthCard
+            title="Verify your email"
+            subtitle={
+                isNewSignup
+                    ? "We've sent a verification link to your inbox. Didn't get it? Enter your email below and we'll send another."
+                    : 'Please verify your email address to continue. Enter your email below to receive a new verification link.'
+            }
+            footer={
+                <p className="text-center text-sm text-gray-600 dark:text-gray-400">
+                    Already verified?{' '}
+                    <Link className={linkClasses} href="/login">
+                        Sign in
+                    </Link>
+                </p>
+            }
         >
-            <h2 className="mb-6 flex flex-wrap items-center justify-center gap-2 text-center text-2xl font-bold text-caramel">
-                <div className="my-auto whitespace-nowrap">Verify your</div>
-                <Image
-                    src="/full-logo.png"
-                    alt="Caramel"
-                    height={90}
-                    width={90}
-                    className="my-auto mt-2"
-                />
-                <div className="my-auto whitespace-nowrap">account</div>
-            </h2>
-
-            <div className="mb-6 text-center text-gray-600 dark:text-gray-300">
-                <p>
-                    {isNewSignup
-                        ? "We've sent a verification email to your inbox."
-                        : 'Please verify your email address to continue.'}
-                </p>
-                <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
-                    {isNewSignup
-                        ? "Didn't receive it? Enter your email below to resend."
-                        : 'Enter your email below to receive a new verification link.'}
-                </p>
-            </div>
-
-            <div className="space-y-4">
+            <div className="space-y-5">
                 <div>
-                    <label
-                        htmlFor="verify-email"
-                        className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300"
-                    >
+                    <label htmlFor="verify-email" className={labelClasses}>
                         Email
                     </label>
                     <input
@@ -112,7 +103,7 @@ export default function VerifyPageClient({
                         type="email"
                         required
                         autoComplete="email"
-                        placeholder="Enter your email"
+                        placeholder="you@example.com"
                         value={email}
                         onChange={event => setEmail(event.target.value)}
                         className={inputClasses}
@@ -122,21 +113,11 @@ export default function VerifyPageClient({
                     type="button"
                     onClick={handleResendVerification}
                     disabled={resendingEmail}
-                    className="w-full rounded-lg bg-caramel py-2.5 font-semibold text-white shadow-sm transition duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel focus-visible:ring-offset-2 enabled:hover:bg-caramel/90 enabled:hover:shadow-caramel-sm enabled:active:bg-caramel disabled:cursor-not-allowed disabled:opacity-60 dark:focus-visible:ring-offset-darkerBg"
+                    className={primaryButtonClasses}
                 >
-                    {resendingEmail ? 'Sending...' : 'Send verification email'}
+                    {resendingEmail ? 'Sending…' : 'Send verification email'}
                 </button>
             </div>
-
-            <p className="mt-6 text-center text-sm text-gray-600 dark:text-gray-400">
-                Already verified?{' '}
-                <Link
-                    className="rounded-sm font-semibold text-caramel underline-offset-2 transition hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/50"
-                    href="/login"
-                >
-                    Sign In
-                </Link>
-            </p>
-        </motion.div>
+        </AuthCard>
     )
 }

--- a/apps/caramel-app/src/app/providers.tsx
+++ b/apps/caramel-app/src/app/providers.tsx
@@ -33,7 +33,26 @@ export default function Providers({ children }: { children: ReactNode }) {
     // is what satisfies every Tailwind `dark:` variant and paints the page
     // background.
     const [isDarkMode, setDarkMode] = useState(false)
-    const pagesLayoutless = useMemo(() => ['/login', '/signup', '/verify'], [])
+    /* Must list EVERY route in the src/app/(auth) group.
+     *
+     * The (auth) group has its own full-screen shell (brand panel, background,
+     * theme toggle), and anything missing from this list gets the marketing
+     * Layout wrapped around that shell as well — two headers, two theme
+     * toggles, a footer under the sign-in form. That is exactly what
+     * /forgot-password and /reset-password shipped as until this line was
+     * updated, because the list is matched by hand rather than derived from the
+     * route group. tests/unit/auth-routes-layoutless.test.ts walks the (auth)
+     * directory and fails when a route is added without being listed here. */
+    const pagesLayoutless = useMemo(
+        () => [
+            '/login',
+            '/signup',
+            '/verify',
+            '/forgot-password',
+            '/reset-password',
+        ],
+        [],
+    )
 
     useEffect(() => {
         setDarkMode(document.documentElement.classList.contains('dark'))

--- a/apps/caramel-app/src/components/PasswordStrength/PasswordChecker.tsx
+++ b/apps/caramel-app/src/components/PasswordStrength/PasswordChecker.tsx
@@ -1,41 +1,31 @@
 import PasswordItem from '@/components/PasswordStrength/PasswordItem'
+import { passwordRules } from '@/lib/passwordRules'
 
 interface PasswordCheckerProps {
     password: string
     confirmPassword: string
 }
 
+/**
+ * The rules come from `@/lib/passwordRules` — the same source the signup and
+ * reset-password schemas validate against. This list used to hard-code its own
+ * copy of the policy and had already drifted from the schema (it ticked
+ * "minimum length reached" at 5 characters), so a shopper could see every item
+ * green and still have the form reject the password.
+ */
 const PasswordChecker = ({
     password,
     confirmPassword,
 }: PasswordCheckerProps) => {
     const checkList = [
+        ...passwordRules.map(rule => ({
+            id: rule.id,
+            term: rule.test(password),
+            success_message: rule.success,
+            failure_message: rule.failure,
+        })),
         {
-            id: 1,
-            term: password.length >= 5,
-            success_message: 'The minimum length is reached',
-            failure_message: 'At least 5 characters required',
-        },
-        {
-            id: 2,
-            term: /[A-Z]/.test(password),
-            success_message: 'At least one uppercase letter',
-            failure_message: 'At least one uppercase letter required',
-        },
-        {
-            id: 3,
-            term: /[0-9]/.test(password),
-            success_message: 'At least one number',
-            failure_message: 'At least one number required',
-        },
-        {
-            id: 4,
-            term: /[!@#$%^&*+-]/.test(password),
-            success_message: 'At least special character',
-            failure_message: 'At least special character required',
-        },
-        {
-            id: 5,
+            id: 'match',
             term: password === confirmPassword && password.length > 0,
             success_message: 'Passwords match',
             failure_message: 'Passwords must match',

--- a/apps/caramel-app/src/components/auth/AuthCard.tsx
+++ b/apps/caramel-app/src/components/auth/AuthCard.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { motion } from 'framer-motion'
+
+/**
+ * The form column of an auth page.
+ *
+ * The heading is an <h1>. Every auth page previously opened at <h2> with no
+ * <h1> anywhere in the document, which is both a heading-hierarchy failure for
+ * screen readers and the single clearest on-page signal a crawler reads. The
+ * old heading also inlined a 90px logo image mid-sentence ("Sign in to
+ * [logo]"), so the accessible name depended on that image's alt text and the
+ * line wrapped awkwardly at every width; the brand now lives in the panel
+ * beside it, where it belongs.
+ */
+export default function AuthCard({
+    title,
+    subtitle,
+    children,
+    footer,
+}: {
+    title: string
+    subtitle?: React.ReactNode
+    children: React.ReactNode
+    footer?: React.ReactNode
+}) {
+    return (
+        <motion.div
+            className="w-full min-w-0 max-w-[26rem]"
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+        >
+            <h1 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-2xl">
+                {title}
+            </h1>
+            {subtitle ? (
+                <p className="mt-2 text-[15px] leading-relaxed text-gray-600 dark:text-gray-400">
+                    {subtitle}
+                </p>
+            ) : null}
+            <div className="mt-8 sm:mt-6">{children}</div>
+            {footer ? <div className="mt-8 sm:mt-6">{footer}</div> : null}
+        </motion.div>
+    )
+}
+
+/** "or" rule between the social buttons and the email form. */
+export function AuthDivider({ label = 'or' }: { label?: string }) {
+    return (
+        <div className="relative my-6">
+            <div
+                aria-hidden="true"
+                className="absolute inset-0 flex items-center"
+            >
+                <div className="w-full border-t border-gray-200 dark:border-gray-800" />
+            </div>
+            <div className="relative flex justify-center">
+                <span className="bg-white px-3 text-xs font-medium uppercase tracking-wider text-gray-500 dark:bg-darkBg dark:text-gray-400">
+                    {label}
+                </span>
+            </div>
+        </div>
+    )
+}

--- a/apps/caramel-app/src/components/auth/PasswordField.tsx
+++ b/apps/caramel-app/src/components/auth/PasswordField.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import {
+    fieldErrorClasses,
+    inputWithAffordanceClasses,
+    labelClasses,
+} from '@/components/auth/authStyles'
+import { useId, useState } from 'react'
+import { HiEye, HiEyeOff } from 'react-icons/hi'
+
+type PasswordFieldProps = {
+    label: string
+    name: string
+    /** `new-password` on signup/reset, `current-password` on login. */
+    autoComplete: 'current-password' | 'new-password'
+    placeholder?: string
+    value?: string
+    error?: string
+    required?: boolean
+    onChange?: React.ChangeEventHandler<HTMLInputElement>
+    onBlur?: React.FocusEventHandler<HTMLInputElement>
+    onFocus?: React.FocusEventHandler<HTMLInputElement>
+    /** Rendered on the label row, e.g. the "Forgot password?" link. */
+    trailingLabel?: React.ReactNode
+}
+
+/**
+ * Password input with a reveal toggle.
+ *
+ * A typo in a masked field is the most common reason a correct password gets
+ * rejected, and every field on these pages was previously mask-only with no way
+ * to check. The toggle is a real <button> (not a div) so it is reachable by
+ * keyboard, and it reports state through aria-pressed rather than icon alone.
+ */
+export default function PasswordField({
+    label,
+    name,
+    autoComplete,
+    placeholder,
+    value,
+    error,
+    required,
+    onChange,
+    onBlur,
+    onFocus,
+    trailingLabel,
+}: PasswordFieldProps) {
+    const [revealed, setRevealed] = useState(false)
+    const id = useId()
+    const errorId = `${id}-error`
+
+    return (
+        <div>
+            <div className="flex items-baseline justify-between gap-3">
+                <label htmlFor={id} className={labelClasses}>
+                    {label}
+                </label>
+                {trailingLabel}
+            </div>
+            <div className="relative">
+                <input
+                    id={id}
+                    name={name}
+                    type={revealed ? 'text' : 'password'}
+                    required={required}
+                    autoComplete={autoComplete}
+                    placeholder={placeholder}
+                    value={value}
+                    onChange={onChange}
+                    onBlur={onBlur}
+                    onFocus={onFocus}
+                    aria-invalid={error ? true : undefined}
+                    aria-describedby={error ? errorId : undefined}
+                    className={inputWithAffordanceClasses}
+                />
+                <button
+                    type="button"
+                    onClick={() => setRevealed(current => !current)}
+                    aria-label={revealed ? 'Hide password' : 'Show password'}
+                    aria-pressed={revealed}
+                    className="absolute inset-y-0 right-0 flex w-12 items-center justify-center rounded-r-xl text-gray-500 transition hover:text-caramel focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/50 dark:text-gray-400"
+                >
+                    {revealed ? (
+                        <HiEyeOff aria-hidden="true" className="h-5 w-5" />
+                    ) : (
+                        <HiEye aria-hidden="true" className="h-5 w-5" />
+                    )}
+                </button>
+            </div>
+            {error ? (
+                <p id={errorId} role="alert" className={fieldErrorClasses}>
+                    {error}
+                </p>
+            ) : null}
+        </div>
+    )
+}

--- a/apps/caramel-app/src/components/auth/SocialSignIn.tsx
+++ b/apps/caramel-app/src/components/auth/SocialSignIn.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { socialButtonClasses } from '@/components/auth/authStyles'
+import { signIn } from '@/lib/auth/client'
+import { useState } from 'react'
+import { FaApple } from 'react-icons/fa'
+import { FcGoogle } from 'react-icons/fc'
+import { toast } from 'sonner'
+
+type Provider = 'google' | 'apple'
+
+const PROVIDER_LABEL: Record<Provider, string> = {
+    google: 'Google',
+    apple: 'Apple',
+}
+
+/**
+ * Google + Apple buttons, shared by every auth page.
+ *
+ * The handler was previously duplicated in LoginPageClient and
+ * SignupPageClient with only the toast wording differing. `verb` covers that
+ * difference so there is one implementation of the redirect and its failure
+ * handling.
+ *
+ * The Google mark is FcGoogle (the official four-colour G). It used to be
+ * FaGoogle tinted `text-caramel`, i.e. a recoloured Google logo — which
+ * Google's own branding guidelines for "Sign in with Google" do not permit.
+ */
+export default function SocialSignIn({
+    verb = 'Sign in',
+    callbackURL = '/',
+}: {
+    verb?: 'Sign in' | 'Sign up'
+    callbackURL?: string
+}) {
+    const [pending, setPending] = useState<Provider | null>(null)
+
+    const handle = async (provider: Provider) => {
+        setPending(provider)
+        try {
+            const result = await signIn.social({ provider, callbackURL })
+            if (result?.error) {
+                toast.error(
+                    `Unable to continue with ${PROVIDER_LABEL[provider]}. Please try again.`,
+                )
+                setPending(null)
+                return
+            }
+            // On success signIn.social navigates away to the provider, so the
+            // pending state intentionally stays set until the page unloads.
+        } catch {
+            toast.error('Something went wrong. Please try again later.')
+            setPending(null)
+        }
+    }
+
+    return (
+        <div className="space-y-3">
+            <button
+                type="button"
+                onClick={() => handle('google')}
+                disabled={!!pending}
+                className={socialButtonClasses}
+            >
+                <FcGoogle aria-hidden="true" className="h-5 w-5" />
+                <span>
+                    {pending === 'google'
+                        ? 'Redirecting…'
+                        : `${verb} with Google`}
+                </span>
+            </button>
+            <button
+                type="button"
+                onClick={() => handle('apple')}
+                disabled={!!pending}
+                className={socialButtonClasses}
+            >
+                <FaApple
+                    aria-hidden="true"
+                    className="h-5 w-5 text-gray-900 dark:text-gray-100"
+                />
+                <span>
+                    {pending === 'apple'
+                        ? 'Redirecting…'
+                        : `${verb} with Apple`}
+                </span>
+            </button>
+        </div>
+    )
+}

--- a/apps/caramel-app/src/components/auth/authStyles.ts
+++ b/apps/caramel-app/src/components/auth/authStyles.ts
@@ -1,0 +1,28 @@
+/**
+ * One source of truth for auth-form styling.
+ *
+ * These exact class strings previously existed twice, character-for-character,
+ * in LoginPageClient and SignupPageClient. Two copies is how the two pages drift
+ * apart, and adding /forgot-password and /reset-password would have made four.
+ * Any visual change to auth inputs now happens here once.
+ */
+
+export const inputClasses =
+    'w-full rounded-xl border border-gray-300 bg-white px-4 py-3 text-gray-900 shadow-sm transition duration-200 placeholder:text-gray-400 hover:border-gray-400 focus:border-caramel focus:outline-none focus:ring-2 focus:ring-caramel/30 dark:border-gray-700 dark:bg-darkBg dark:text-gray-100 dark:shadow-none dark:placeholder:text-gray-500 dark:hover:border-gray-600 dark:focus:border-caramel'
+
+/** Same as `inputClasses` but leaves room for the trailing reveal button. */
+export const inputWithAffordanceClasses = `${inputClasses} pr-12`
+
+export const labelClasses =
+    'mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300'
+
+export const socialButtonClasses =
+    'flex w-full items-center justify-center gap-3 rounded-xl border border-gray-300 bg-white px-4 py-3 font-medium text-gray-700 shadow-sm transition duration-200 hover:border-caramel hover:bg-caramel/5 active:bg-caramel/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/50 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:bg-darkBg dark:text-gray-200 dark:shadow-none dark:hover:border-caramel/60 dark:hover:bg-caramel/10 dark:active:bg-caramel/15 dark:focus-visible:ring-offset-darkerBg'
+
+export const primaryButtonClasses =
+    'w-full rounded-xl bg-caramel py-3 font-semibold text-white shadow-sm transition duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel focus-visible:ring-offset-2 enabled:hover:bg-caramel/90 enabled:hover:shadow-caramel-sm enabled:active:bg-caramel disabled:cursor-not-allowed disabled:opacity-60 dark:focus-visible:ring-offset-darkerBg'
+
+export const linkClasses =
+    'rounded-sm font-semibold text-caramel underline-offset-2 transition hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/50'
+
+export const fieldErrorClasses = 'mt-1.5 text-sm text-red-600 dark:text-red-400'

--- a/apps/caramel-app/src/lib/auth/auth.ts
+++ b/apps/caramel-app/src/lib/auth/auth.ts
@@ -1,3 +1,4 @@
+import ResetPasswordTemplate from '@/emails/ResetPasswordTemplate'
 import VerificationRequestTemplate from '@/emails/VerificationRequestTemplate'
 import { sendEmail } from '@/lib/email'
 import { env } from '@/lib/env'
@@ -37,6 +38,34 @@ export const auth = betterAuth({
     emailAndPassword: {
         enabled: true,
         requireEmailVerification: true,
+        // Until this landed there was NO password recovery at all: no
+        // sendResetPassword here, no /forgot-password route, and no client
+        // call to forgetPassword — so an email+password user who forgot their
+        // password was permanently locked out of their account with no
+        // self-serve way back in and no support flow to hand them.
+        //
+        // The send failure is handled exactly like the verification email
+        // above, and for the same reason: Better Auth swallows what this
+        // callback throws, so a broken mailer would otherwise look like a
+        // successful request to both the shopper and to us.
+        sendResetPassword: async ({ user, url }) => {
+            try {
+                const html = await render(ResetPasswordTemplate({ url }))
+                await sendEmail({
+                    to: user.email,
+                    subject: 'Reset your Caramel password',
+                    html,
+                })
+            } catch (error) {
+                console.error('reset password email send failed:', error)
+                Sentry.captureException(error, {
+                    tags: { surface: 'auth-reset-password-email' },
+                    extra: { userEmail: user.email },
+                })
+                await Sentry.flush(2000)
+                throw error
+            }
+        },
         password: {
             hash: async (password: string) => bcrypt.hash(password, saltRounds),
             verify: async ({

--- a/apps/caramel-app/src/lib/auth/client.ts
+++ b/apps/caramel-app/src/lib/auth/client.ts
@@ -18,3 +18,9 @@ export const signIn = {
 export const signUp = authClient.signUp
 export const signOut = authClient.signOut
 export const useSession = authClient.useSession
+
+/** Sends the reset email. Named `forgetPassword` in older Better Auth; this
+ *  project is pinned to 1.6.23, where the endpoint is /request-password-reset. */
+export const requestPasswordReset = authClient.requestPasswordReset
+/** Consumes the token from that email and sets the new password. */
+export const resetPassword = authClient.resetPassword

--- a/apps/caramel-app/src/lib/passwordRules.ts
+++ b/apps/caramel-app/src/lib/passwordRules.ts
@@ -1,0 +1,60 @@
+/**
+ * The password policy, in one place.
+ *
+ * It previously existed twice: as a yup schema in SignupPageClient and as a
+ * hand-written checklist in PasswordChecker. They had already drifted — the
+ * checklist ticked "minimum length reached" at 5 characters, and any change to
+ * one copy silently left the other lying to the shopper. The reset-password
+ * flow is a third consumer, so this is now the only definition.
+ *
+ * Raised 5 -> 8 characters with this consolidation. It applies to newly-set
+ * passwords only (signup and reset); existing accounts are unaffected because
+ * sign-in never re-validates against the policy.
+ */
+
+export const MIN_PASSWORD_LENGTH = 8
+
+export const PASSWORD_UPPERCASE = /[A-Z]/
+export const PASSWORD_NUMBER = /[0-9]/
+export const PASSWORD_SPECIAL = /[!@#$%^&*+-]/
+
+export type PasswordRule = {
+    id: string
+    test: (password: string) => boolean
+    /** Shown in the checklist once satisfied. */
+    success: string
+    /** Shown in the checklist while unsatisfied, and as the form-level error. */
+    failure: string
+}
+
+export const passwordRules: PasswordRule[] = [
+    {
+        id: 'length',
+        test: password => password.length >= MIN_PASSWORD_LENGTH,
+        success: `At least ${MIN_PASSWORD_LENGTH} characters`,
+        failure: `Use at least ${MIN_PASSWORD_LENGTH} characters`,
+    },
+    {
+        id: 'uppercase',
+        test: password => PASSWORD_UPPERCASE.test(password),
+        success: 'At least one uppercase letter',
+        failure: 'Add at least one uppercase letter',
+    },
+    {
+        id: 'number',
+        test: password => PASSWORD_NUMBER.test(password),
+        success: 'At least one number',
+        failure: 'Add at least one number',
+    },
+    {
+        id: 'special',
+        test: password => PASSWORD_SPECIAL.test(password),
+        success: 'At least one special character',
+        failure: 'Add at least one special character (!@#$%^&*+-)',
+    },
+]
+
+/** First unmet rule, or undefined when the password satisfies the policy. */
+export function firstPasswordFailure(password: string): string | undefined {
+    return passwordRules.find(rule => !rule.test(password))?.failure
+}

--- a/apps/caramel-app/tests/unit/auth-routes-layoutless.test.ts
+++ b/apps/caramel-app/tests/unit/auth-routes-layoutless.test.ts
@@ -1,0 +1,74 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * providers.tsx keeps a hand-written list of routes that must NOT be wrapped in
+ * the marketing Layout. The (auth) group renders its own full-screen shell, so
+ * a route missing from that list gets both: two headers, two theme toggles, and
+ * a site footer underneath the sign-in form.
+ *
+ * That is not hypothetical — /forgot-password and /reset-password were added on
+ * 2026-08-09 and shipped exactly that way until an e2e snapshot showed the
+ * marketing banner above the form. A hand-maintained list next to a filesystem
+ * router will drift again, so this derives the truth from the directory.
+ */
+
+const appDir = path.resolve(__dirname, '../../src/app')
+const authDir = path.join(appDir, '(auth)')
+const providersFile = path.join(appDir, 'providers.tsx')
+
+function authRoutes(): string[] {
+    return fs
+        .readdirSync(authDir, { withFileTypes: true })
+        .filter(entry => entry.isDirectory())
+        .filter(entry =>
+            ['page.tsx', 'page.ts'].some(file =>
+                fs.existsSync(path.join(authDir, entry.name, file)),
+            ),
+        )
+        .map(entry => `/${entry.name}`)
+}
+
+function declaredLayoutlessRoutes(): string[] {
+    const source = fs.readFileSync(providersFile, 'utf8')
+    const match = source.match(
+        /const pagesLayoutless = useMemo\(\s*\(\)\s*=>\s*\[([\s\S]*?)\]/,
+    )
+    if (!match) {
+        throw new Error(
+            'Could not find the pagesLayoutless array in providers.tsx — update this test if it was renamed.',
+        )
+    }
+    // exec loop rather than [...matchAll]: this package's tsc target does not
+    // allow iterating a RegExpStringIterator (TS2802).
+    const routes: string[] = []
+    const pattern = /'([^']+)'/g
+    let entry: RegExpExecArray | null
+    while ((entry = pattern.exec(match[1])) !== null) {
+        routes.push(entry[1])
+    }
+    return routes
+}
+
+describe('auth route group is layoutless', () => {
+    it('finds the auth routes on disk', () => {
+        // Guards the guard: a glob that silently matches nothing would make
+        // every assertion below vacuously true.
+        expect(authRoutes().length).toBeGreaterThanOrEqual(5)
+    })
+
+    it('lists every (auth) route in pagesLayoutless', () => {
+        const declared = declaredLayoutlessRoutes()
+        const missing = authRoutes().filter(route => !declared.includes(route))
+        expect(missing).toEqual([])
+    })
+
+    it('does not list routes that no longer exist', () => {
+        const routes = authRoutes()
+        const stale = declaredLayoutlessRoutes().filter(
+            route => !routes.includes(route),
+        )
+        expect(stale).toEqual([])
+    })
+})


### PR DESCRIPTION
The login and signup pages were two mismatched cards floating in a mostly empty
viewport. Reworking them surfaced a bigger problem: **there was no password
recovery at all.**

## The gap this closes

`emailAndPassword` had no `sendResetPassword`, there was no `/forgot-password`
or `/reset-password` route, and nothing in the app ever called
`requestPasswordReset`. An email+password user who forgot their password was
permanently locked out — no self-serve path, no support flow. The login form had
no "Forgot password?" link because there was nothing to link to.

Now: link on the form → `/forgot-password` → emailed link (new
`ResetPasswordTemplate`, 1 hour, single use) → `/reset-password` → done. The send
failure is reported to Sentry and rethrown, matching how the verification email
was hardened after the 2026-08-08 cutover, because Better Auth swallows what
that callback throws.

## Design

Full-height split: brand panel owns the left edge (keeping the coupon-ticket
perforation), the form gets its own column. Verified at 1440px light + dark and
390px, where the panel is replaced by a compact logo header.

- A real `<h1>` per page. Every auth page previously opened at `<h2>` with **no
  `<h1>` in the document**, and the old heading inlined a 90px logo image
  mid-sentence ("Sign in to `[logo]`") so its accessible name depended on that
  image's alt text.
- Password fields get a reveal toggle — a real `<button>` with `aria-pressed`.
- Failures show in the form, not only in a toast that has already dismissed.
- Titles/descriptions rewritten. Signup's was "Join Caramel and start enjoying
  our services", which could describe any product; it now names the category,
  the price, and the differentiator. `/forgot-password` and `/reset-password`
  are `noindex` — the reset URL carries a single-use token as a query parameter.

## Defects found and fixed along the way

- **The new routes rendered the marketing Header *and* Footer** on top of the
  auth shell — two headers, two theme toggles, a site footer under the form —
  because `providers.tsx` keeps a hand-written list of layoutless routes next to
  a filesystem router. Fixed, and `tests/unit/auth-routes-layoutless.test.ts`
  now derives the route list from disk so the next added route fails the build
  instead of shipping wrong.
- **The password policy existed twice and had already drifted.** The checklist
  ticked "minimum length reached" at 5 characters while the schema demanded
  more, so a shopper could see every item green and still be rejected. Both now
  read `@/lib/passwordRules` (raised to 8, applies to newly-set passwords only).
- **yup printed raw regexes at shoppers.** Rules carried no messages, so a
  lowercase-only password was answered with `password must match the following:
  /[A-Z]/`. Every rule has real copy now, pinned by a test.
- **The verify page reported success on failed resends.** The Better Auth client
  *returns* `{ error }` rather than throwing, so the `try/catch` never saw a
  failure and every call said "Verification email sent!" — the same silent-send
  shape that hid the broken verification path during the cutover.
- The Google button used `FaGoogle` recoloured `text-caramel`, which Google's
  branding rules for "Sign in with Google" do not permit. It is the real
  four-colour mark now.
- Input classes and the social-sign-in handler were duplicated verbatim across
  login and signup; two new pages would have made it four copies. Consolidated
  into `src/components/auth/`.

## Verification

- `tsc --noEmit`, `eslint .`, prettier: clean
- `vitest run` — **530 passed / 63 files** (3 new)
- `playwright test e2e/auth.spec.ts e2e/auth-flows.spec.ts` — **45 passed**,
  including the real-session login that seeds a verified user and asserts an
  authenticated `/profile`

Existing specs were retargeted at the new copy, keeping each assertion's intent,
plus new coverage for the reveal toggle, the reset route, the single `<h1>`, the
stated minimum length, the no-raw-regex rule, the layoutless shell on all five
routes, and that `/forgot-password` answers identically whether or not the
address is registered (it must not become an account-enumeration oracle).

Argos will flag the login/signup visual baselines — that is the redesign, and
those snapshots need a human to accept them.
