### PR TITLE
test(e2e): signup redirect wait was tighter than a cold /verify page load

### DIFF
--- a/apps/caramel-app/e2e/auth-flows.spec.ts
+++ b/apps/caramel-app/e2e/auth-flows.spec.ts
@@ -180,8 +180,13 @@ test.describe('Auth Flows — Signup', () => {
             .getByRole('button', { name: 'Create account', exact: true })
             .click()
 
-        // Uses window.location.href so wait for navigation
-        await page.waitForURL('**/verify?signup=success', { timeout: 10000 })
+        // Uses window.location.href so wait for navigation. 30s, not 10s:
+        // against the DEPLOYED site this waits for /verify's full `load` event
+        // on a cold first attempt (fonts, analytics), and 10s made this the
+        // suite's one flaky test twice in a row on 2026-08-09 — while a live
+        // measurement put the signup POST itself at 0.8s, so the app is fast
+        // and the old budget was simply tighter than a cold page load.
+        await page.waitForURL('**/verify?signup=success', { timeout: 30000 })
     })
 
     test('signup with existing email shows error toast', async ({ page }) => {


### PR DESCRIPTION
The one flaky test on main's deployed-site suite, twice in a row (runs at 197123f): signup's waitForURL('**/verify?signup=success') at 10s. Live measurement: the signup POST itself is 0.8s — the wait covers /verify's full load event on a cold first attempt (fonts, analytics), which occasionally exceeds 10s. Raised to 30s, matching the same fix already applied to the login spec in #162. The redirect mechanism is proven (passes on retry every time, and failOnFlakyTests keeps flakes visible).