### PR TITLE
ci: fail main's E2E in seconds with the real reason when prod is serving an older commit

### DIFF
--- a/.github/workflows/checks-app.yml
+++ b/.github/workflows/checks-app.yml
@@ -402,20 +402,31 @@ jobs:
       # failed at 14:40:44Z, two seconds before the deploy carrying its fix
       # finished at 14:40:46Z. Wait for the site to report this exact commit.
       #
-      # dev only: dev.grabcaramel.com is the root docker-compose/Dockerfile
-      # build, whose context carries the git metadata /api/version is stamped
-      # from. Prod is a Dokploy *Nixpacks* app built from apps/caramel-app,
-      # whose context excludes the repo's .git — it answers "unknown" and this
-      # gate could never pass there. Drop the condition when prod moves onto
-      # the root compose (RUNBOOK "Deploys & rollback").
+      # Both branches now, not dev only. The old condition existed because prod
+      # was a Dokploy *Nixpacks* app whose build context excluded the repo's
+      # .git, so /api/version answered "unknown" and this gate could never pass
+      # — with the standing note to drop it "when prod moves onto the root
+      # compose". That happened on 2026-08-08: grabcaramel.com IS the compose
+      # stack and answers a real sha.
+      #
+      # The two branches need OPPOSITE timeouts, because they deploy in
+      # opposite ways:
+      #   dev  — autodeploy ON. Wait out a real build (a push burst can queue
+      #          one behind another), so 1200s.
+      #   main — autoDeploy is OFF BY DESIGN on the prod compose. No deploy is
+      #          coming, so waiting is pure latency: poll once and fail with the
+      #          exact reason. Before this, a merge that changed any asserted
+      #          copy surfaced as ~13 `locator.fill: Test timeout` errors after
+      #          ~30 minutes (2026-08-09, the auth redesign) — all of which
+      #          meant only "prod is still serving an older commit".
       - name: Wait for the deployment to carry this commit
-        if: github.ref == 'refs/heads/dev'
         env:
-          VERSION_URL: https://dev.grabcaramel.com/api/version
-          EXPECTED_SHA: ${{ github.sha }}
-          # One full Docker build is ~10 min; a push burst queues builds
-          # back-to-back, so one queued-behind build fits inside 20.
-          DEPLOY_WAIT_TIMEOUT_SECONDS: '1200'
+          VERSION_URL: "${{ github.ref == 'refs/heads/dev' && 'https://dev.grabcaramel.com/api/version' || 'https://grabcaramel.com/api/version' }}"
+          EXPECTED_SHA: '${{ github.sha }}'
+          DEPLOY_WAIT_TIMEOUT_SECONDS: "${{ github.ref == 'refs/heads/dev' && '1200' || '0' }}"
+          # Quoted: the prod branch of this expression contains ': ', which YAML
+          # would otherwise read as a nested mapping key.
+          DEPLOY_WAIT_HINT: "${{ github.ref == 'refs/heads/dev' && '' || 'Prod deploys are MANUAL: the Dokploy prod compose has autoDeploy OFF by design, so merging to main never reaches grabcaramel.com. This is not a failed deploy and not a broken build — the E2E suite runs against the LIVE site, so it cannot verify a commit prod is not serving. Deploy the prod compose, then re-run this job.' }}"
         run: bash .github/workflows/scripts/wait-for-deploy.sh
 
       - name: Run E2E tests

--- a/.github/workflows/scripts/wait-for-deploy.sh
+++ b/.github/workflows/scripts/wait-for-deploy.sh
@@ -14,6 +14,10 @@
 #   EXPECTED_SHA  - the commit CI checked out (github.sha)
 #   DEPLOY_WAIT_TIMEOUT_SECONDS   - optional, default 600
 #   DEPLOY_WAIT_INTERVAL_SECONDS  - optional, default 15
+#   DEPLOY_WAIT_HINT              - optional, printed verbatim on failure. For
+#                                   branches whose deploy is MANUAL, the generic
+#                                   "the deploy failed or is slow" guidance below
+#                                   is wrong; this is where a branch says so.
 #
 # Nothing here passes on a missing or mismatched sha. A 404 counts as "not
 # deployed yet", never as a pass: the deploy that carries this commit is also
@@ -115,5 +119,9 @@ timeout — check the platform's deployment log.
 EOF
     ;;
 esac
+
+if [ -n "${DEPLOY_WAIT_HINT:-}" ]; then
+    printf '\n%s\n' "$DEPLOY_WAIT_HINT"
+fi
 
 exit 1


### PR DESCRIPTION
## The problem

`CI Checks – App` went red on `main` at 6659e7d and the failure was unreadable: **13 × `locator.fill: Test timeout of 30000ms exceeded`, after ~30 minutes.** None of that says what actually happened.

What actually happened: the `e2e-push` job runs the suite against **`https://grabcaramel.com` — the live site**, and prod's Dokploy compose has `autoDeploy: false` by design. `grabcaramel.com/api/version` reports `5acf5af`; main is `6659e7d`. Five commits behind. The auth redesign (#162) was the first merge to change copy the specs assert on, so the suite correctly reported that prod does not serve it — just illegibly, and slowly.

The app is fine: the PR job ran the same suite against the actual code and got **130 E2E passed, 530 unit passed**.

## The fix

The job already has `wait-for-deploy.sh`. It was gated `if: github.ref == 'refs/heads/dev'` with a standing note to drop the condition *"when prod moves onto the root compose"* — which happened on 2026-08-08. Prod is the compose stack now and `/api/version` answers a real sha, so the gate finally works there.

The two branches need opposite timeouts, because they deploy in opposite ways:

| branch | deploy | timeout | rationale |
| --- | --- | ---: | --- |
| `dev` | autodeploy ON | 1200s | wait out a real build; a push burst queues one behind another |
| `main` | **manual** | 0s | no deploy is coming — waiting is pure latency |

Plus a new optional `DEPLOY_WAIT_HINT`, because the script's generic "the deploy failed or is slower than the timeout" guidance is actively wrong for a branch whose deploy is manual.

## Proof

Run by hand against live prod — all three paths:

```
# stale prod, hint set
Last observed: serving 5acf5af7f8d738300c1d3b176b3abf1150f61e1a
Prod deploys are MANUAL: autoDeploy OFF by design.
--- exit=1 elapsed=1s

# real prod sha
Deployment is serving 5acf5af… after 1 poll(s) — running E2E against it.
exit=0

# fail path, hint unset -> no blank block appended
exit=1
```

**1 second instead of ~30 minutes**, exit 1, naming the exact commit prod serves.

`python -c "yaml.safe_load(...)"` confirms the workflow parses and the step is now unconditional with branch-aware env. Note the `on:` block only pushes `main` and `dev`, so the `||` fallback can only ever mean prod.

## What this does NOT do

It does not make main green — nothing can, except deploying. It converts a confusing 30-minute red into an accurate 30-second one. **#161 (rate limiter) and #162 (auth + password reset) are still undeployed.**

Also note this PR's own CI exercises `e2e-pr`, not `e2e-push`, so the changed step does not run here — hence the by-hand proof above.