### PR TITLE
fix(ci): visual baselines captured Next's dev indicator, so every build reported changes

### DIFF
--- a/apps/caramel-app/next.config.mjs
+++ b/apps/caramel-app/next.config.mjs
@@ -65,6 +65,17 @@ const nextConfig = {
     // workspace deps correctly.
     output: 'standalone',
     outputFileTracingRoot: workspaceRoot,
+    // The visual-regression job screenshots a `next dev` server, and dev mode
+    // paints Next's on-screen dev indicator (a dark "N" badge, position:fixed
+    // bottom-left) INTO every full-page capture. It shows or hides depending on
+    // compile activity at capture time, so it landed in some baselines and not
+    // others — 918 of the 1145 changed pixels in Snapvisor build #254's
+    // home-page diff were that badge alone. That is why builds on branches which
+    // touch no app code at all (PR #160 changed one workflow file) still
+    // reported 8/8 snapshots changed: the visual gate was reporting its own
+    // overlay, not the product. Hidden only under CI so local dev keeps it;
+    // compile/runtime errors are still reported either way.
+    ...(process.env.CI ? { devIndicators: false } : {}),
     turbopack: {
         root: workspaceRoot,
     },


### PR DESCRIPTION
## What was wrong

Snapvisor has been reporting **8/8 snapshots changed on every build**, including builds on branches that touch no application code at all — PR #160 changed exactly one file (`.github/workflows/watch-store-versions.yml`) and still reported all 8 pages as visually changed. A gate that is always red is a gate nobody reads, and `main` builds auto-approve, so baselines have been drifting unreviewed.

## Root cause

I pulled the diff mask for `chromium/home-page.png` from build #254 and measured it: **1,145 changed pixels out of 13,184,000 (0.009%)**, in four clusters.

| cluster | pixels | what it is |
| --- | ---: | --- |
| y 663–700, x 19–56 | **918** | Next.js dev indicator (dark "N" badge) |
| y 8125–8180 | 162 | text anti-aliasing, identical glyphs |
| y 53–87 | 49 | logo anti-aliasing |
| remainder | 16 | anti-aliasing |

The visual job runs `PLAYWRIGHT_WEB_COMMAND: pnpm dev`, so it screenshots a **dev-mode** server. Next paints its on-screen dev indicator (`position: fixed`, bottom-left) into every full-page capture, and it shows or hides depending on compile activity at capture time — so it is in some baselines and absent from others. 80% of all reported "visual change" was the tooling photographing its own overlay.

## Fix

`devIndicators: false`, gated on `CI` so local development keeps the badge. Verified both branches load correctly:

- `CI=true node -e "import('./next.config.mjs')"` → `devIndicators = false`
- unset → `devIndicators = undefined`

Compile and runtime errors are still reported with the indicator hidden (documented Next behaviour).

## Not fixed here

The residual ~227px of anti-aliasing variance still trips the comparison, and the job screenshots dev mode rather than a production build — so the baselines are not what users actually see. Both are follow-ups, not blockers.

Build #254 (the auth redesign) has been reviewed and approved manually: the login/signup diffs are the intended redesign, the other six were this noise.