### PR TITLE
fix(extension): popup nulled every real store because the worker sent a hostname where the guard expects a URL

### DIFF
--- a/apps/caramel-extension/background.js
+++ b/apps/caramel-extension/background.js
@@ -371,39 +371,22 @@ currentBrowser.runtime.onMessage.addListener(
                         return
                     }
 
-                    const tab = tabs[0]
-                    const tabUrl = tab.url || ''
-
-                    // Don't inject into extension pages (popup, options, etc.)
-                    if (
-                        tabUrl.startsWith('chrome-extension://') ||
-                        tabUrl.startsWith('moz-extension://') ||
-                        tabUrl.startsWith('safari-web-extension://')
-                    ) {
-                        // For extension pages, just return the URL without injecting
-                        try {
-                            const url = new URL(tabUrl)
-                            sendResponse({
-                                domainRecord: null,
-                                url: url.hostname,
-                            })
-                        } catch {
-                            sendResponse({ domainRecord: null, url: null })
-                        }
-                        return
-                    }
-
-                    // Content scripts are injected by manifest. Use tab URL directly
-                    // to avoid reinjection and duplicate declaration errors.
-                    try {
-                        const hostname = tabUrl
-                            ? new URL(tabUrl).hostname
-                            : null
-                        sendResponse({ domainRecord: null, url: hostname })
-                    } catch (err) {
-                        logError('hostname from tab URL', err)
-                        sendResponse({ domainRecord: null, url: null })
-                    }
+                    // CONTRACT: `url` is the tab's FULL URL (scheme included),
+                    // never a bare hostname. The popup's non-web-tab guard
+                    // (popup.js, `/^https?:\/\//`) is the sole consumer and the
+                    // scheme is the only thing that lets it tell a store page
+                    // from chrome://, about:, or this extension's own pages.
+                    // This handler used to answer `new URL(tabUrl).hostname` —
+                    // "www.ebay.com" — which that guard nulled as a non-web
+                    // tab, so the popup skipped its coupon fetch and showed
+                    // the empty "Ready when you are" state on every real store
+                    // (found live on eBay iOS, 2026-08-09). Pinned by
+                    // tests/popup-tab-url-contract.test.mjs, which runs THIS
+                    // handler against the popup's real guard.
+                    sendResponse({
+                        domainRecord: null,
+                        url: tabs[0].url || null,
+                    })
                 },
             )
 

--- a/apps/caramel-extension/popup.js
+++ b/apps/caramel-extension/popup.js
@@ -262,10 +262,11 @@ async function initPopup() {
             // show an honest error state with a retry, NEVER leave the popup blank.
             try {
                 if (url) {
-                    const domain = url.replace(
-                        /^(?:https?:\/\/)?(?:www\.)?/,
-                        '',
-                    )
+                    // url is the tab's FULL URL (background.js's
+                    // getActiveTabDomainRecord contract) — parse it rather than
+                    // regex-stripping, or the path/query would ride along into
+                    // the coupons API's site parameter.
+                    const domain = new URL(url).hostname.replace(/^www\./, '')
                     let coupons = []
                     try {
                         coupons = await fetchCoupons(domain, '')

--- a/apps/caramel-extension/tests/popup-tab-url-contract.test.mjs
+++ b/apps/caramel-extension/tests/popup-tab-url-contract.test.mjs
@@ -1,0 +1,146 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+import {
+    getOnMessageListeners,
+    loadExtensionSource,
+    loadExtensionSources,
+} from './_load.mjs'
+
+// Producer/consumer CONTRACT pin for getActiveTabDomainRecord — born from a
+// live bug (eBay, iOS Safari, 2026-08-09): background.js answered with
+// `new URL(tabUrl).hostname` ("www.ebay.com") while popup.js's non-web-tab
+// guard (`/^https?:\/\//`) requires a scheme, so EVERY real store nulled to
+// "no active tab" and the popup skipped its coupon fetch — showing the
+// "Ready when you are" empty state (plus a Log in button) on sites the
+// extension had just flagged as having coupons. The store had 96 live eBay
+// coupons at the time; nothing was wrong server-side.
+//
+// Every other popup suite stubs the service worker with a hand-written
+// payload (`cb({ url: 'https://example.com/cart' })`), which is exactly how
+// the drift stayed invisible: the fixtures described the contract, the
+// producer broke it, and no test ran the two against each other. This suite
+// closes that hole by capturing the REAL background.js handler's response
+// and feeding it — unedited — to the REAL popup.
+//
+// (jsdom lacks a service-worker realm, so producer and consumer are loaded
+// into separate stub realms and bridged by replaying the captured payload —
+// the payload itself is never hand-authored.)
+
+const STORE_TAB_URL = 'https://www.ebay.com/itm/1234567890?campid=abc'
+const NON_WEB_TAB_URL = 'chrome://newtab/'
+
+/** Runs the real background.js onMessage handler for a tab whose full URL is
+ * `tabUrl` and resolves with the getActiveTabDomainRecord payload. */
+function captureProducerPayload(tabUrl) {
+    loadExtensionSource('background.js', [])
+    const [handler] = getOnMessageListeners()
+    globalThis.chrome.tabs.query = (_query, cb) => cb([{ url: tabUrl }])
+    return new Promise(resolve =>
+        handler({ action: 'getActiveTabDomainRecord' }, {}, resolve),
+    )
+}
+
+/** Loads the real popup stack, replays `payload` as the service worker's
+ * getActiveTabDomainRecord answer, runs initPopup(), and reports what the
+ * popup did: which site (if any) it fetched coupons for, and which view
+ * landed in the DOM. */
+async function runPopupAgainst(payload) {
+    document.body.innerHTML =
+        '<div id="loading-container"></div><div id="auth-container"></div>'
+
+    // Same load order as index.html / the manifests (see popup.test.mjs).
+    loadExtensionSource('coupon-constants.generated.js', [])
+    loadExtensionSources(
+        [
+            'caramel-base.js',
+            'dom-utils.js',
+            'store-detect.js',
+            'coupon-apply.js',
+            'coupon-fetch.js',
+            'coupon-runner.js',
+        ],
+        [],
+    )
+
+    const observed = { fetchedSite: null }
+    globalThis.currentBrowser.runtime.sendMessage = (message, cb) => {
+        if (message?.action === 'getActiveTabDomainRecord') {
+            cb(payload)
+        } else if (message?.action === 'fetchCoupons') {
+            observed.fetchedSite = message.site
+            cb({
+                coupons: [
+                    {
+                        id: 1,
+                        code: 'CONTRACT10',
+                        title: '10% off',
+                        status: 'valid',
+                    },
+                ],
+            })
+        } else {
+            cb(undefined)
+        }
+    }
+    globalThis.currentBrowser.storage.sync.get = (_keys, cb) => cb({})
+
+    const { initPopup } = loadExtensionSource('popup.js', ['initPopup'])
+
+    // initPopup resolves before its async render chain finishes (see
+    // popup.test.mjs's waitForRenderLoadError note) — wrap the three terminal
+    // render functions for a deterministic completion signal.
+    const rendered = new Promise(resolve => {
+        for (const name of [
+            'renderCouponsView',
+            'renderUnsupportedSite',
+            'renderProfileCard',
+            'renderLoadError',
+        ]) {
+            const original = globalThis[name]
+            globalThis[name] = (...args) => {
+                const result = original(...args)
+                resolve(name)
+                return result
+            }
+        }
+    })
+
+    await initPopup()
+    const view = await rendered
+    return {
+        observed,
+        view,
+        html: document.getElementById('auth-container').innerHTML,
+    }
+}
+
+describe('getActiveTabDomainRecord producer/consumer contract', () => {
+    let storePayload
+    let nonWebPayload
+
+    beforeAll(async () => {
+        // Capture both payloads from the REAL producer up front — each
+        // loadExtensionSource call installs a fresh chrome stub, so the
+        // producer runs are done before any popup realm is built.
+        storePayload = await captureProducerPayload(STORE_TAB_URL)
+        nonWebPayload = await captureProducerPayload(NON_WEB_TAB_URL)
+    })
+
+    it('producer answers with the FULL tab URL (scheme included), never a bare hostname', () => {
+        expect(storePayload.url).toBe(STORE_TAB_URL)
+    })
+
+    it('a store tab renders the coupon list, fetching by hostname without www/path/query', async () => {
+        const { observed, view, html } = await runPopupAgainst(storePayload)
+        expect(observed.fetchedSite).toBe('ebay.com')
+        expect(view).toBe('renderCouponsView')
+        expect(html).toContain('CONTRACT10')
+        // The empty state that shipped to eBay users must not be what renders.
+        expect(html).not.toContain('View Supported Stores')
+    })
+
+    it('a non-web tab still lands on the introduction view without fetching (PR #143 behavior preserved)', async () => {
+        const { observed, view } = await runPopupAgainst(nonWebPayload)
+        expect(observed.fetchedSite).toBeNull()
+        expect(view).toBe('renderUnsupportedSite')
+    })
+})


### PR DESCRIPTION
## The bug (user-reported, live on eBay mobile)

On a store the extension had just flagged as having coupons, opening the popup showed the generic empty state — "Ready when you are" + "View Supported Stores" + "Log in" — with no coupon list and no way to copy codes. Reported on iOS Safari; actually live on **every platform** since Aug 7.

Root cause is a producer/consumer contract break:

- `background.js`'s `getActiveTabDomainRecord` answered with `new URL(tabUrl).hostname` — a bare hostname like `www.ebay.com`
- `popup.js`'s non-web-tab guard (added in #143 to greet chrome:// pages instead of blaming the connection) tests `/^https?:\/\//` — which a bare hostname always fails

So the popup nulled the site on **every real store**, skipped the coupon fetch entirely, and fell into the no-site empty state. Logging in didn't help (that view has no coupon list either). Server-side was fine — eBay had 96 live coupons at the time. The guest coupon list with working Copy buttons already existed; this guard just made it unreachable.

## Why CI stayed green

Every popup suite stubs the worker with a hand-written payload — `cb({ url: 'https://example.com/cart' })` — i.e. the fixtures described the intended contract while the real producer broke it, and nothing ever ran the two against each other.

## The fix

Producer-side: the handler now answers with the tab's **full URL** (scheme included), which is also the only shape that lets the guard do its actual job — bare hostnames can't distinguish a store from `chrome://newtab` (whose hostname parse yields junk like `newtab`). The popup's domain derivation switches from regex-stripping to `new URL(url).hostname`, so paths/queries can't leak into the coupons API's `site` param. The two previously-divergent branches (extension pages vs web pages) collapse into one honest answer.

The existing fixtures now match the real producer instead of accidentally diverging from it.

## The guard test

`tests/popup-tab-url-contract.test.mjs` — captures the payload from the **real** `background.js` handler and feeds it, unedited, to the **real** popup:

1. producer answers with the full tab URL, never a hostname
2. a store tab renders the coupon list, fetching `ebay.com` (no www/path/query)
3. a `chrome://` tab still lands on the introduction view without fetching (#143 behavior preserved)

**Red-proofed**: with the fix stashed, the contract test fails against the old producer; with it, 666/666 extension tests pass.

## Ships in

Should ride the next extension release train (1.3.1/1.4.0): the bug is in Firefox 1.3.0 (public), the Chrome 1.3.0 draft (publish deferred), and the Aug-8 TestFlight builds. Chrome's live 1.1.0 predates it.