### PR TITLE
feat(coupons): attribute signed-in coupon reports, one per user per coupon per UTC day

### DIFF
--- a/apps/caramel-app/src/app/api/coupons/[id]/report/route.ts
+++ b/apps/caramel-app/src/app/api/coupons/[id]/report/route.ts
@@ -1,5 +1,10 @@
 import { withRoute } from '@/lib/api/withRoute'
-import { recordFailed, recordWorked } from '@/lib/couponSignals'
+import {
+    recordFailed,
+    recordWorked,
+    type CouponSignalWriter,
+} from '@/lib/couponSignals'
+import prisma from '@/lib/prisma'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 
@@ -12,8 +17,13 @@ import { z } from 'zod'
 // extension fetches with host_permissions, so its request bypasses CORS
 // entirely (adding CORS/OPTIONS here would be dead ceremony).
 //
-// Writes ONLY the app-owned coupon_signals table (through couponSignals.ts) —
-// NEVER the external read-only coupons catalog.
+// Writes ONLY app-owned tables — the aggregate `coupon_signals` (through
+// couponSignals.ts) and, for a signed-in caller, the attributed
+// `coupon_reports` row. NEVER the external read-only coupons catalog.
+//
+// This is the ONE place the worked/failed vocabulary is declared; coupon_reports
+// stores `outcome` as an open string precisely so this schema stays its single
+// source of truth.
 const ReportBodySchema = z.object({
     outcome: z.enum(['worked', 'failed']),
     // Optional free-text a store/verifier attached to a failure. Bounded here
@@ -21,15 +31,31 @@ const ReportBodySchema = z.object({
     storeReason: z.string().trim().max(200).optional(),
 })
 
+/**
+ * Midnight UTC of `now`. The dedup window is a UTC DAY, not a rolling 24h and
+ * not the caller's local day: the client never sends a timezone, and a rolling
+ * window would make "did I already report this today?" depend on the minute the
+ * previous report landed.
+ */
+function startOfUtcDay(now: Date): Date {
+    return new Date(
+        Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+    )
+}
+
 export const POST = withRoute(
     {
         method: 'POST',
         routeName: 'coupons/report',
         rateLimit: 'mutation',
         origin: true,
+        // Resolve-but-never-gate. The extension reports anonymously today and
+        // must keep doing so; a session only ADDS the attributed row below. A
+        // garbage/expired credential resolves to null and is simply anonymous.
+        auth: 'optional',
         body: ReportBodySchema,
     },
-    async ({ req, body }) => {
+    async ({ req, body, session }) => {
         // withRoute threads ONLY `req` to the handler — it deliberately does
         // not forward Next's dynamic route `params` (a path param is
         // route-specific data, not a cross-cutting concern, so the shared
@@ -46,11 +72,78 @@ export const POST = withRoute(
             )
         }
 
-        if (body.outcome === 'worked') {
-            await recordWorked(id)
-        } else {
-            await recordFailed(id, body.storeReason ?? null)
+        const userId = session?.user?.id ?? null
+
+        // The aggregate signal write — identical for every caller, so the
+        // signed-in path can never end up writing a DIFFERENT signal than the
+        // anonymous one.
+        const writeSignal = (client: CouponSignalWriter) =>
+            body.outcome === 'worked'
+                ? recordWorked(id, client)
+                : recordFailed(id, body.storeReason ?? null, client)
+
+        if (!userId) {
+            // Anonymous — unchanged from before attribution existed: ONE
+            // statement, no transaction, no catalog lookup. This is the
+            // extension's high-volume path and a BEGIN/COMMIT round-trip around
+            // a single upsert would buy nothing. Nothing is written to
+            // coupon_reports for an anonymous report — DELIBERATE, not an
+            // oversight: coupon_reports is ATTRIBUTION, and every row in it
+            // names a user. Anonymous volume is already fully counted by the
+            // aggregate, so a user_id NULL row would carry no information the
+            // aggregate lacks while doubling the storage and the write cost on
+            // the extension's highest-volume path. (The column is nullable
+            // because the schema was written before this call; a reader may
+            // assume user_id IS NOT NULL for every row this route creates.)
+            await writeSignal(prisma)
+            return NextResponse.json({ ok: true })
         }
+
+        // Signed in: the signal and the attribution are ONE atomic unit, so a
+        // failure can never leave a counted report with no attribution (or the
+        // reverse) for a client that will retry.
+        await prisma.$transaction(async tx => {
+            // Written on EVERY report — first or fifth of the day. Dedup below
+            // applies to the ATTRIBUTION ONLY: repeat anonymous reports have
+            // always each bumped the aggregate, so suppressing a signed-in
+            // user's second report would mean signing in silently weakens the
+            // signal the whole catalog is ranked by.
+            await writeSignal(tx)
+
+            // coupon_reports.coupon_id carries a real FK to `coupons`
+            // (coupon_signals deliberately carries none, so an aggregate can
+            // outlive a tombstoned coupon). An id that isn't in the catalog
+            // therefore CANNOT be attributed — check first rather than letting
+            // the insert raise a foreign-key violation, which would 500 a
+            // request that used to return 200. The signal above still lands,
+            // exactly as it does for an unknown id today.
+            const coupon = await tx.coupon.findUnique({
+                where: { id },
+                select: { id: true },
+            })
+            if (!coupon) return
+
+            // One attributed report per (user, coupon, UTC day). Postgres
+            // cannot express a UNIQUE on date_trunc('day', created_at), so this
+            // is app-side by necessity; it rides the
+            // (coupon_id, user_id, created_at) index the table ships with. A
+            // same-day repeat is IDEMPOTENT — no second row, no error, still
+            // 200: a user re-reporting is not a client mistake to be surfaced.
+            const alreadyReportedToday = await tx.couponReport.findFirst({
+                where: {
+                    couponId: id,
+                    userId,
+                    createdAt: { gte: startOfUtcDay(new Date()) },
+                },
+                select: { id: true },
+            })
+            if (alreadyReportedToday) return
+
+            await tx.couponReport.create({
+                data: { couponId: id, userId, outcome: body.outcome },
+            })
+        })
+
         // withRoute's try/catch routes any thrown error to Sentry (the
         // pipeline default) — no local catch needed.
         return NextResponse.json({ ok: true })

--- a/apps/caramel-app/src/lib/couponSignals.ts
+++ b/apps/caramel-app/src/lib/couponSignals.ts
@@ -19,7 +19,18 @@
 // (or mutate) the externally-owned catalog. Signals are keyed by the catalog
 // coupon id as a string, matching the app's Coupon.id: string.
 import prisma from '@/lib/prisma'
+import type { Prisma } from '@prisma/client'
 import * as Sentry from '@sentry/nextjs'
+
+/**
+ * The only slice of the Prisma client these writers need. Satisfied by BOTH the
+ * module-level singleton and an interactive-transaction client, so a caller that
+ * must write the signal atomically alongside another row — the report route's
+ * signed-in attribution, which pairs a `coupon_signals` upsert with a
+ * `coupon_reports` insert — passes its `tx` and gets the exact same write rather
+ * than a second, independently-written copy of it.
+ */
+export type CouponSignalWriter = Pick<Prisma.TransactionClient, 'couponSignal'>
 
 /**
  * Extension reported this coupon worked at checkout — stamp the last-worked
@@ -28,8 +39,11 @@ import * as Sentry from '@sentry/nextjs'
  * bumping it here too would double-count every success. This writer owns
  * `lastWorkedAt` only.
  */
-export async function recordWorked(couponId: string): Promise<void> {
-    await prisma.couponSignal.upsert({
+export async function recordWorked(
+    couponId: string,
+    client: CouponSignalWriter = prisma,
+): Promise<void> {
+    await client.couponSignal.upsert({
         where: { couponId },
         create: { couponId, lastWorkedAt: new Date() },
         update: { lastWorkedAt: new Date() },
@@ -58,11 +72,12 @@ export async function recordUsage(couponId: string): Promise<void> {
 export async function recordFailed(
     couponId: string,
     reason?: string | null,
+    client: CouponSignalWriter = prisma,
 ): Promise<void> {
     // `reason` is already length-bounded by the report route's zod body schema
     // (trim().max(200)); passed straight through — no second-guessing a value
     // the boundary already validated.
-    await prisma.couponSignal.upsert({
+    await client.couponSignal.upsert({
         where: { couponId },
         create: {
             couponId,

--- a/apps/caramel-app/tests/integration/coupon-report.itest.ts
+++ b/apps/caramel-app/tests/integration/coupon-report.itest.ts
@@ -1,0 +1,230 @@
+import { POST } from '@/app/api/coupons/[id]/report/route'
+import prisma from '@/lib/prisma'
+import { NextRequest } from 'next/server'
+import {
+    afterAll,
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi,
+} from 'vitest'
+
+// Attributed-report integration — the DB-backed sibling of
+// tests/unit/coupons-report.test.ts. The unit suite drives the route against an
+// in-memory fake, which can prove the LOGIC but never the SCHEMA: that
+// coupon_reports.coupon_id really carries a foreign key, that the per-day
+// window really is a Postgres timestamp comparison, that a real row lands with a
+// real user attached. Those are exactly the facts that would make the route 500
+// in production while every unit test stayed green, so they are proven here
+// against the REAL prisma client + live local Postgres (:58005), catalog
+// migrated (the harness/CI runs `prisma migrate deploy` first).
+//
+// Private id/email ranges (700071xxx coupons, a reports-itest.example site and
+// user) that no seed row and no other integration file touches — see
+// coupons-write.itest.ts's header for the full range map. Everything is deleted
+// after each test so the suite is idempotent and re-runnable.
+const KNOWN_ID = '700071001'
+const OTHER_ID = '700071002'
+const ABSENT_ID = '700071404' // deliberately never inserted — the FK case
+const ALL_COUPON_IDS = [KNOWN_ID, OTHER_ID, ABSENT_ID]
+const ITEST_SITE = 'reports-itest.example'
+const USER_EMAIL = 'reports-itest@example.com'
+
+// Only better-auth is stood in for: a real session would need a full sign-in
+// round-trip, and WHICH user id the wrapper resolves is already pinned by
+// withRoute's own tests. Everything below this line — prisma, the FK, the
+// dedup query — is real.
+const { getSessionMock } = vi.hoisted(() => ({
+    getSessionMock: vi.fn(
+        async (_opts: { headers: Headers }) => null as unknown,
+    ),
+}))
+vi.mock('@/lib/auth/auth', () => ({
+    auth: { api: { getSession: getSessionMock } },
+}))
+// The rate limiter is an in-memory bucket shared across the whole file; a suite
+// that posts a dozen reports would trip it on request count alone, which proves
+// nothing about attribution. Origin gating stays REAL.
+vi.mock('@/lib/rateLimit', async importOriginal => {
+    const actual = await importOriginal<typeof import('@/lib/rateLimit')>()
+    return { ...actual, checkRateLimit: vi.fn(async () => null) }
+})
+
+let userId = ''
+
+async function insertCoupon(id: string) {
+    await prisma.coupon.create({
+        data: {
+            id,
+            code: `REPORT-ITEST-${id}`,
+            site: ITEST_SITE,
+            title: 'reports itest coupon',
+            description: 'synthetic row for the attributed-report itest',
+            // NOT 'valid' — stays out of coupons-read.itest.ts's status='valid'
+            // census.
+            status: 'pending',
+        },
+    })
+}
+
+function reportRequest(id: string, body: unknown) {
+    return new NextRequest(`http://localhost/api/coupons/${id}/report`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+    })
+}
+
+async function cleanup() {
+    // coupon_reports first: its FK to coupons is ON DELETE CASCADE, but the
+    // user relation is too, and deleting in dependency order keeps this cleanup
+    // honest about what it is removing rather than relying on a cascade.
+    await prisma.couponReport.deleteMany({
+        where: { couponId: { in: ALL_COUPON_IDS } },
+    })
+    await prisma.couponSignal.deleteMany({
+        where: { couponId: { in: ALL_COUPON_IDS } },
+    })
+    await prisma.coupon.deleteMany({ where: { id: { in: ALL_COUPON_IDS } } })
+    await prisma.user.deleteMany({ where: { email: USER_EMAIL } })
+}
+
+beforeEach(async () => {
+    await cleanup()
+    const user = await prisma.user.create({ data: { email: USER_EMAIL } })
+    userId = user.id
+    getSessionMock.mockImplementation(async () => ({
+        session: { id: 'itest-session' },
+        user: { id: userId },
+    }))
+    await insertCoupon(KNOWN_ID)
+})
+
+afterEach(cleanup)
+afterAll(async () => {
+    await cleanup()
+    await prisma.$disconnect()
+})
+
+describe('POST /api/coupons/[id]/report — attribution against real pg :58005', () => {
+    it('a signed-in report lands one coupon_reports row carrying the real user id, alongside the aggregate signal', async () => {
+        const res = await POST(reportRequest(KNOWN_ID, { outcome: 'worked' }))
+        expect(res.status).toBe(200)
+
+        const reports = await prisma.couponReport.findMany({
+            where: { couponId: KNOWN_ID },
+        })
+        expect(reports).toHaveLength(1)
+        expect(reports[0]).toMatchObject({
+            couponId: KNOWN_ID,
+            userId,
+            outcome: 'worked',
+        })
+        expect(reports[0]!.createdAt).toBeInstanceOf(Date)
+
+        const signal = await prisma.couponSignal.findUnique({
+            where: { couponId: KNOWN_ID },
+        })
+        expect(signal?.lastWorkedAt).toBeInstanceOf(Date)
+    })
+
+    it('a same-day repeat adds no second row but DOES bump the aggregate again', async () => {
+        await POST(reportRequest(KNOWN_ID, { outcome: 'failed' }))
+        const res = await POST(reportRequest(KNOWN_ID, { outcome: 'failed' }))
+        expect(res.status).toBe(200)
+
+        expect(
+            await prisma.couponReport.count({ where: { couponId: KNOWN_ID } }),
+        ).toBe(1)
+        // Repeat ANONYMOUS reports have always each bumped failCount; the
+        // signed-in path matches that rather than silently weakening the
+        // aggregate for users who sign in.
+        const signal = await prisma.couponSignal.findUnique({
+            where: { couponId: KNOWN_ID },
+        })
+        expect(signal?.failCount).toBe(2)
+    })
+
+    it('a report already stored YESTERDAY does not block today (the window is the UTC day, not "ever")', async () => {
+        // Backdated directly so the check is exercised against Postgres's own
+        // timestamp comparison rather than a faked clock.
+        await prisma.couponReport.create({
+            data: {
+                couponId: KNOWN_ID,
+                userId,
+                outcome: 'worked',
+                createdAt: new Date(Date.now() - 36 * 60 * 60 * 1000),
+            },
+        })
+
+        await POST(reportRequest(KNOWN_ID, { outcome: 'worked' }))
+
+        expect(
+            await prisma.couponReport.count({ where: { couponId: KNOWN_ID } }),
+        ).toBe(2)
+    })
+
+    it('an id absent from the catalog → 200 with the signal written and NO report row (the FK is real)', async () => {
+        const res = await POST(reportRequest(ABSENT_ID, { outcome: 'worked' }))
+
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({ ok: true })
+        expect(
+            await prisma.couponReport.count({ where: { couponId: ABSENT_ID } }),
+        ).toBe(0)
+        // Unchanged from before attribution existed: coupon_signals has no FK,
+        // so an unknown id still gets its aggregate row.
+        const signal = await prisma.couponSignal.findUnique({
+            where: { couponId: ABSENT_ID },
+        })
+        expect(signal?.lastWorkedAt).toBeInstanceOf(Date)
+    })
+
+    it('the FK the route precheck exists for is REAL — a direct insert for that same absent id is rejected by Postgres', async () => {
+        // Red-proof for the precheck: without it the route would hand this exact
+        // insert to the driver and the request would 500. coupon_signals is the
+        // control — it takes the same unknown id without complaint.
+        await expect(
+            prisma.couponReport.create({
+                data: { couponId: ABSENT_ID, userId, outcome: 'worked' },
+            }),
+        ).rejects.toThrow()
+
+        await expect(
+            prisma.couponSignal.create({ data: { couponId: ABSENT_ID } }),
+        ).resolves.toMatchObject({ couponId: ABSENT_ID })
+    })
+
+    it('dedup is per (user, coupon) — the same user reporting another coupon the same day is attributed', async () => {
+        await insertCoupon(OTHER_ID)
+
+        await POST(reportRequest(KNOWN_ID, { outcome: 'worked' }))
+        await POST(reportRequest(OTHER_ID, { outcome: 'worked' }))
+
+        const reports = await prisma.couponReport.findMany({
+            where: { couponId: { in: [KNOWN_ID, OTHER_ID] } },
+            orderBy: { couponId: 'asc' },
+        })
+        expect(reports.map(report => report.couponId)).toEqual([
+            KNOWN_ID,
+            OTHER_ID,
+        ])
+    })
+
+    it('an anonymous report writes the signal and NOTHING to coupon_reports', async () => {
+        getSessionMock.mockImplementation(async () => null)
+
+        const res = await POST(reportRequest(KNOWN_ID, { outcome: 'worked' }))
+
+        expect(res.status).toBe(200)
+        expect(
+            await prisma.couponReport.count({ where: { couponId: KNOWN_ID } }),
+        ).toBe(0)
+        const signal = await prisma.couponSignal.findUnique({
+            where: { couponId: KNOWN_ID },
+        })
+        expect(signal?.lastWorkedAt).toBeInstanceOf(Date)
+    })
+})

--- a/apps/caramel-app/tests/unit/coupons-report.test.ts
+++ b/apps/caramel-app/tests/unit/coupons-report.test.ts
@@ -1,6 +1,6 @@
 import { POST } from '@/app/api/coupons/[id]/report/route'
 import { NextRequest } from 'next/server'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Report-route unit pins — the app side of the trust loop (W1). Mirrors
 // coupons-expire.test.ts's shape: mock the DB the signal lives in (here
@@ -9,20 +9,118 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 // the PATH (withRoute doesn't thread Next's route params), that each outcome
 // routes to the right recorder, and that the withRoute body gate rejects a
 // bad outcome before anything is written.
-const { prismaMock } = vi.hoisted(() => ({
-    prismaMock: {
-        couponSignal: {
-            upsert: vi.fn(
-                async (args: {
-                    where: { couponId: string }
-                    create: Record<string, unknown>
-                    update: Record<string, unknown>
-                }) => ({ couponId: args.where.couponId }),
+//
+// ANNOUNCED FAKE, not a canned mock: `coupons` and `coupon_reports` are backed
+// by tiny in-memory tables below, so the route's per-day dedup and its
+// catalog-existence guard are genuinely EXERCISED. A canned
+// `findFirst: async () => null` would let a deleted dedup check pass every
+// assertion here. The real query SHAPE is pinned separately (see "the dedup
+// lookup is scoped to…"), because a fake can only ever prove the logic, never
+// the SQL.
+const { prismaMock, txMock, reportRows, catalogIds, getSessionMock } =
+    vi.hoisted(() => {
+        interface ReportRow {
+            id: string
+            couponId: string
+            userId: string | null
+            outcome: string
+            createdAt: Date
+        }
+        const rows: ReportRow[] = []
+        // Catalog ids that "exist" — coupon_reports.coupon_id carries a real FK
+        // to `coupons` (coupon_signals deliberately carries none), so an id
+        // absent from this set is the unknown-coupon case.
+        const ids = new Set<string>()
+
+        const signalUpsert = vi.fn(
+            async (args: {
+                where: { couponId: string }
+                create: Record<string, unknown>
+                update: Record<string, unknown>
+            }) => ({ couponId: args.where.couponId }),
+        )
+        const txSignalUpsert = vi.fn(
+            async (args: {
+                where: { couponId: string }
+                create: Record<string, unknown>
+                update: Record<string, unknown>
+            }) => ({ couponId: args.where.couponId }),
+        )
+
+        const tx = {
+            couponSignal: { upsert: txSignalUpsert },
+            coupon: {
+                findUnique: vi.fn(async (args: { where: { id: string } }) =>
+                    ids.has(args.where.id) ? { id: args.where.id } : null,
+                ),
+            },
+            couponReport: {
+                findFirst: vi.fn(
+                    async (args: {
+                        where: {
+                            couponId: string
+                            userId: string | null
+                            createdAt: { gte: Date }
+                        }
+                    }) => {
+                        const { couponId, userId, createdAt } = args.where
+                        return (
+                            rows.find(
+                                row =>
+                                    row.couponId === couponId &&
+                                    row.userId === userId &&
+                                    row.createdAt >= createdAt.gte,
+                            ) ?? null
+                        )
+                    },
+                ),
+                create: vi.fn(
+                    async (args: {
+                        data: {
+                            couponId: string
+                            userId: string
+                            outcome: string
+                        }
+                    }) => {
+                        const row = {
+                            id: `report-${rows.length + 1}`,
+                            ...args.data,
+                            createdAt: new Date(),
+                        }
+                        rows.push(row)
+                        return row
+                    },
+                ),
+            },
+        }
+
+        return {
+            reportRows: rows,
+            catalogIds: ids,
+            txMock: tx,
+            prismaMock: {
+                // The anonymous path writes the signal through the singleton
+                // client directly; the signed-in path writes it through `tx`.
+                // Keeping the two upsert spies SEPARATE is what lets a test
+                // assert which path a request actually took.
+                couponSignal: { upsert: signalUpsert },
+                $transaction: vi.fn(
+                    async (fn: (client: typeof tx) => Promise<unknown>) =>
+                        fn(tx),
+                ),
+            },
+            getSessionMock: vi.fn(
+                async (_opts: { headers: Headers }) => null as unknown,
             ),
-        },
-    },
-}))
+        }
+    })
 vi.mock('@/lib/prisma', () => ({ default: prismaMock }))
+// withRoute lazy-imports better-auth only when a route declares `auth`; this
+// stands in for the whole auth graph so the route's session resolution is
+// drivable without bcrypt/prisma/email templates.
+vi.mock('@/lib/auth/auth', () => ({
+    auth: { api: { getSession: getSessionMock } },
+}))
 
 // Keep isOriginAllowed real (a no-Origin request passes, like the extension's
 // host_permissions fetch); only the rate-limit round-trip is stubbed out.
@@ -31,31 +129,68 @@ vi.mock('@/lib/rateLimit', async importOriginal => {
     return { ...actual, checkRateLimit: vi.fn(async () => null) }
 })
 
-function reportRequest(id: string, body: unknown) {
+const KNOWN_COUPON = '42'
+
+function reportRequest(id: string, body: unknown, bearer?: string) {
+    const headers: Record<string, string> = {
+        'content-type': 'application/json',
+    }
+    if (bearer !== undefined) headers.authorization = bearer
     return new NextRequest(`http://localhost/api/coupons/${id}/report`, {
         method: 'POST',
-        headers: { 'content-type': 'application/json' },
+        headers,
         body: JSON.stringify(body),
     })
 }
 
+/** better-auth resolves a session for this user id on the next request(s). */
+function signedInAs(userId: string) {
+    getSessionMock.mockImplementation(async () => ({
+        session: { id: `session-${userId}` },
+        user: { id: userId },
+    }))
+}
+
+/** better-auth resolves NOTHING — the anonymous case (no, garbage, or expired
+ * credential all land here: getSession returns null, it does not throw). */
+function anonymous() {
+    getSessionMock.mockImplementation(async () => null)
+}
+
 beforeEach(() => {
     prismaMock.couponSignal.upsert.mockClear()
+    prismaMock.$transaction.mockClear()
+    txMock.couponSignal.upsert.mockClear()
+    txMock.coupon.findUnique.mockClear()
+    txMock.couponReport.findFirst.mockClear()
+    txMock.couponReport.create.mockClear()
+    reportRows.length = 0
+    catalogIds.clear()
+    catalogIds.add(KNOWN_COUPON)
+    anonymous()
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2026-08-09T12:00:00.000Z'))
+})
+
+afterAll(() => {
+    vi.useRealTimers()
 })
 
 describe('POST /api/coupons/[id]/report — app-owned trust signal (W1)', () => {
     it('outcome "worked" → 200 {ok:true}, stamps lastWorkedAt ONLY (no workCount — increment owns that)', async () => {
-        const res = await POST(reportRequest('42', { outcome: 'worked' }))
+        const res = await POST(
+            reportRequest(KNOWN_COUPON, { outcome: 'worked' }),
+        )
 
         expect(res.status).toBe(200)
         expect(await res.json()).toEqual({ ok: true })
         expect(prismaMock.couponSignal.upsert).toHaveBeenCalledTimes(1)
         const arg = prismaMock.couponSignal.upsert.mock.calls[0]![0]
-        expect(arg.where).toEqual({ couponId: '42' })
+        expect(arg.where).toEqual({ couponId: KNOWN_COUPON })
         // W4-D2 split: recordWorked owns lastWorkedAt; recordUsage (POST
         // /increment) owns workCount. A "worked" report must NOT bump workCount,
         // or a successful apply (which fires BOTH report+increment) double-counts.
-        expect(arg.create).toMatchObject({ couponId: '42' })
+        expect(arg.create).toMatchObject({ couponId: KNOWN_COUPON })
         expect(arg.create.lastWorkedAt).toBeInstanceOf(Date)
         expect(arg.create).not.toHaveProperty('workCount')
         expect(arg.update.lastWorkedAt).toBeInstanceOf(Date)
@@ -64,7 +199,7 @@ describe('POST /api/coupons/[id]/report — app-owned trust signal (W1)', () => 
 
     it('outcome "failed" with a storeReason → 200, upserts a fail signal carrying the reason', async () => {
         const res = await POST(
-            reportRequest('42', {
+            reportRequest(KNOWN_COUPON, {
                 outcome: 'failed',
                 storeReason: 'Minimum spend not met',
             }),
@@ -74,7 +209,7 @@ describe('POST /api/coupons/[id]/report — app-owned trust signal (W1)', () => 
         expect(prismaMock.couponSignal.upsert).toHaveBeenCalledTimes(1)
         const arg = prismaMock.couponSignal.upsert.mock.calls[0]![0]
         expect(arg.create).toMatchObject({
-            couponId: '42',
+            couponId: KNOWN_COUPON,
             failCount: 1,
             lastFailReason: 'Minimum spend not met',
         })
@@ -95,9 +230,253 @@ describe('POST /api/coupons/[id]/report — app-owned trust signal (W1)', () => 
     })
 
     it('an invalid outcome → 422 (withRoute body gate), nothing written', async () => {
-        const res = await POST(reportRequest('42', { outcome: 'maybe' }))
+        const res = await POST(
+            reportRequest(KNOWN_COUPON, { outcome: 'maybe' }),
+        )
 
         expect(res.status).toBe(422)
         expect(prismaMock.couponSignal.upsert).not.toHaveBeenCalled()
+    })
+})
+
+// CHARACTERIZATION — written against the pre-attribution route and required to
+// stay green through it. Attribution is ADDITIVE: the anonymous request the
+// extension sends today (no credential, `origin`-gated only) must behave
+// byte-for-byte as it did before coupon_reports existed.
+describe('POST /api/coupons/[id]/report — anonymous behavior (characterization)', () => {
+    it('no credentials → 200 with the signal written, NO attributed row, and no transaction opened', async () => {
+        const res = await POST(
+            reportRequest(KNOWN_COUPON, { outcome: 'worked' }),
+        )
+
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({ ok: true })
+        // The signal goes through the singleton client, exactly as before.
+        expect(prismaMock.couponSignal.upsert).toHaveBeenCalledTimes(1)
+        // Anonymous is the extension's high-volume path: one statement, so no
+        // BEGIN/COMMIT round-trip is paid for it.
+        expect(prismaMock.$transaction).not.toHaveBeenCalled()
+        expect(txMock.couponReport.create).not.toHaveBeenCalled()
+        expect(reportRows).toEqual([])
+    })
+
+    it('a garbage bearer is treated as anonymous — 200, never a 401, and still no attributed row', async () => {
+        // better-auth returns null (it does not throw) for a garbage, revoked,
+        // or expired credential, and auth: 'optional' must turn all of those
+        // into "anonymous" rather than "reject". A 401 here would break every
+        // extension install carrying a stale token.
+        const res = await POST(
+            reportRequest(
+                KNOWN_COUPON,
+                { outcome: 'worked' },
+                'Bearer expired.garbage.token',
+            ),
+        )
+
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({ ok: true })
+        expect(prismaMock.couponSignal.upsert).toHaveBeenCalledTimes(1)
+        expect(txMock.couponReport.create).not.toHaveBeenCalled()
+        expect(reportRows).toEqual([])
+    })
+
+    it('repeat anonymous reports are NOT deduped — every one writes the signal again', async () => {
+        await POST(reportRequest(KNOWN_COUPON, { outcome: 'failed' }))
+        await POST(reportRequest(KNOWN_COUPON, { outcome: 'failed' }))
+        await POST(reportRequest(KNOWN_COUPON, { outcome: 'failed' }))
+
+        // This is the semantics the signed-in path is measured against: the
+        // aggregate counter has always counted every report.
+        expect(prismaMock.couponSignal.upsert).toHaveBeenCalledTimes(3)
+    })
+
+    it('an id that is well-formed but absent from the catalog still writes the signal (coupon_signals has no FK)', async () => {
+        catalogIds.clear() // nothing exists in the catalog
+
+        const res = await POST(
+            reportRequest('999000404', { outcome: 'worked' }),
+        )
+
+        expect(res.status).toBe(200)
+        expect(prismaMock.couponSignal.upsert).toHaveBeenCalledTimes(1)
+        expect(prismaMock.couponSignal.upsert.mock.calls[0]![0].where).toEqual({
+            couponId: '999000404',
+        })
+    })
+})
+
+// ATTRIBUTION — what a session ADDS. Everything above still holds; a signed-in
+// report writes the same aggregate signal AND one `coupon_reports` row naming
+// the user, at most once per coupon per UTC day.
+describe('POST /api/coupons/[id]/report — signed-in attribution (coupon_reports)', () => {
+    it('a signed-in report writes the aggregate signal AND an attributed row, inside ONE transaction', async () => {
+        signedInAs('user-1')
+
+        const res = await POST(
+            reportRequest(KNOWN_COUPON, { outcome: 'worked' }, 'Bearer good'),
+        )
+
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({ ok: true })
+        // Both writes go through the SAME transaction client — a half-write
+        // (signal counted, attribution lost, or the reverse) is impossible for
+        // a client that will retry.
+        expect(prismaMock.$transaction).toHaveBeenCalledTimes(1)
+        expect(txMock.couponSignal.upsert).toHaveBeenCalledTimes(1)
+        expect(prismaMock.couponSignal.upsert).not.toHaveBeenCalled()
+        expect(reportRows).toEqual([
+            {
+                id: 'report-1',
+                couponId: KNOWN_COUPON,
+                userId: 'user-1',
+                outcome: 'worked',
+                createdAt: new Date('2026-08-09T12:00:00.000Z'),
+            },
+        ])
+    })
+
+    it('stores the outcome verbatim — a "failed" report is attributed as failed, with the signal still carrying the reason', async () => {
+        signedInAs('user-1')
+
+        await POST(
+            reportRequest(
+                KNOWN_COUPON,
+                { outcome: 'failed', storeReason: 'Expired code' },
+                'Bearer good',
+            ),
+        )
+
+        expect(reportRows[0]).toMatchObject({
+            userId: 'user-1',
+            outcome: 'failed',
+        })
+        expect(
+            txMock.couponSignal.upsert.mock.calls[0]![0].create,
+        ).toMatchObject({
+            couponId: KNOWN_COUPON,
+            failCount: 1,
+            lastFailReason: 'Expired code',
+        })
+    })
+
+    it('a same-day repeat is IDEMPOTENT — 200, no second row, and the aggregate signal is STILL written', async () => {
+        signedInAs('user-1')
+
+        await POST(
+            reportRequest(KNOWN_COUPON, { outcome: 'worked' }, 'Bearer good'),
+        )
+        vi.setSystemTime(new Date('2026-08-09T23:59:59.000Z')) // same UTC day
+        const res = await POST(
+            reportRequest(KNOWN_COUPON, { outcome: 'worked' }, 'Bearer good'),
+        )
+
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({ ok: true })
+        expect(txMock.couponReport.create).toHaveBeenCalledTimes(1)
+        expect(reportRows).toHaveLength(1)
+        // The signal is NOT deduped — repeat anonymous reports each bump it
+        // (pinned above), so signing in must not silently weaken the aggregate.
+        expect(txMock.couponSignal.upsert).toHaveBeenCalledTimes(2)
+    })
+
+    it('the SAME user reporting the SAME coupon the next UTC day is attributed again', async () => {
+        signedInAs('user-1')
+
+        vi.setSystemTime(new Date('2026-08-09T23:59:00.000Z'))
+        await POST(
+            reportRequest(KNOWN_COUPON, { outcome: 'worked' }, 'Bearer good'),
+        )
+        vi.setSystemTime(new Date('2026-08-10T00:01:00.000Z')) // 2 minutes later
+        await POST(
+            reportRequest(KNOWN_COUPON, { outcome: 'worked' }, 'Bearer good'),
+        )
+
+        // The window is the UTC DAY, not a rolling 24h — two minutes apart but
+        // across midnight is two reports.
+        expect(reportRows).toHaveLength(2)
+        expect(reportRows.map(row => row.userId)).toEqual(['user-1', 'user-1'])
+    })
+
+    it('the dedup lookup is scoped to (this coupon, this user, midnight UTC) — nothing broader', async () => {
+        signedInAs('user-1')
+        vi.setSystemTime(new Date('2026-08-09T18:30:45.123Z'))
+
+        await POST(
+            reportRequest(KNOWN_COUPON, { outcome: 'worked' }, 'Bearer good'),
+        )
+
+        // Pins the QUERY, not just the outcome: the in-memory fake can prove the
+        // logic but never the SQL, so a window widened to "ever" or narrowed to
+        // "this instant" is caught here.
+        expect(txMock.couponReport.findFirst).toHaveBeenCalledTimes(1)
+        expect(txMock.couponReport.findFirst.mock.calls[0]![0]).toEqual({
+            where: {
+                couponId: KNOWN_COUPON,
+                userId: 'user-1',
+                createdAt: { gte: new Date('2026-08-09T00:00:00.000Z') },
+            },
+            select: { id: true },
+        })
+    })
+
+    it('dedup is PER USER — a different user reporting the same coupon the same day is attributed too', async () => {
+        signedInAs('user-1')
+        await POST(
+            reportRequest(KNOWN_COUPON, { outcome: 'worked' }, 'Bearer good'),
+        )
+        signedInAs('user-2')
+        await POST(
+            reportRequest(KNOWN_COUPON, { outcome: 'failed' }, 'Bearer good'),
+        )
+
+        expect(reportRows.map(row => row.userId)).toEqual(['user-1', 'user-2'])
+    })
+
+    it('dedup is PER COUPON — the same user reporting a different coupon the same day is attributed too', async () => {
+        catalogIds.add('43')
+        signedInAs('user-1')
+
+        await POST(
+            reportRequest(KNOWN_COUPON, { outcome: 'worked' }, 'Bearer good'),
+        )
+        await POST(reportRequest('43', { outcome: 'worked' }, 'Bearer good'))
+
+        expect(reportRows.map(row => row.couponId)).toEqual([
+            KNOWN_COUPON,
+            '43',
+        ])
+    })
+
+    it('an unknown coupon id → 200 with the signal written and NO insert attempted (the FK would raise, not 500)', async () => {
+        signedInAs('user-1')
+        catalogIds.clear() // the id passes /^\d{1,18}$/ but no catalog row exists
+
+        const res = await POST(
+            reportRequest('999000404', { outcome: 'worked' }, 'Bearer good'),
+        )
+
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({ ok: true })
+        // Signals behavior for an unknown id is UNCHANGED (no FK on that table).
+        expect(txMock.couponSignal.upsert).toHaveBeenCalledTimes(1)
+        expect(txMock.couponSignal.upsert.mock.calls[0]![0].where).toEqual({
+            couponId: '999000404',
+        })
+        // The existence check runs BEFORE the insert, so the FK never fires.
+        expect(txMock.coupon.findUnique).toHaveBeenCalledTimes(1)
+        expect(txMock.couponReport.create).not.toHaveBeenCalled()
+        expect(reportRows).toEqual([])
+    })
+
+    it('a bad id is still rejected before any session-dependent work (400, nothing written, no transaction)', async () => {
+        signedInAs('user-1')
+
+        const res = await POST(
+            reportRequest('abc', { outcome: 'worked' }, 'Bearer good'),
+        )
+
+        expect(res.status).toBe(400)
+        expect(prismaMock.$transaction).not.toHaveBeenCalled()
+        expect(reportRows).toEqual([])
     })
 })


### PR DESCRIPTION
Builds on #168 (rebased onto `main` after it landed as `1c30dca`). `coupon_reports` was created inert there; this makes it the first table the app actually writes.

`POST /api/coupons/[id]/report` now declares `auth: 'optional'`. Anonymous reports behave exactly as before. A signed-in report additionally writes one attributed `coupon_reports` row — at most one per (user, coupon, UTC day).

## Decisions

**1. Anonymous reports write NOTHING to `coupon_reports`.**
The aggregate `coupon_signals` row already counts every anonymous report. A `user_id IS NULL` row would carry no information the aggregate doesn't already hold, while doubling the storage and the write cost on the extension's highest-volume path. `coupon_reports` is therefore exactly what its name says: attribution. A row in it always names a user.

Consequence for readers: "how many people reported this coupon" is still `coupon_signals`; `coupon_reports` answers "which signed-in users reported it, and when".

**2. The aggregate signal is written on EVERY report, including a signed-in same-day duplicate.**
Repeat *anonymous* reports have always each bumped the counters (pinned by `repeat anonymous reports are NOT deduped — every one writes the signal again`). Matching that is the only option that doesn't make signing in silently *weaken* the signal the whole catalog is ranked by: if a duplicate suppressed the aggregate write too, the same three reports would count 3× from a logged-out user and 1× from a logged-in one. Dedup applies to the attribution row only.

**3. A same-day duplicate is idempotent, not an error.**
Still `200 {ok:true}`, no second row. A user re-reporting a coupon they already reported is not a client mistake, and a 409 would only teach the extension to special-case a success.

**4. Anonymous keeps its single un-transacted write; only the signed-in path opens a transaction.**
Signed-in pairs the signal upsert with the attribution insert in ONE `$transaction`, so a retrying client can never leave a counted report with no attribution (or the reverse). Anonymous writes one statement and pays no `BEGIN`/`COMMIT` round-trip for it. To keep both paths writing the *same* signal rather than a second hand-written copy, `recordWorked`/`recordFailed` take an optional client (`CouponSignalWriter`, satisfied by both the singleton and a `tx`), defaulting to the singleton — every existing caller is unchanged.

**5. Unknown coupon id: prechecked, never a 500.**
`coupon_reports.coupon_id` carries a real FK to `coupons` (`coupon_signals` deliberately carries none, so an aggregate can outlive a tombstoned coupon). A well-formed id that isn't in the catalog would therefore have raised a foreign-key violation on insert and turned a `200` into a `500`. The route reads the catalog row inside the same transaction and skips the attribution when it's absent — **the signal still lands, exactly as it does today**, so unknown-id behavior is bit-for-bit unchanged. The FK is proven real (not assumed) by an integration test that issues the same insert directly and watches Postgres reject it, with the `coupon_signals` insert as the control.

**6. The dedup window is the UTC day**, not a rolling 24h and not the caller's local day: the client never sends a timezone, and a rolling window would make "did I already report this today?" depend on the minute the previous report landed. There is no unique constraint to lean on — Postgres can't express `UNIQUE(date_trunc('day', created_at))` — so the check is app-side by necessity, riding the `(coupon_id, user_id, created_at)` index the table already ships with.

## Tests

Characterization first: the anonymous pins were written and run **green against the unmodified route** before a line of it changed, then kept green through the change.

`tests/unit/coupons-report.test.ts` — 4 → 17 tests. Backed by an announced in-memory fake of `coupons`/`coupon_reports` (not canned return values), so the dedup logic is genuinely executed; the fake can prove the logic but never the SQL, so the query shape is pinned separately.

*Characterization (anonymous, unchanged):*
- no credentials → 200 with the signal written, NO attributed row, and no transaction opened
- a garbage bearer is treated as anonymous — 200, never a 401, and still no attributed row
- repeat anonymous reports are NOT deduped — every one writes the signal again
- an id that is well-formed but absent from the catalog still writes the signal (coupon_signals has no FK)

*Attribution:*
- a signed-in report writes the aggregate signal AND an attributed row, inside ONE transaction
- stores the outcome verbatim — a "failed" report is attributed as failed, with the signal still carrying the reason
- a same-day repeat is IDEMPOTENT — 200, no second row, and the aggregate signal is STILL written
- the SAME user reporting the SAME coupon the next UTC day is attributed again
- the dedup lookup is scoped to (this coupon, this user, midnight UTC) — nothing broader
- dedup is PER USER / dedup is PER COUPON
- an unknown coupon id → 200 with the signal written and NO insert attempted (the FK would raise, not 500)
- a bad id is still rejected before any session-dependent work (400, nothing written, no transaction)

`tests/integration/coupon-report.itest.ts` — 7 new tests on the real prisma client against a live Postgres (the existing `Integration (DB)` CI job), because the schema facts are precisely what a fake cannot prove: the FK exists, the window is a real timestamp comparison (a report backdated 36h does not block today), a row lands carrying a real `users.id`.

### Red-proof

Four mutations of the shipped logic, each reverted:

| mutation | caught by |
| --- | --- |
| dedup early-return removed | `a same-day repeat is IDEMPOTENT…` |
| dedup window widened to the epoch (dedup forever) | `the SAME user reporting the SAME coupon the next UTC day…`, `the dedup lookup is scoped to…` |
| catalog-existence precheck removed | `an unknown coupon id → 200… NO insert attempted` |
| signal write moved below the dedup return (duplicate suppresses the aggregate) | `a same-day repeat is IDEMPOTENT…`, `an unknown coupon id → 200…` |

Plus the schema-level red-proof in the integration suite: `the FK the route precheck exists for is REAL — a direct insert for that same absent id is rejected by Postgres`.

## Gates

`vitest` 557/557 (64 files) · `test:integration` 27/27 (7 files, real Postgres 18.4) · `tsc --noEmit` · `eslint` · `oxlint` · `prettier --check` · `knip` · `prisma validate` — all green locally; pre-commit hook passed unbypassed.

## For the profile page

`coupon_reports` is now populated for signed-in users and is the table behind a "your reports" stat: `prisma.couponReport.count({ where: { userId } })`, or `findMany` with `include: { coupon: true }` for a list. Every row has a non-null `user_id` (decision 1), at most one per coupon per UTC day (decision 6), and `outcome` is `'worked' | 'failed'` — a vocabulary declared in exactly one place, `ReportBodySchema` in the report route. The FK is `ON DELETE CASCADE`, so a report can never outlive its coupon; a "your reports" list needs no null-coupon branch.
