### PR TITLE
feat(api): withRoute auth 'optional' mode + the three login-features tables

### DIFF
--- a/apps/caramel-app/prisma/migrations/20260809204144_login_features_foundation/migration.sql
+++ b/apps/caramel-app/prisma/migrations/20260809204144_login_features_foundation/migration.sql
@@ -1,0 +1,60 @@
+-- CreateTable
+CREATE TABLE "public"."coupon_reports" (
+    "id" TEXT NOT NULL,
+    "coupon_id" TEXT NOT NULL,
+    "user_id" TEXT,
+    "outcome" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "coupon_reports_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."favorite_stores" (
+    "user_id" TEXT NOT NULL,
+    "store_name" TEXT NOT NULL,
+    "notify_on_new" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "favorite_stores_pkey" PRIMARY KEY ("user_id","store_name")
+);
+
+-- CreateTable
+CREATE TABLE "public"."savings_events" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "coupon_id" TEXT,
+    "store" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "amount_cents" INTEGER NOT NULL,
+    "currency" VARCHAR(3) NOT NULL DEFAULT 'USD',
+    "occurred_at" TIMESTAMPTZ(6) NOT NULL,
+    "client_event_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "savings_events_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "coupon_reports_coupon_id_user_id_created_at_idx" ON "public"."coupon_reports"("coupon_id", "user_id", "created_at");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "savings_events_client_event_id_key" ON "public"."savings_events"("client_event_id");
+
+-- CreateIndex
+CREATE INDEX "savings_events_user_id_occurred_at_idx" ON "public"."savings_events"("user_id", "occurred_at");
+
+-- AddForeignKey
+ALTER TABLE "public"."coupon_reports" ADD CONSTRAINT "coupon_reports_coupon_id_fkey" FOREIGN KEY ("coupon_id") REFERENCES "public"."coupons"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."coupon_reports" ADD CONSTRAINT "coupon_reports_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."favorite_stores" ADD CONSTRAINT "favorite_stores_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."savings_events" ADD CONSTRAINT "savings_events_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."savings_events" ADD CONSTRAINT "savings_events_coupon_id_fkey" FOREIGN KEY ("coupon_id") REFERENCES "public"."coupons"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/caramel-app/prisma/schema.prisma
+++ b/apps/caramel-app/prisma/schema.prisma
@@ -54,25 +54,28 @@ model Verification {
 }
 
 model User {
-  id                String     @id @default(uuid())
+  id                String          @id @default(uuid())
   name              String?
   firstName         String?
   lastName          String?
-  username          String?    @unique
-  email             String?    @unique
-  emailVerified     Boolean    @default(false) @map("email_verified")
+  username          String?         @unique
+  email             String?         @unique
+  emailVerified     Boolean         @default(false) @map("email_verified")
   password          String?
-  token             String?    @unique
+  token             String?         @unique
   image             String?
   encodedPictureUrl String?
   tokenExpiry       DateTime?
-  createdAt         DateTime   @default(now())
-  updatedAt         DateTime   @default(now()) @updatedAt
+  createdAt         DateTime        @default(now())
+  updatedAt         DateTime        @default(now()) @updatedAt
   deletedAt         DateTime?
-  role              Role?      @default(USER)
-  status            UserStatus @default(NOT_VERIFIED)
+  role              Role?           @default(USER)
+  status            UserStatus      @default(NOT_VERIFIED)
   accounts          Account[]
   sessions          Session[]
+  couponReports     CouponReport[]
+  favoriteStores    FavoriteStore[]
+  savingsEvents     SavingsEvent[]
 
   @@map("users")
 }
@@ -153,6 +156,12 @@ model Coupon {
   // omits it: seed rows + insert safety), never rewritten on update.
   updatedAt           DateTime  @default(now()) @map("updated_at")
 
+  // Back-relations for the login-features tables below. Relation fields are
+  // Prisma-side only — they add no column to `coupons` and leave the ingest
+  // write path untouched.
+  reports       CouponReport[]
+  savingsEvents SavingsEvent[]
+
   @@index([site])
   @@index([status, expired])
   @@map("coupons")
@@ -195,6 +204,122 @@ model Source {
   updatedAt DateTime @default(now()) @map("updated_at")
 
   @@map("sources")
+}
+
+// -----------------------------------------------------------------------------
+// App-owned SIGNED-IN-USER tables (login-features foundation).
+//
+// All three are USER-FACING app state — what a person reported, starred, and
+// saved — and are owned by this app end to end. None of them models any part of
+// the external pipeline's private machinery (prisma-schema-secrecy.test.ts), and
+// none is written by ingest.
+//
+// This migration is INERT: it creates the tables and nothing reads or writes
+// them yet. The routes, the per-day dedup, and the extension calls land in later
+// PRs. TODO: no feature is complete until those ship — an empty table here is
+// the foundation, not the feature.
+
+/// One user-attributed "did this coupon work?" report, kept ALONGSIDE the
+/// aggregate CouponSignal (which stays the anonymous counter the extension and
+/// card rendering read). This table is the attribution the aggregate cannot
+/// carry: who said it, and when — so a later PR can weight a signed-in report,
+/// show a user their own history, and drop duplicates.
+///
+/// `userId` is NULLABLE: anonymous reports are the DEFAULT case today (the
+/// report route is `origin`-gated, not auth-gated) and must keep working
+/// unchanged. A NULL row is an anonymous report, not a defect.
+///
+/// Dedup: Prisma cannot express a UNIQUE on date_trunc('day', created_at), so
+/// there is deliberately NO unique constraint here — the (couponId, userId,
+/// createdAt) index exists to make the app-side per-day check a cheap lookup.
+/// Until that check ships, this table accepts repeat reports. TODO: enforce
+/// one-report-per-user-per-coupon-per-day in app logic (later PR).
+model CouponReport {
+  id        String   @id @default(cuid())
+  // FK into the app-owned catalog with CASCADE: a report about a coupon row
+  // that no longer exists is meaningless, so it goes with it. (Distinct from
+  // CouponSignal, which holds NO FK because an aggregate must outlive a
+  // tombstoned coupon. Note ingest never DELETEs — it tombstones by status —
+  // so this cascade is a correctness backstop, not a routine path.)
+  couponId  String   @map("coupon_id")
+  coupon    Coupon   @relation(fields: [couponId], references: [id], onDelete: Cascade)
+  userId    String?  @map("user_id")
+  user      User?    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  // Same two-value vocabulary the report route's zod body already accepts
+  // ('worked' | 'failed'), stored as an OPEN string rather than an enum so the
+  // route schema stays the single place that vocabulary is declared.
+  outcome   String
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@index([couponId, userId, createdAt])
+  @@map("coupon_reports")
+}
+
+/// A store a user starred. Composite PK (userId, storeName) IS the dedup — one
+/// row per user per store, no surrogate id needed.
+///
+/// `storeName` is a plain string matching StoreConfig's key rather than an FK:
+/// a user may favorite a store before the pipeline has published a config for
+/// it, and un-publishing a config must not silently delete someone's favorite.
+model FavoriteStore {
+  userId      String   @map("user_id")
+  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  // Store key, same vocabulary as StoreConfig.storeName.
+  storeName   String   @map("store_name")
+  // DORMANT: a hook for a future "email me new coupons for this store" opt-in.
+  // Nothing reads it and there is NO email code anywhere in this PR. TODO: a
+  // later PR either wires the notification or this column is dropped.
+  notifyOnNew Boolean  @default(false) @map("notify_on_new")
+  createdAt   DateTime @default(now()) @map("created_at")
+
+  @@id([userId, storeName])
+  @@map("favorite_stores")
+}
+
+/// One recorded "you saved $X" moment, the append-only ledger behind a lifetime
+/// savings total.
+///
+/// `clientEventId` is UNIQUE and supplied by the client: the extension may
+/// retry a submission (offline, SW restart, a flaky network) and the retry must
+/// not double-count the same saving. The uniqueness constraint — not app
+/// logic — is what makes the replay idempotent.
+///
+/// `couponId` is nullable with onDelete: SetNull, NOT Cascade: money the user
+/// actually saved is theirs and must survive the coupon row disappearing. The
+/// denormalized `store`/`code`/`amountCents` are kept precisely so the event
+/// still renders with no coupon to join to.
+model SavingsEvent {
+  id String @id @default(cuid())
+
+  userId String @map("user_id")
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  couponId String? @map("coupon_id")
+  coupon   Coupon? @relation(fields: [couponId], references: [id], onDelete: SetNull)
+
+  // Denormalized at write time — the human-readable record of the saving,
+  // independent of whether the catalog row survives.
+  store       String
+  code        String
+  // Integer minor units, never a float: this is money and it is summed.
+  amountCents Int    @map("amount_cents")
+  // ISO 4217. VarChar(3), NOT Char(3): Postgres silently space-pads a CHAR, so
+  // a bad 2-letter code would be stored as 'US ' and compare equal to 'US' —
+  // a silent data defect. VarChar caps the length and stores what it was given.
+  // Open string (not an enum) so a new currency is data, not a migration; the
+  // write route's zod schema is where the vocabulary gets validated.
+  currency    String @default("USD") @db.VarChar(3)
+
+  // When the saving HAPPENED (client-reported), distinct from createdAt = when
+  // the server recorded it. A replayed/backfilled event has an occurredAt far
+  // older than its createdAt, and totals must be grouped by the former.
+  occurredAt    DateTime @map("occurred_at") @db.Timestamptz(6)
+  // Client-generated idempotency key for the retry above.
+  clientEventId String   @unique @map("client_event_id")
+  createdAt     DateTime @default(now()) @map("created_at")
+
+  @@index([userId, occurredAt])
+  @@map("savings_events")
 }
 
 enum UserStatus {

--- a/apps/caramel-app/src/lib/api/withRoute.ts
+++ b/apps/caramel-app/src/lib/api/withRoute.ts
@@ -25,8 +25,9 @@
 // Concern order (each an early return): compute CORS → origin-gate 403
 // (origin: true = isOriginAllowed's permissive allowlist; origin:
 // 'extension' = isExtensionOrigin's strict extension-protocol-only check,
-// no missing-Origin bypass — D5) → apiKey 401 → auth 401 → rateLimit 429 →
-// body safeParse 422 → handler
+// no missing-Origin bypass — D5) → apiKey 401 → auth 401 (never for
+// auth: 'optional', which resolves a session but gates nothing) →
+// rateLimit 429 → body safeParse 422 → handler
 // (try/catch → F-002's handleRouteError). CORS headers are merged onto
 // EVERY exit point (incl. 4xx/429/500) — matches the pre-F-007
 // authorize/oauth-exchange behavior of attaching corsHeaders to their
@@ -108,8 +109,8 @@ function unauthorized(cors: Headers): NextResponse {
 
 // better-auth's session type, resolved purely at the type level (no
 // runtime import of '@/lib/auth/auth' unless a route actually opts into
-// `auth: 'session'` — see the dynamic import below). Not exercised by any
-// current route (F-007 establishes the mechanism; nothing needs it yet).
+// `auth` — see the dynamic import below). Used today by extension/me and
+// extension/session (both `'session'`); `'optional'` has no route yet.
 type Session = Awaited<
     ReturnType<typeof import('@/lib/auth/auth').auth.api.getSession>
 >
@@ -140,8 +141,23 @@ export interface RouteConfig<TBody> {
      * to POST /api/ingest/catalog). Distinct secrets, one checker each; never a
      * second, independently-written comparison. */
     apiKey?: 'trustedServer' | 'ingest'
-    /** better-auth session gate. */
-    auth?: 'session'
+    /** better-auth session resolution.
+     *
+     * `'session'` GATES: no session → 401, handler never runs.
+     *
+     * `'optional'` never gates. It resolves the session the same way and
+     * hands the handler the same value, but an absent or unrecognized
+     * credential simply arrives as `session: null` and the request
+     * proceeds — for endpoints that serve everyone and merely do MORE for
+     * a signed-in caller (attribute a write, read a preference). Without
+     * it a bearer on a non-`'session'` route is dropped unread, so such a
+     * handler cannot tell a signed-in caller from an anonymous one.
+     *
+     * `'optional'` softens the ABSENCE of auth, not the FAILURE of the
+     * auth system: a THROWN session lookup (DB down) propagates to Next's
+     * onRequestError → Sentry exactly as under `'session'`, rather than
+     * being swallowed into a silent downgrade to anonymous. */
+    auth?: 'session' | 'optional'
     /** zod schema the JSON body must satisfy — 422 on mismatch. Omit (or
      * null) for routes that parse their own body (classify-cart's
      * sanitize(), oauth/redirect's formData/query, and the GET routes
@@ -152,6 +168,10 @@ export interface RouteConfig<TBody> {
 export interface RouteContext<TBody> {
     req: NextRequest
     body: TBody
+    /** Resolved better-auth session — null unless the route declares
+     * `auth`. Under `'session'` the wrapper has already 401'd a null, so a
+     * handler there always sees a real session; under `'optional'` null is
+     * the ordinary anonymous case, not an error. */
     session: Session | null
     /** The CORS headers already computed for this request — withRoute
      * merges these onto whatever the handler returns automatically;
@@ -193,14 +213,21 @@ export function withRoute<TBody = undefined>(
         }
 
         let session: Session | null = null
-        if (config.auth === 'session') {
-            // Lazy import — only routes that opt into session-auth pull in
-            // the full better-auth graph (bcrypt, prisma, email templates).
-            // No current route does; this keeps the other 15 routes'
-            // dependency graph exactly what it was pre-F-007.
+        if (config.auth) {
+            // Lazy import — only routes that opt into session resolution
+            // pull in the full better-auth graph (bcrypt, prisma, email
+            // templates); every route that declares no `auth` keeps the
+            // dependency graph it had pre-F-007.
             const { auth } = await import('@/lib/auth/auth')
+            // Identical resolution for both modes — they differ ONLY in
+            // what a null result means. getSession returns null (it does
+            // not throw) for a missing, malformed, revoked, or expired
+            // credential, so 'optional' turns all of those into an
+            // anonymous request rather than a 401.
             session = await auth.api.getSession({ headers: req.headers })
-            if (!session) return unauthorized(cors)
+            if (!session && config.auth === 'session') {
+                return unauthorized(cors)
+            }
         }
 
         if (config.rateLimit) {

--- a/apps/caramel-app/tests/unit/withRoute.test.ts
+++ b/apps/caramel-app/tests/unit/withRoute.test.ts
@@ -42,8 +42,13 @@ const { captureExceptionMock } = vi.hoisted(() => ({
 }))
 vi.mock('@sentry/nextjs', () => ({ captureException: captureExceptionMock }))
 
+// Typed with better-auth's actual call shape ({ headers }) so the
+// auth: 'optional' tests can assert the wrapper really forwarded the request's
+// credentials, not just that it called something.
 const { getSessionMock } = vi.hoisted(() => ({
-    getSessionMock: vi.fn(async () => null as unknown),
+    getSessionMock: vi.fn(
+        async (_opts: { headers: Headers }) => null as unknown,
+    ),
 }))
 vi.mock('@/lib/auth/auth', () => ({
     auth: { api: { getSession: getSessionMock } },
@@ -318,7 +323,7 @@ describe('withRoute — apiKey', () => {
     })
 })
 
-describe("withRoute — auth: 'session' (implemented + tested; zero current routes use it)", () => {
+describe("withRoute — auth: 'session' (the GATING mode; used by extension/me + extension/session)", () => {
     it('null session -> 401, without ever needing the real better-auth module', async () => {
         getSessionMock.mockImplementation(async () => null)
         const handler = withRoute(
@@ -340,6 +345,156 @@ describe("withRoute — auth: 'session' (implemented + tested; zero current rout
         const res = await handler(makeReq())
         expect(res.status).toBe(200)
         expect(await res.json()).toEqual({ session: fakeSession })
+    })
+
+    // Pins the gate against the 'optional' mode added below: adding a second
+    // auth mode must not soften this one. Every 401 case that held before
+    // still holds, and the wrapper still short-circuits BEFORE the handler.
+    it('unchanged by the introduction of auth: "optional" — a null session never reaches the handler', async () => {
+        getSessionMock.mockImplementation(async () => null)
+        const handlerBody = vi.fn(async () => NextResponse.json({ ok: true }))
+        const handler = withRoute(
+            { method: 'GET', routeName: 'test', auth: 'session' },
+            handlerBody,
+        )
+        const res = await handler(
+            makeReq('http://localhost/api/test', {
+                headers: { authorization: 'Bearer not-a-real-token' },
+            }),
+        )
+        expect(res.status).toBe(401)
+        expect(handlerBody).not.toHaveBeenCalled()
+    })
+})
+
+// The third auth mode: resolve a session when the caller has one, NEVER reject
+// when they don't. Exists because a bearer/cookie on any route that isn't
+// `auth: 'session'` is dropped unread — so a handler serving both anonymous and
+// signed-in callers (report attribution, favorites, saved totals) previously had
+// no way to tell them apart without also locking anonymous users out.
+describe("withRoute — auth: 'optional' (resolve-but-never-gate)", () => {
+    it('a valid session is handed to the handler exactly as under auth: "session"', async () => {
+        const fakeSession = { session: { id: 's1' }, user: { id: 'u1' } }
+        getSessionMock.mockImplementation(async () => fakeSession)
+        const handler = withRoute(
+            { method: 'GET', routeName: 'test', auth: 'optional' },
+            async ({ session }) => NextResponse.json({ session }),
+        )
+        const res = await handler(makeReq())
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({ session: fakeSession })
+    })
+
+    it('no credentials at all -> 200, handler runs with session: null', async () => {
+        getSessionMock.mockImplementation(async () => null)
+        const handler = withRoute(
+            { method: 'GET', routeName: 'test', auth: 'optional' },
+            async ({ session }) => NextResponse.json({ session }),
+        )
+        const res = await handler(makeReq())
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({ session: null })
+    })
+
+    // The specific regression this mode must never develop: better-auth returns
+    // null (it does not throw) for a garbage, revoked, or expired credential, and
+    // 'optional' must treat all of those as "anonymous", not as "reject".
+    it('a garbage/expired bearer -> still 200 with session: null, NOT a 401', async () => {
+        getSessionMock.mockImplementation(async () => null)
+        const handler = withRoute(
+            { method: 'GET', routeName: 'test', auth: 'optional' },
+            async ({ session }) => NextResponse.json({ session }),
+        )
+        const res = await handler(
+            makeReq('http://localhost/api/test', {
+                headers: { authorization: 'Bearer expired.garbage.token' },
+            }),
+        )
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({ session: null })
+    })
+
+    it('still resolves the session — it reads the request headers rather than skipping the lookup', async () => {
+        // Guards the cheap wrong implementation: a mode that never calls
+        // getSession would pass every assertion above about anonymous requests
+        // while silently making the signed-in case impossible.
+        getSessionMock.mockImplementation(async () => null)
+        const handler = withRoute(
+            { method: 'GET', routeName: 'test', auth: 'optional' },
+            ok,
+        )
+        await handler(
+            makeReq('http://localhost/api/test', {
+                headers: { authorization: 'Bearer some-token' },
+            }),
+        )
+        expect(getSessionMock).toHaveBeenCalledTimes(1)
+        const [args] = getSessionMock.mock.calls[0]!
+        expect(args.headers.get('authorization')).toBe('Bearer some-token')
+    })
+
+    it('omitting auth entirely still skips the lookup completely (session: null, better-auth never imported)', async () => {
+        const handler = withRoute(
+            { method: 'GET', routeName: 'test' },
+            async ({ session }) => NextResponse.json({ session }),
+        )
+        const res = await handler(
+            makeReq('http://localhost/api/test', {
+                headers: { authorization: 'Bearer some-token' },
+            }),
+        )
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({ session: null })
+        expect(getSessionMock).not.toHaveBeenCalled()
+    })
+
+    // 'optional' softens the ABSENCE of auth, not the FAILURE of the auth
+    // system. A throwing getSession means the session store is broken (DB
+    // down) — downgrading that to "anonymous" would silently serve every user
+    // the logged-out experience with nothing reported. It propagates instead,
+    // identically under both modes, reaching Sentry via Next's onRequestError.
+    it('a THROWING session lookup propagates rather than silently downgrading to anonymous', async () => {
+        getSessionMock.mockImplementation(async () => {
+            throw new Error('session store unreachable')
+        })
+        const optionalHandler = withRoute(
+            { method: 'GET', routeName: 'test', auth: 'optional' },
+            ok,
+        )
+        await expect(optionalHandler(makeReq())).rejects.toThrow(
+            'session store unreachable',
+        )
+
+        const sessionHandler = withRoute(
+            { method: 'GET', routeName: 'test', auth: 'session' },
+            ok,
+        )
+        await expect(sessionHandler(makeReq())).rejects.toThrow(
+            'session store unreachable',
+        )
+    })
+
+    it('does not exempt a request from the other concerns — the origin gate still 403s an anonymous cross-origin caller', async () => {
+        getSessionMock.mockImplementation(async () => null)
+        const handler = withRoute(
+            {
+                method: 'POST',
+                routeName: 'test',
+                auth: 'optional',
+                origin: true,
+            },
+            ok,
+        )
+        const res = await handler(
+            makeReq('http://localhost/api/test', {
+                method: 'POST',
+                headers: {
+                    origin: 'https://evil.example.com',
+                    host: 'localhost',
+                },
+            }),
+        )
+        expect(res.status).toBe(403)
     })
 })
 


### PR DESCRIPTION
Foundation only. **No user-facing behavior changes**: no route declares the new auth mode, and nothing reads or writes the three new tables. Both pieces exist so the actual login features can land as small, reviewable PRs on top.

## 1. `withRoute` gains a third auth mode: `auth: 'optional'`

Today the session is resolved **only** when a route declares `auth: 'session'`. On every other route a bearer or session cookie is dropped unread, so a handler that wants to serve everyone but do *more* for a signed-in caller has no way to tell the two apart — its only option was `'session'`, which locks anonymous users out entirely.

`'optional'` resolves the session exactly as `'session'` does and hands the handler the same value, but never rejects: an absent, malformed, revoked, or expired credential simply arrives as `session: null` and the request proceeds.

Two deliberate boundaries:

- **`'optional'` softens the absence of auth, not the failure of the auth system.** A *throwing* `getSession` (session store down) propagates to Next's `onRequestError` → Sentry, identically under both modes, rather than being swallowed into a silent downgrade where every user quietly gets the logged-out experience. There is a test pinning this for both modes.
- **It exempts nothing else.** Origin gate, api-key gate, rate limit, and body validation all still apply — the concern order is unchanged.

Rate limiting still keys on IP (`src/lib/rateLimit.ts` untouched).

Also corrected a stale comment that claimed no route used `auth` — `extension/me` and `extension/session` both do.

## 2. Prisma: three app-owned tables

All three are user-facing app state, owned by this app end to end. None models any part of the external pipeline's private machinery, and none is written by ingest — `tests/unit/prisma-schema-secrecy.test.ts` passes unchanged.

| Model | Table | Notes |
|---|---|---|
| `CouponReport` | `coupon_reports` | `user_id` **nullable** — anonymous reports are the default case today and must keep working. `outcome` is an open string carrying the `'worked' \| 'failed'` vocabulary the report route's zod body already defines. |
| `FavoriteStore` | `favorite_stores` | Composite PK `(user_id, store_name)` *is* the dedup. `notify_on_new` is a dormant column for a future opt-in — **no email code anywhere in this PR**. |
| `SavingsEvent` | `savings_events` | Append-only savings ledger. `client_event_id` is `UNIQUE`, so an extension retry cannot double-count a saving — the constraint, not app logic, makes the replay idempotent. |

Two decisions worth a reviewer's attention:

- **FK delete semantics differ on purpose.** `coupon_reports.coupon_id` cascades (a report about a coupon that no longer exists is meaningless), while `savings_events.coupon_id` is `SET NULL` — money a user actually saved is theirs and must survive the catalog row disappearing, which is why `store`/`code`/`amount_cents` are denormalized at write time. Ingest only ever tombstones by status, never `DELETE`s, so the cascade is a backstop rather than a routine path.
- **`currency` is `VARCHAR(3)`, not `CHAR(3)`.** Postgres silently space-pads a `CHAR`, so a bad two-letter code would be stored as `'US '` and compare equal to `'US'` — a silent data defect. This is a deliberate deviation from the "3-char" spec.

Per-day report dedup is **not** in this PR: Prisma cannot express a unique index on `date_trunc('day', created_at)`, so there is intentionally no unique constraint and the `(coupon_id, user_id, created_at)` index exists to make the app-side check cheap. Until that check ships the table accepts repeat reports — marked with a `TODO:` in the schema.

## How this is tested

- **8 new `withRoute` tests** (`tests/unit/withRoute.test.ts`), covering: valid session passed through; no credentials → 200 with `session: null`; garbage/expired bearer → 200 with `session: null` and **not** a 401; the lookup actually happens and forwards the request's headers; omitting `auth` still skips the lookup entirely; a throwing lookup propagates under both modes; and the origin gate still 403s an anonymous cross-origin caller. Existing `'session'` behavior is pinned by an added test asserting a null session never reaches the handler.
- **Red-proofed**, two mutations, each caught:
  - making `'optional'` gate like `'session'` → the 2 "never gate" tests fail
  - making `'optional'` skip the lookup → the 3 "resolves the session" tests fail
- **Schema**: `prisma validate` and `prisma generate` clean; the secrecy gate passes.
- **Migration replay proven against a real Postgres 15**, not just generated: replaying the full migration history into a shadow database and diffing against the datamodel reports `No difference detected.` The committed `migration.sql` is byte-identical to `prisma migrate diff`'s output for the schema delta.
- Full app unit suite **544 passed / 64 files** (was 536), `tsc --noEmit` clean, eslint clean, oxlint clean, knip clean, prettier clean. The extension workspace is untouched.

## Adjacent defect found, deliberately not fixed here

The `schema-drift` CI job cannot fail. Every one of its three checks ends in `--exit-code || echo "No drift detected..."`, which swallows a real failure into a reassuring log line.

It matters concretely: that job's `SHADOW_DATABASE_URL` points at `caramel_ci?schema=__shadow`, and under a non-`public` shadow schema the migration history genuinely breaks. The older migrations create unqualified tables (`"users"`) that land in `__shadow`, while migrations generated by newer Prisma versions emit `"public"."..."`. This PR's migration is the first to carry a `public.`-qualified FK to one of those older tables, so it is the first to hit `P3006 / P1014 — the underlying table for model public.users does not exist`. With a dedicated shadow *database* (the normal Prisma setup) the same history replays cleanly, which is how it was verified above.

So the job will go green on this PR either way, and the migration is correct. But the check is decorative until the `|| echo` is removed and the shadow URL points at a database rather than a schema. That is a pre-existing hole deserving its own PR with its own red-proof, not a rider on a foundation change.
