### PR TITLE
feat(favorites): follow a store from the extension popup and its coupons page

### DIFF
--- a/apps/caramel-app/src/app/(marketing)/coupons/[store]/page.tsx
+++ b/apps/caramel-app/src/app/(marketing)/coupons/[store]/page.tsx
@@ -200,7 +200,13 @@ export default async function StoreCouponsPage({
                 // The star renders nothing at all for signed-out visitors, so
                 // this route's server HTML — the thing SEO and the AEO prose
                 // below depend on — is unchanged for crawlers.
-                heroAction={<StoreFavoriteStar store={base} />}
+                //
+                // No star when `base` is empty: this route answers 200 for a
+                // slug that names no registrable store (the noindexed branch in
+                // generateMetadata above), and there is nothing there to follow.
+                heroAction={
+                    base ? <StoreFavoriteStar store={base} /> : undefined
+                }
                 heroTitle={`Best ${base} coupon codes today`}
                 heroSubtitle={`Save at ${base} with Caramel—the privacy-first coupon finder that applies the top deals automatically at checkout.`}
             />

--- a/apps/caramel-app/src/app/(marketing)/coupons/[store]/page.tsx
+++ b/apps/caramel-app/src/app/(marketing)/coupons/[store]/page.tsx
@@ -1,5 +1,6 @@
 import CouponsSection from '@/components/coupons/coupons-section'
 import PopularStores from '@/components/coupons/popular-stores'
+import StoreFavoriteStar from '@/components/coupons/store-favorite-star'
 import { attachSignals } from '@/lib/couponSignals'
 import { listStoreCoupons } from '@/lib/couponsRepo'
 import { BASE_URL } from '@/lib/env.client'
@@ -191,6 +192,15 @@ export default async function StoreCouponsPage({
                 initialCoupons={coupons}
                 initialTotal={total}
                 disableInitialFetch
+                // `base` — not the raw slug — because that is the normalized
+                // store key favorites are filed under (the same value the
+                // canonical URL uses), so /coupons/www.nike.com and
+                // /coupons/nike.com star ONE row rather than two.
+                //
+                // The star renders nothing at all for signed-out visitors, so
+                // this route's server HTML — the thing SEO and the AEO prose
+                // below depend on — is unchanged for crawlers.
+                heroAction={<StoreFavoriteStar store={base} />}
                 heroTitle={`Best ${base} coupon codes today`}
                 heroSubtitle={`Save at ${base} with Caramel—the privacy-first coupon finder that applies the top deals automatically at checkout.`}
             />

--- a/apps/caramel-app/src/app/api/account/favorites/[store]/route.ts
+++ b/apps/caramel-app/src/app/api/account/favorites/[store]/route.ts
@@ -1,0 +1,88 @@
+import {
+    addFavoriteStore,
+    normalizeFavoriteStoreKey,
+    removeFavoriteStore,
+} from '@/lib/account/favoriteStores'
+import { withRoute } from '@/lib/api/withRoute'
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+// PUT /api/account/favorites/:store   — follow a store   (idempotent upsert)
+// DELETE /api/account/favorites/:store — unfollow a store (idempotent delete)
+//
+// PUT/DELETE rather than POST/POST because both are genuinely idempotent: the
+// star is a toggle two surfaces can fire (the extension popup header and the
+// /coupons/[store] page), the web page removes optimistically with an undo, and
+// none of that may depend on how many times a request actually landed. A repeat
+// PUT is 200, a repeat DELETE is 200 — never a 404 the caller has to special-case.
+//
+// The store key travels in the PATH, so both methods carry no body and the
+// response always echoes the NORMALIZED key the server actually wrote, which is
+// what a client should store (see favoriteStores.ts's vocabulary header — the
+// popup sends the tab's hostname and gets back the registrable domain).
+//
+// Same route-config idiom as extension/me + coupons/[id]/report: session-gated,
+// origin-gated, mutation-rate-limited, no CORS/OPTIONS (host_permissions fetch).
+const routeConfig = {
+    routeName: 'account/favorites/store',
+    rateLimit: 'mutation',
+    origin: true,
+    auth: 'session',
+} as const
+
+function invalidStore(): NextResponse {
+    return NextResponse.json({ error: 'Invalid store' }, { status: 422 })
+}
+
+/**
+ * The `:store` path segment, normalized to a real store key — or null when the
+ * segment names no store.
+ *
+ * withRoute deliberately does not thread Next's dynamic `params` to handlers (a
+ * path param is route-specific data, not a cross-cutting concern), so the
+ * segment is read off the URL exactly as coupons/[id]/report reads its id: the
+ * LAST segment of `/api/account/favorites/<store>`. It arrives
+ * percent-encoded from every caller (`encodeURIComponent`), so it is decoded
+ * before normalization — a raw `decodeURIComponent` throws on a malformed
+ * escape, which would otherwise become a 500 for what is plainly a 422.
+ */
+function storeKeyFromUrl(req: NextRequest): string | null {
+    const segments = new URL(req.url).pathname.split('/')
+    const raw = segments[segments.length - 1] ?? ''
+    if (!raw) return null
+    let decoded: string
+    try {
+        decoded = decodeURIComponent(raw)
+    } catch {
+        return null
+    }
+    return normalizeFavoriteStoreKey(decoded)
+}
+
+export const PUT = withRoute(
+    { ...routeConfig, method: 'PUT' },
+    async ({ req, session }) => {
+        if (!session?.user) {
+            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+        }
+        const store = storeKeyFromUrl(req)
+        if (!store) return invalidStore()
+
+        await addFavoriteStore(session.user.id, store)
+        return NextResponse.json({ ok: true, store, favorited: true })
+    },
+)
+
+export const DELETE = withRoute(
+    { ...routeConfig, method: 'DELETE' },
+    async ({ req, session }) => {
+        if (!session?.user) {
+            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+        }
+        const store = storeKeyFromUrl(req)
+        if (!store) return invalidStore()
+
+        await removeFavoriteStore(session.user.id, store)
+        return NextResponse.json({ ok: true, store, favorited: false })
+    },
+)

--- a/apps/caramel-app/src/app/api/account/favorites/route.ts
+++ b/apps/caramel-app/src/app/api/account/favorites/route.ts
@@ -1,0 +1,37 @@
+import { listFavoriteStores } from '@/lib/account/favoriteStores'
+import { withRoute } from '@/lib/api/withRoute'
+import { NextResponse } from 'next/server'
+
+// GET /api/account/favorites — the stores the signed-in user follows.
+//
+// `auth: 'session'` GATES this one (not 'optional'): a favorites list is
+// per-person state with nothing meaningful to serve an anonymous caller, so a
+// missing/expired credential is a 401 and the handler never runs. Both callers
+// are already signed-in surfaces — the account page's "Stores you follow"
+// section and the extension popup's star, which sends the same bearer it uses
+// for every other API call.
+//
+// No CORS / no OPTIONS export, matching coupons/[id]/report: the MV3 extension
+// fetches with host_permissions, so its request never preflights and CORS
+// headers here would be dead ceremony. `origin: true` still rejects a random
+// website's cross-origin fetch (it accepts extension protocols and same-origin
+// — see rateLimit.ts's isOriginAllowed).
+export const GET = withRoute(
+    {
+        method: 'GET',
+        routeName: 'account/favorites',
+        rateLimit: 'read',
+        origin: true,
+        auth: 'session',
+    },
+    async ({ session }) => {
+        if (!session?.user) {
+            // withRoute's auth gate already 401s a missing session; this guard
+            // covers the malformed-session edge (and narrows the type), the
+            // same way extension/me does.
+            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+        }
+        const favorites = await listFavoriteStores(session.user.id)
+        return NextResponse.json({ favorites })
+    },
+)

--- a/apps/caramel-app/src/components/coupons/coupons-section.tsx
+++ b/apps/caramel-app/src/components/coupons/coupons-section.tsx
@@ -23,6 +23,14 @@ interface CouponsSectionProps {
     disableInitialFetch?: boolean
     heroTitle?: string
     heroSubtitle?: string
+    /** Optional control rendered under the hero subtitle — the store page's
+     * "follow this store" star. A SLOT rather than a prop the section knows
+     * about, so this shared component stays ignorant of accounts and favorites.
+     *
+     * Omitting it renders NOTHING extra: /coupons (a visual-regression
+     * baseline) passes no slot and its DOM is byte-identical to before. Only
+     * /coupons/[store], which has no baseline, fills it. */
+    heroAction?: React.ReactNode
 }
 
 const ITEMS_PER_PAGE = 5
@@ -34,6 +42,7 @@ export default function CouponsSection({
     disableInitialFetch = false,
     heroTitle = 'All Coupons',
     heroSubtitle = 'Browse verified coupon codes, promo codes, and offers.',
+    heroAction,
 }: CouponsSectionProps) {
     const MIN_LOADING_DELAY_MS = 350
 
@@ -280,6 +289,7 @@ export default function CouponsSection({
                         {heroSubtitle}
                     </p>
                 ) : null}
+                {heroAction ?? null}
             </motion.div>
 
             <div className="flex gap-8 md:flex-col">

--- a/apps/caramel-app/src/components/coupons/store-favorite-star.tsx
+++ b/apps/caramel-app/src/components/coupons/store-favorite-star.tsx
@@ -1,0 +1,156 @@
+'use client'
+
+import { useSession } from '@/lib/auth/client'
+import { promptSupportOnFailure } from '@/lib/feedback/promptSupportOnFailure'
+import { useCallback, useEffect, useState } from 'react'
+import { FaRegStar, FaStar } from 'react-icons/fa'
+import { toast } from 'sonner'
+
+// The "follow this store" star on /coupons/[store].
+//
+// PLACEMENT IS DELIBERATE AND NARROW. It goes on the store page and nowhere
+// else: SiteCard (/supported-stores) and CouponCard (/coupons) are both inside
+// the eight visual-regression baselines, so a star in either would turn this
+// into an eight-screenshot diff. /coupons/[store] has no baseline. Grid-wide
+// starring, if it ever ships, is its own PR with an intentional baseline update.
+//
+// SIGNED-OUT RENDERS NOTHING. Not a disabled star, not a "sign in to follow"
+// stub: a control that exists only to bounce someone into a login form is worse
+// than no control, and the store page's job is showing codes. Following is
+// taught where it can actually be performed — the extension popup and the
+// account page's empty state.
+
+/** `aria-pressed` is what a toggle BUTTON announces (a switch would be
+ * `aria-checked`; this is a button). Labels name the store so the control makes
+ * sense read on its own out of the page's tab order. */
+function starLabel(store: string, following: boolean): string {
+    return following
+        ? `Remove ${store} from your stores`
+        : `Follow ${store} to keep its best codes one click away`
+}
+
+export default function StoreFavoriteStar({ store }: { store: string }) {
+    const { data: session, isPending } = useSession()
+    // Same hydration hazard the profile page documents: the session lives in a
+    // cookie the CLIENT reads for itself, so the server always renders the
+    // signed-out branch (nothing) while a warm client would render the star on
+    // its very first pass — a mismatch React resolves by throwing the tree away.
+    // Holding the null branch until mounted makes the hydrating render match the
+    // server; the real state lands one commit later, before paint.
+    const [mounted, setMounted] = useState(false)
+    const [following, setFollowing] = useState(false)
+    const [busy, setBusy] = useState(false)
+
+    useEffect(() => setMounted(true), [])
+
+    const signedIn = Boolean(session?.user)
+
+    // Current state comes from the list endpoint rather than a per-store probe:
+    // one route, one shape, and the account page needs the same list anyway.
+    useEffect(() => {
+        if (!signedIn) return
+        let cancelled = false
+        fetch('/api/account/favorites')
+            .then(res => (res.ok ? res.json() : null))
+            .then((data: { favorites?: { store: string }[] } | null) => {
+                if (cancelled || !data?.favorites) return
+                setFollowing(data.favorites.some(f => f.store === store))
+            })
+            .catch(() => {
+                // A failed READ leaves the star showing "not following", which
+                // is the honest default: the next click sends a PUT, which is
+                // idempotent, so a wrong guess here cannot corrupt anything.
+                // Deliberately silent — this is a passive state fetch the user
+                // never asked for, and promptSupportOnFailure is for actions
+                // the user SEES fail.
+            })
+        return () => {
+            cancelled = true
+        }
+    }, [signedIn, store])
+
+    const write = useCallback(
+        async (next: boolean) => {
+            const res = await fetch(
+                `/api/account/favorites/${encodeURIComponent(store)}`,
+                { method: next ? 'PUT' : 'DELETE' },
+            )
+            if (!res.ok) throw new Error(`favorites ${res.status}`)
+        },
+        [store],
+    )
+
+    const toggle = useCallback(async () => {
+        if (busy) return
+        const next = !following
+        setBusy(true)
+        // Optimistic: the star flips now. Both writes are idempotent, so the
+        // only thing a failure has to undo is this local flip.
+        setFollowing(next)
+        try {
+            await write(next)
+            if (next) {
+                toast.success(`Following ${store}.`)
+            } else {
+                // Undo is not optional on the unstar. The star is a small
+                // target and a mis-tap that silently drops a followed store is
+                // exactly the failure this affordance invites.
+                toast(`Removed ${store} from your stores.`, {
+                    action: {
+                        label: 'Undo',
+                        onClick: () => {
+                            setFollowing(true)
+                            write(true).catch(error => {
+                                setFollowing(false)
+                                toast.error(
+                                    `Couldn’t add ${store} back. Please try again.`,
+                                )
+                                promptSupportOnFailure({
+                                    error,
+                                    operation: 'favorite_store_undo',
+                                })
+                            })
+                        },
+                    },
+                })
+            }
+        } catch (error) {
+            setFollowing(!next)
+            toast.error(
+                next
+                    ? `Couldn’t follow ${store}. Please try again.`
+                    : `Couldn’t remove that store. It’s still on your list.`,
+            )
+            promptSupportOnFailure({
+                error,
+                operation: 'favorite_store_toggle',
+            })
+        } finally {
+            setBusy(false)
+        }
+    }, [busy, following, store, write])
+
+    if (!mounted || isPending || !signedIn) return null
+
+    const Icon = following ? FaStar : FaRegStar
+
+    return (
+        <div className="mt-5 flex justify-center">
+            <button
+                type="button"
+                onClick={toggle}
+                aria-pressed={following}
+                aria-label={starLabel(store, following)}
+                disabled={busy}
+                // min-h/min-w keep the tap target at 44px on the phone
+                // viewports this page is most often read on. The focus ring
+                // comes free from globals.css's :focus-visible rule for
+                // buttons — no competing ring here.
+                className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center gap-2 rounded-xl border border-gray-300 bg-white px-4 py-2.5 text-sm font-semibold text-gray-700 shadow-sm transition duration-200 hover:border-caramel hover:bg-caramel/5 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-700 dark:bg-darkBg dark:text-gray-200 dark:shadow-none dark:hover:border-caramel/60 dark:hover:bg-caramel/10"
+            >
+                <Icon aria-hidden="true" className="h-4 w-4 text-caramel" />
+                {following ? 'Following' : 'Follow this store'}
+            </button>
+        </div>
+    )
+}

--- a/apps/caramel-app/src/lib/account/favoriteStores.ts
+++ b/apps/caramel-app/src/lib/account/favoriteStores.ts
@@ -1,0 +1,97 @@
+// src/lib/account/favoriteStores.ts
+//
+// The one read/write path for `favorite_stores` — "the stores you follow".
+//
+// STORE KEY VOCABULARY (the reason this module exists rather than three
+// inline Prisma calls). `FavoriteStore.storeName` is not free text: it is the
+// REGISTRABLE base domain that `resolveStoreDomain()` produces — lowercase,
+// `www.`/subdomains stripped, resolved against the Public Suffix List, so
+// `www.nike.com`, `shop.nike.com` and `https://nike.com/cart` all key the same
+// row. That is deliberately the SAME vocabulary as:
+//
+//   - `store_configs.store_name` (the published apply-config; its seed rows are
+//     'ebay.com', 'amazon.com', 'codecademy.com') — joins on equality;
+//   - the catalog's `coupons.site`, which listStoreCoupons() matches with
+//     `site = <key> OR site LIKE '%.' || <key>` (a store's coupons are filed
+//     under any of its hostnames);
+//   - the `/coupons/[store]` URL, whose canonical is exactly this key.
+//
+// So a favorite joins cleanly against catalog data without a second
+// normalization step anywhere, and a row read back out of this table can be
+// dropped straight into a store-page href.
+//
+// Normalization happens HERE, at the write boundary, not at the call site: a
+// row in this table is always already normalized, and an input that names no
+// real store (a bare public suffix like `co.uk`, an invented TLD, junk) is
+// refused rather than stored — the same refusal `/coupons/[store]` makes, for
+// the same reason (see storeDomain.ts's header: treating `co.uk` as a store
+// once returned another brand's coupons for 230 hostnames).
+import prisma from '@/lib/prisma'
+import { resolveStoreDomain } from '@/lib/storeDomain'
+
+/** One followed store as the API serves it. */
+export interface FavoriteStoreRecord {
+    /** The normalized store key — see this module's header. */
+    store: string
+    /** ISO timestamp of when the user starred it. */
+    createdAt: string
+}
+
+/**
+ * The store key for `raw`, or null when `raw` names no real store. Callers
+ * MUST reject null (422) rather than passing the raw value through — this is
+ * the only sanctioned way to turn user input into a `store_name`.
+ */
+export function normalizeFavoriteStoreKey(raw: string): string | null {
+    return resolveStoreDomain(raw)
+}
+
+/** Every store `userId` follows, most recently starred first. */
+export async function listFavoriteStores(
+    userId: string,
+): Promise<FavoriteStoreRecord[]> {
+    const rows = await prisma.favoriteStore.findMany({
+        where: { userId },
+        orderBy: { createdAt: 'desc' },
+        select: { storeName: true, createdAt: true },
+    })
+    return rows.map(row => ({
+        store: row.storeName,
+        createdAt: row.createdAt.toISOString(),
+    }))
+}
+
+/**
+ * Follows `storeName` for `userId`. IDEMPOTENT: starring an already-starred
+ * store is a success, not a conflict — the star is a toggle the extension and
+ * the web page can both fire, and a double-tap must not produce an error the
+ * user has to think about.
+ *
+ * `update: {}` is load-bearing, not a placeholder: re-starring must NOT reset
+ * `createdAt` (the profile page orders by it) and must NOT touch
+ * `notifyOnNew`, which is a dormant column this PR never writes.
+ */
+export async function addFavoriteStore(
+    userId: string,
+    storeName: string,
+): Promise<void> {
+    await prisma.favoriteStore.upsert({
+        where: { userId_storeName: { userId, storeName } },
+        create: { userId, storeName },
+        update: {},
+    })
+}
+
+/**
+ * Unfollows `storeName` for `userId`. IDEMPOTENT the other way: `deleteMany`
+ * rather than `delete` because a `delete` on a missing composite key throws
+ * P2025, which would turn an unstar of something already unstarred (a stale
+ * popup, a double-tap, an undo that raced) into a 500. Zero rows removed is a
+ * correct outcome here, not an error.
+ */
+export async function removeFavoriteStore(
+    userId: string,
+    storeName: string,
+): Promise<void> {
+    await prisma.favoriteStore.deleteMany({ where: { userId, storeName } })
+}

--- a/apps/caramel-app/tests/unit/account-favorites.test.ts
+++ b/apps/caramel-app/tests/unit/account-favorites.test.ts
@@ -1,0 +1,304 @@
+import { DELETE, PUT } from '@/app/api/account/favorites/[store]/route'
+import { GET } from '@/app/api/account/favorites/route'
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Favorites-route unit pins — "the stores you follow". Same shape as
+// coupons-report.test.ts: mock the app Postgres (@/lib/prisma), keep
+// isOriginAllowed real, drive the exported handlers with constructed
+// NextRequests.
+//
+// What these pin, and why each one is here rather than assumed:
+//   - the SESSION GATE actually gates (an anonymous caller must never reach the
+//     DB — a favorites row is per-person state);
+//   - both writes are IDEMPOTENT, in both directions, because two surfaces fire
+//     the same toggle and the web star removes optimistically with an undo;
+//   - the store key is NORMALIZED at the boundary, so `www.NIKE.com`, a bare
+//     hostname and a full URL all key ONE row that joins against the catalog;
+//   - garbage that names no store is refused 422 and never reaches Prisma.
+const { prismaMock } = vi.hoisted(() => ({
+    prismaMock: {
+        favoriteStore: {
+            findMany: vi.fn(
+                async (_args: unknown) =>
+                    [] as { storeName: string; createdAt: Date }[],
+            ),
+            upsert: vi.fn(async (_args: unknown) => ({})),
+            deleteMany: vi.fn(async (_args: unknown) => ({ count: 0 })),
+        },
+    },
+}))
+vi.mock('@/lib/prisma', () => ({ default: prismaMock }))
+
+// Only the rate-limit round-trip is stubbed; isOriginAllowed stays real so a
+// no-Origin request passes exactly like the extension's host_permissions fetch.
+vi.mock('@/lib/rateLimit', async importOriginal => {
+    const actual = await importOriginal<typeof import('@/lib/rateLimit')>()
+    return { ...actual, checkRateLimit: vi.fn(async () => null) }
+})
+
+const { getSessionMock } = vi.hoisted(() => ({
+    getSessionMock: vi.fn(
+        async (_opts: { headers: Headers }) => null as unknown,
+    ),
+}))
+vi.mock('@/lib/auth/auth', () => ({
+    auth: { api: { getSession: getSessionMock } },
+}))
+
+const USER_ID = 'user_abc123'
+
+function signedIn(): void {
+    getSessionMock.mockResolvedValue({ user: { id: USER_ID } })
+}
+function signedOut(): void {
+    getSessionMock.mockResolvedValue(null)
+}
+
+function listRequest(): NextRequest {
+    return new NextRequest('http://localhost/api/account/favorites', {
+        method: 'GET',
+    })
+}
+
+function storeRequest(rawStore: string, method: 'PUT' | 'DELETE'): NextRequest {
+    return new NextRequest(
+        `http://localhost/api/account/favorites/${encodeURIComponent(rawStore)}`,
+        { method },
+    )
+}
+
+beforeEach(() => {
+    prismaMock.favoriteStore.findMany.mockClear()
+    prismaMock.favoriteStore.findMany.mockResolvedValue([])
+    prismaMock.favoriteStore.upsert.mockClear()
+    prismaMock.favoriteStore.deleteMany.mockClear()
+    getSessionMock.mockReset()
+})
+
+describe('favorites routes — the session gate is a real gate', () => {
+    it('GET /api/account/favorites 401s an anonymous caller and never queries', async () => {
+        signedOut()
+        const res = await GET(listRequest())
+
+        expect(res.status).toBe(401)
+        expect(prismaMock.favoriteStore.findMany).not.toHaveBeenCalled()
+    })
+
+    it('PUT 401s an anonymous caller and writes nothing', async () => {
+        signedOut()
+        const res = await PUT(storeRequest('nike.com', 'PUT'))
+
+        expect(res.status).toBe(401)
+        expect(prismaMock.favoriteStore.upsert).not.toHaveBeenCalled()
+    })
+
+    it('DELETE 401s an anonymous caller and deletes nothing', async () => {
+        signedOut()
+        const res = await DELETE(storeRequest('nike.com', 'DELETE'))
+
+        expect(res.status).toBe(401)
+        expect(prismaMock.favoriteStore.deleteMany).not.toHaveBeenCalled()
+    })
+})
+
+describe('GET /api/account/favorites — the list', () => {
+    it('serves only the session user’s rows, newest first, as {store, createdAt}', async () => {
+        signedIn()
+        prismaMock.favoriteStore.findMany.mockResolvedValue([
+            {
+                storeName: 'nike.com',
+                createdAt: new Date('2026-08-09T10:00:00Z'),
+            },
+            {
+                storeName: 'ebay.com',
+                createdAt: new Date('2026-08-01T10:00:00Z'),
+            },
+        ])
+
+        const res = await GET(listRequest())
+
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({
+            favorites: [
+                { store: 'nike.com', createdAt: '2026-08-09T10:00:00.000Z' },
+                { store: 'ebay.com', createdAt: '2026-08-01T10:00:00.000Z' },
+            ],
+        })
+        const args = prismaMock.favoriteStore.findMany.mock.calls[0]![0] as {
+            where: { userId: string }
+            orderBy: { createdAt: string }
+        }
+        expect(args.where).toEqual({ userId: USER_ID })
+        expect(args.orderBy).toEqual({ createdAt: 'desc' })
+    })
+
+    it('a user with no favorites gets an empty list, not an error', async () => {
+        signedIn()
+        const res = await GET(listRequest())
+
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({ favorites: [] })
+    })
+})
+
+describe('PUT /api/account/favorites/:store — idempotent follow', () => {
+    it('follows the store and echoes the normalized key', async () => {
+        signedIn()
+        const res = await PUT(storeRequest('nike.com', 'PUT'))
+
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({
+            ok: true,
+            store: 'nike.com',
+            favorited: true,
+        })
+        const args = prismaMock.favoriteStore.upsert.mock.calls[0]![0] as {
+            where: { userId_storeName: { userId: string; storeName: string } }
+            create: { userId: string; storeName: string }
+            update: Record<string, unknown>
+        }
+        expect(args.where.userId_storeName).toEqual({
+            userId: USER_ID,
+            storeName: 'nike.com',
+        })
+        expect(args.create).toEqual({ userId: USER_ID, storeName: 'nike.com' })
+    })
+
+    it('following an already-followed store is a 200, not a conflict', async () => {
+        signedIn()
+        const first = await PUT(storeRequest('nike.com', 'PUT'))
+        const second = await PUT(storeRequest('nike.com', 'PUT'))
+
+        expect(first.status).toBe(200)
+        expect(second.status).toBe(200)
+        expect(await second.json()).toMatchObject({ favorited: true })
+        expect(prismaMock.favoriteStore.upsert).toHaveBeenCalledTimes(2)
+    })
+
+    it('the upsert’s update clause is EMPTY — re-following never resets createdAt or notifyOnNew', async () => {
+        // Re-starring must not reorder the account page's list, and this PR
+        // writes no email opt-in anywhere: notify_on_new stays at its default.
+        signedIn()
+        await PUT(storeRequest('nike.com', 'PUT'))
+
+        const args = prismaMock.favoriteStore.upsert.mock.calls[0]![0] as {
+            create: Record<string, unknown>
+            update: Record<string, unknown>
+        }
+        expect(args.update).toEqual({})
+        expect(args.create).not.toHaveProperty('notifyOnNew')
+        expect(args.create).not.toHaveProperty('createdAt')
+    })
+})
+
+describe('DELETE /api/account/favorites/:store — idempotent unfollow', () => {
+    it('unfollows the store and echoes the normalized key', async () => {
+        signedIn()
+        const res = await DELETE(storeRequest('nike.com', 'DELETE'))
+
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({
+            ok: true,
+            store: 'nike.com',
+            favorited: false,
+        })
+        expect(prismaMock.favoriteStore.deleteMany).toHaveBeenCalledWith({
+            where: { userId: USER_ID, storeName: 'nike.com' },
+        })
+    })
+
+    it('unfollowing something not followed is a 200, never a 404', async () => {
+        // deleteMany, not delete: `delete` on a missing composite key throws
+        // P2025, which would turn a stale popup or a double-tap into a 500.
+        signedIn()
+        prismaMock.favoriteStore.deleteMany.mockResolvedValue({ count: 0 })
+
+        const first = await DELETE(storeRequest('nike.com', 'DELETE'))
+        const second = await DELETE(storeRequest('nike.com', 'DELETE'))
+
+        expect(first.status).toBe(200)
+        expect(second.status).toBe(200)
+        expect(await second.json()).toMatchObject({ favorited: false })
+    })
+})
+
+describe('store-key vocabulary — one row per real store', () => {
+    // Every one of these is a different way a caller can name the SAME store:
+    // the popup sends the tab hostname, the web page sends the canonical base
+    // domain, and a hand-typed URL carries a scheme and a path.
+    const sameStore: [string, string][] = [
+        ['nike.com', 'nike.com'],
+        ['www.nike.com', 'nike.com'],
+        ['WWW.NIKE.COM', 'nike.com'],
+        ['shop.nike.com', 'nike.com'],
+        ['https://www.nike.com/cart?x=1', 'nike.com'],
+    ]
+
+    it.each(sameStore)('PUT %s writes store_name %s', async (raw, expected) => {
+        signedIn()
+        const res = await PUT(storeRequest(raw, 'PUT'))
+
+        expect(res.status).toBe(200)
+        expect(await res.json()).toMatchObject({ store: expected })
+        const args = prismaMock.favoriteStore.upsert.mock.calls[0]![0] as {
+            create: { storeName: string }
+        }
+        expect(args.create.storeName).toBe(expected)
+    })
+
+    it('a multi-label public suffix keeps its registrable label (mymemory.co.uk, not co.uk)', async () => {
+        // The bug storeDomain.ts exists to prevent: "last two labels" collapsed
+        // this to the SUFFIX, which matched every UK store in the catalogue.
+        signedIn()
+        await PUT(storeRequest('www.mymemory.co.uk', 'PUT'))
+
+        const args = prismaMock.favoriteStore.upsert.mock.calls[0]![0] as {
+            create: { storeName: string }
+        }
+        expect(args.create.storeName).toBe('mymemory.co.uk')
+    })
+})
+
+describe('validation — input that names no store is refused, not stored', () => {
+    const garbage = [
+        'co.uk', // a bare public suffix is not a store
+        'com',
+        'localhost',
+        'not a domain',
+        '../../etc/passwd',
+        "nike.com'; DROP TABLE favorite_stores;--",
+        '%%%',
+    ]
+
+    it.each(garbage)('PUT %j → 422 and writes nothing', async raw => {
+        signedIn()
+        const res = await PUT(storeRequest(raw, 'PUT'))
+
+        expect(res.status).toBe(422)
+        expect(await res.json()).toEqual({ error: 'Invalid store' })
+        expect(prismaMock.favoriteStore.upsert).not.toHaveBeenCalled()
+    })
+
+    it.each(garbage)('DELETE %j → 422 and deletes nothing', async raw => {
+        signedIn()
+        const res = await DELETE(storeRequest(raw, 'DELETE'))
+
+        expect(res.status).toBe(422)
+        expect(prismaMock.favoriteStore.deleteMany).not.toHaveBeenCalled()
+    })
+
+    it('a malformed percent-escape is a 422, not a 500', async () => {
+        // decodeURIComponent throws on '%zz'; an unguarded decode would make
+        // that an uncaught 500 for what is plainly bad input.
+        signedIn()
+        const res = await PUT(
+            new NextRequest('http://localhost/api/account/favorites/%zz', {
+                method: 'PUT',
+            }),
+        )
+
+        expect(res.status).toBe(422)
+        expect(prismaMock.favoriteStore.upsert).not.toHaveBeenCalled()
+    })
+})

--- a/apps/caramel-extension/.size-limit.js
+++ b/apps/caramel-extension/.size-limit.js
@@ -162,7 +162,22 @@ module.exports = [
     {
         name: 'popup.js',
         path: 'popup.js',
-        limit: '54 KB',
+        // 2026-08-09 — 54 → 60 KB, first raise for this budget. The
+        // follow-this-store star in the coupons-view header: the button markup,
+        // the star SVG in both states, and wireFavoriteStoreButton() (asks the
+        // account what it follows, paints the true state, toggles through the
+        // service worker, reverts a rejected write). ~3.5 kB is code and markup;
+        // the rest states the two constraints that would otherwise be re-decided
+        // wrongly — the star is signed-in-only, and it must live INSIDE the
+        // existing header row, because popup-sizing.test.mjs's 320px coupon-list
+        // cap is measured against everything stacked above it and a header that
+        // grew by a row would slice the last coupon card. A trimming pass paid
+        // back 0.35 kB; going further meant deleting those two, which the
+        // 232 → 233 KB note above already ruled the worse trade. Measured
+        // 59.32 kB — 60 rather than 59.5 for the same reason the 249 line gives:
+        // headroom keeps the next comment edit from failing a build for a reason
+        // that says nothing true about bundle weight.
+        limit: '60 KB',
         brotli: false,
     },
     {
@@ -180,7 +195,16 @@ module.exports = [
         // grew a per-call override; 8 s stays the default for small calls)
         // plus one retry — the measured cold fetch is the slow one and the
         // warm retry lands in seconds. Measured 17.55 kB.
-        limit: '18 KB',
+        //
+        // 2026-08-09 — 18 → 20 KB. The two favorites actions the popup star
+        // rides on (getFavoriteStores / setFavoriteStore → the session-gated
+        // /api/account/favorites routes, via fetchCaramelApi so the stored
+        // bearer is attached in the one place that ever attaches it). ~0.9 kB is
+        // code; the rest records why a 401 is answered as an error rather than
+        // an empty list — "you follow nothing" and "we couldn't ask" are
+        // different answers and the star must not paint the first when it means
+        // the second. Measured 19.02 kB; 20 for the usual headroom.
+        limit: '20 KB',
         brotli: false,
     },
 ]

--- a/apps/caramel-extension/assets/styles.css
+++ b/apps/caramel-extension/assets/styles.css
@@ -716,6 +716,34 @@ body {
     color: var(--cm-on-brand);
 }
 
+/* Right-hand action cluster in the coupons-view header (follow-star + log out).
+   .coupons-profile-row is space-between with exactly two children; wrapping the
+   two buttons keeps it two, so adding the star doesn't spread the row.
+
+   HEIGHT-NEUTRAL BY CONSTRUCTION, and that is the point: the buttons inside
+   already own the row's height (.coupons-logout-button min-height: 40px) and
+   this rule adds no padding, border or min-height of its own. Everything
+   stacked above the coupon list is pinned arithmetic — tests/popup-sizing.test.mjs
+   holds .coupon-list's 320px cap against a measured ~279px of surrounding
+   chrome, so a header that grew by even one row would slice the last coupon
+   card inside body's overflow:hidden. */
+.coupons-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+/* Icon-only variant of the header button: the label is the aria-label, so the
+   horizontal padding drops to keep it square-ish, and the 40px min-height it
+   inherits carries the tap target. */
+.coupons-icon-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 40px;
+    padding: 6px 10px;
+}
+
 /* -------------- Toast / Confirmation -------------- */
 .copy-toast-container {
     position: fixed;

--- a/apps/caramel-extension/background.js
+++ b/apps/caramel-extension/background.js
@@ -340,6 +340,45 @@ currentBrowser.runtime.onMessage.addListener(
             }
             sendResponse({ success: true })
             return true
+        } else if (message.action === 'getFavoriteStores') {
+            // The stores this account follows. fetchCaramelApi so the stored
+            // bearer rides along (the route is session-gated). A 401 is reported
+            // as an ERROR, never an empty list: "you follow nothing" and "we
+            // couldn't ask" are different answers and the star must not paint
+            // the first when it means the second.
+            fetchCaramelApi(caramelUrl('api/account/favorites'))
+                .then(async r => {
+                    if (!r.ok) return { error: `HTTP ${r.status}` }
+                    return r.json()
+                })
+                .then(resp => sendResponse(resp))
+                .catch(err => {
+                    logError('getFavoriteStores', err)
+                    sendResponse({ error: String(err) })
+                })
+
+            return true
+        } else if (message.action === 'setFavoriteStore') {
+            // Follow / unfollow one store. PUT and DELETE are both idempotent
+            // server-side, so a double-tap or retry is safe; the response echoes
+            // the NORMALIZED key the server wrote (the popup sends a tab
+            // hostname like "shop.nike.com"; the account keys on "nike.com").
+            const { site, favorite } = message
+            fetchCaramelApi(
+                caramelUrl(`api/account/favorites/${encodeURIComponent(site)}`),
+                { method: favorite ? 'PUT' : 'DELETE' },
+            )
+                .then(async r => {
+                    if (!r.ok) return { error: `HTTP ${r.status}` }
+                    return r.json()
+                })
+                .then(resp => sendResponse(resp))
+                .catch(err => {
+                    logError('setFavoriteStore', err)
+                    sendResponse({ error: String(err) })
+                })
+
+            return true
         } else if (message.action === 'fetchSupportedStores') {
             const url = caramelUrl('api/extension/supported-stores')
             // The bulk payload gets the larger budget, and one retry: the

--- a/apps/caramel-extension/popup.js
+++ b/apps/caramel-extension/popup.js
@@ -1025,6 +1025,98 @@ function renderProfileCard(user) {
 }
 
 /* ------------------------------------------------------------ */
+/*  Follow this store (favorites)                               */
+/* ------------------------------------------------------------ */
+// Stroke star when not following, filled when following — the popup's icon
+// convention (16px, currentColor), so it inherits .coupons-logout-button's
+// brand colour and its dark value from --cm-* with no colour of its own.
+const FAVORITE_STAR_SVG = following => `
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="${following ? 'currentColor' : 'none'}" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="m12 3 2.9 5.9 6.5.9-4.7 4.6 1.1 6.5-5.8-3-5.8 3 1.1-6.5L2.6 9.8l6.5-.9z"/>
+  </svg>`
+
+/** Repaints the star for `following` — icon fill, aria-pressed, and the label
+ * a screen reader reads. `aria-pressed` (not aria-checked): this is a toggle
+ * BUTTON, not a switch. */
+function paintFavoriteStoreButton(button, domain, following) {
+    button.setAttribute('aria-pressed', following ? 'true' : 'false')
+    const label = following ? `Unfollow ${domain}` : `Follow ${domain}`
+    button.setAttribute('aria-label', label)
+    button.setAttribute('title', label)
+    button.innerHTML = FAVORITE_STAR_SVG(following)
+}
+
+/**
+ * Wires the header star: asks the account what it follows, paints the true
+ * state, then toggles on click. Every call goes through caramelSendMessage →
+ * background.js, never a direct fetch — the bearer lives in the worker's read
+ * path (getStoredToken), the one place any API call attaches it.
+ *
+ * DISABLED until the account answers, and it stays disabled if the answer never
+ * comes (offline, dead session). An enabled star showing a guessed state invites
+ * a click that writes the opposite of what the user is looking at; a brief
+ * disabled beat does not, and following is not why the popup is open.
+ */
+function wireFavoriteStoreButton(domain) {
+    const button = document.getElementById('favoriteStoreBtn')
+    if (!button || !domain) return
+
+    caramelSendMessage({ action: 'getFavoriteStores' })
+        .then(resp => {
+            if (!resp || resp.error || !Array.isArray(resp.favorites)) return
+            // Suffix-tolerant match, the same predicate the settings view uses
+            // for paused sites: the popup knows the tab hostname
+            // ("shop.nike.com") while the account is keyed on the registrable
+            // domain ("nike.com").
+            const following = resp.favorites.some(
+                f =>
+                    f &&
+                    typeof f.store === 'string' &&
+                    (domain === f.store || domain.endsWith('.' + f.store)),
+            )
+            paintFavoriteStoreButton(button, domain, following)
+            button.disabled = false
+        })
+        .catch(err => log('FAVORITES_LOAD_FAILED', err?.message))
+
+    button.addEventListener('click', () => {
+        if (button.disabled) return
+        const next = button.getAttribute('aria-pressed') !== 'true'
+        // Optimistic, then reconciled: both writes are idempotent, so the only
+        // thing a failure has to undo is this local flip.
+        paintFavoriteStoreButton(button, domain, next)
+        button.disabled = true
+        caramelSendMessage({
+            action: 'setFavoriteStore',
+            site: domain,
+            favorite: next,
+        })
+            .then(resp => {
+                if (!resp || resp.error)
+                    throw new Error(resp?.error || 'failed')
+                paintFavoriteStoreButton(
+                    button,
+                    domain,
+                    Boolean(resp.favorited),
+                )
+                showCopyToast(
+                    resp.favorited
+                        ? `Following ${domain}`
+                        : `Unfollowed ${domain}`,
+                )
+            })
+            .catch(err => {
+                paintFavoriteStoreButton(button, domain, !next)
+                showCopyToast("Couldn't save that — please try again")
+                log('FAVORITE_TOGGLE_FAILED', err?.message)
+            })
+            .finally(() => {
+                button.disabled = false
+            })
+    })
+}
+
+/* ------------------------------------------------------------ */
 /*  Coupons view                                                */
 /* ------------------------------------------------------------ */
 function renderCouponsView(coupons, user, domain) {
@@ -1044,8 +1136,21 @@ function renderCouponsView(coupons, user, domain) {
         <span class="coupons-user-label">Guest</span>
       `
 
+    // Follow-this-store star. SIGNED-IN ONLY: a guest tapping a star only to be
+    // bounced into a sign-in form is a bad first touch, and this header already
+    // branches on `user`. It sits INSIDE the existing header row (never its own
+    // row) and reuses .coupons-logout-button, so the row's height is unchanged —
+    // popup-sizing.test.mjs pins .coupon-list's 320px cap against everything
+    // stacked above it, and a taller header is what would break that. Starts
+    // unpressed + disabled; wireFavoriteStoreButton() corrects it.
+    const favoriteButton = user
+        ? `<button id="favoriteStoreBtn" class="coupons-logout-button coupons-icon-button" type="button" aria-pressed="false" aria-label="Follow ${escHtml(domain)}" title="Follow ${escHtml(domain)}" disabled>
+             ${FAVORITE_STAR_SVG(false)}
+           </button>`
+        : ''
+
     const headerRight = user
-        ? '<button id="logoutBtn" class="coupons-logout-button">Log out</button>'
+        ? `<div class="coupons-header-actions">${favoriteButton}<button id="logoutBtn" class="coupons-logout-button">Log out</button></div>`
         : '<button id="loginToggleBtn" class="coupons-logout-button">Log in</button>'
 
     container.innerHTML = `
@@ -1168,6 +1273,10 @@ function renderCouponsView(coupons, user, domain) {
         logoutBtn.addEventListener('click', () => {
             signOutAndRevoke(() => renderSignInPrompt(selfCallback), logoutBtn)
         })
+
+    /* follow-this-store star (signed-in only; the element simply isn't in the
+       markup for a guest, so this is a no-op there) */
+    wireFavoriteStoreButton(domain)
 
     /* login toggle (guest) */
     const loginToggle = document.getElementById('loginToggleBtn')

--- a/apps/caramel-extension/tests/popup-favorite-store.test.mjs
+++ b/apps/caramel-extension/tests/popup-favorite-store.test.mjs
@@ -1,0 +1,278 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+    getOnMessageListeners,
+    loadExtensionSource,
+    loadExtensionSources,
+} from './_load.mjs'
+
+// The popup's "follow this store" star (favorites).
+//
+// Three things are worth a test here and each has already been a bug class in
+// this popup:
+//
+//  1. THE LOGGED-OUT POPUP MUST BE UNCHANGED. The star is signed-in-only, so a
+//     guest's header must render byte-for-byte what it rendered before — no
+//     star, no wrapper, no extra control to mis-tap into a sign-in wall.
+//  2. THE HEADER MUST NOT GROW. tests/popup-sizing.test.mjs pins .coupon-list's
+//     320px cap against a measured ~279px of chrome stacked above it; a star
+//     that added a row would slice the last coupon inside body's
+//     overflow:hidden. So: one row, two children, star inside the existing row.
+//  3. THE ACTION NAME MUST MATCH THE WORKER'S. popup and background.js agree
+//     only by string, and background's unknown-action branch answers
+//     {error:'unknown_action'} — which the popup would render as a failed
+//     toggle rather than anything obviously broken. The round-trip test below
+//     drives the REAL background handler with the REAL message the popup
+//     produced, so a rename on either side goes red instead of silent (the
+//     same producer/consumer discipline as popup-tab-url-contract.test.mjs).
+
+const DOMAIN = 'shop.nike.com'
+const USER = { username: 'shopper', image: '' }
+const COUPONS = [{ code: 'SAVE10', title: '10% off', status: 'valid' }]
+
+/** Loads the real popup stack (index.html's script order) into a fresh realm
+ * and returns renderCouponsView. */
+function loadPopup() {
+    document.body.innerHTML = '<div id="auth-container"></div>'
+    loadExtensionSource('coupon-constants.generated.js', [])
+    loadExtensionSources(
+        [
+            'caramel-base.js',
+            'dom-utils.js',
+            'store-detect.js',
+            'coupon-apply.js',
+            'coupon-fetch.js',
+            'coupon-runner.js',
+        ],
+        [],
+    )
+    return loadExtensionSource('popup.js', ['renderCouponsView'])
+}
+
+/** Answers every runtime message from `replies`, recording what was sent.
+ * caramelSendMessage rejects on an `undefined` response, so unknown messages
+ * get an explicit empty object rather than nothing. */
+function stubMessaging(replies) {
+    const sent = []
+    globalThis.currentBrowser.runtime.sendMessage = (message, cb) => {
+        sent.push(message)
+        const reply = replies[message?.action]
+        cb(typeof reply === 'function' ? reply(message) : (reply ?? {}))
+    }
+    return sent
+}
+
+/** Lets the star's fire-and-forget message round trips settle. */
+const settle = () => new Promise(resolve => setTimeout(resolve, 0))
+
+function starButton() {
+    return document.getElementById('favoriteStoreBtn')
+}
+
+beforeEach(() => {
+    document.body.innerHTML = ''
+})
+
+describe('popup header star — signed in', () => {
+    it('renders in the header, starts unpressed and disabled, then reflects the account', async () => {
+        const { renderCouponsView } = loadPopup()
+        stubMessaging({
+            getFavoriteStores: { favorites: [{ store: 'nike.com' }] },
+        })
+
+        renderCouponsView(COUPONS, USER, DOMAIN)
+
+        // Before the account answers: present, unpressed, and NOT clickable —
+        // an enabled star showing a guessed state invites a click that writes
+        // the opposite of what the user is looking at.
+        const before = starButton()
+        expect(before).not.toBeNull()
+        expect(before.getAttribute('aria-pressed')).toBe('false')
+        expect(before.disabled).toBe(true)
+
+        await settle()
+
+        // "shop.nike.com" is followed because the ACCOUNT is keyed on the
+        // registrable domain "nike.com" — the suffix-tolerant match is the
+        // whole reason this assertion is interesting.
+        const after = starButton()
+        expect(after.getAttribute('aria-pressed')).toBe('true')
+        expect(after.disabled).toBe(false)
+        expect(after.getAttribute('aria-label')).toBe(`Unfollow ${DOMAIN}`)
+    })
+
+    it('stays unpressed for a store the account does not follow', async () => {
+        const { renderCouponsView } = loadPopup()
+        stubMessaging({
+            getFavoriteStores: { favorites: [{ store: 'ebay.com' }] },
+        })
+
+        renderCouponsView(COUPONS, USER, DOMAIN)
+        await settle()
+
+        expect(starButton().getAttribute('aria-pressed')).toBe('false')
+        expect(starButton().getAttribute('aria-label')).toBe(`Follow ${DOMAIN}`)
+    })
+
+    it('stays disabled — never lying about the state — when the account cannot be reached', async () => {
+        const { renderCouponsView } = loadPopup()
+        stubMessaging({ getFavoriteStores: { error: 'HTTP 401' } })
+
+        renderCouponsView(COUPONS, USER, DOMAIN)
+        await settle()
+
+        expect(starButton().disabled).toBe(true)
+        expect(starButton().getAttribute('aria-pressed')).toBe('false')
+    })
+
+    it('sits inside the existing header row and adds no row of its own', async () => {
+        // The height contract popup-sizing.test.mjs's arithmetic depends on:
+        // .coupons-profile-row keeps exactly its two children (info + actions),
+        // and the star is a descendant of that row rather than a sibling block.
+        const { renderCouponsView } = loadPopup()
+        stubMessaging({ getFavoriteStores: { favorites: [] } })
+
+        renderCouponsView(COUPONS, USER, DOMAIN)
+        await settle()
+
+        const row = document.querySelector('.coupons-profile-row')
+        expect(row.children).toHaveLength(2)
+        expect(row.contains(starButton())).toBe(true)
+        expect(document.querySelectorAll('.coupons-profile-row')).toHaveLength(
+            1,
+        )
+        // Reuses the header button's sizing rather than introducing a control
+        // with its own height.
+        expect(starButton().className).toContain('coupons-logout-button')
+    })
+})
+
+describe('popup header star — logged out', () => {
+    it('is absent, and the guest header is exactly what it was before favorites existed', async () => {
+        const { renderCouponsView } = loadPopup()
+        const sent = stubMessaging({})
+
+        renderCouponsView(COUPONS, null, DOMAIN)
+        await settle()
+
+        expect(starButton()).toBeNull()
+        expect(document.querySelector('.coupons-header-actions')).toBeNull()
+        // The guest header is still the single Log in button, unwrapped.
+        const row = document.querySelector('.coupons-profile-row')
+        expect(row.children).toHaveLength(2)
+        expect(row.lastElementChild.id).toBe('loginToggleBtn')
+        // And a signed-out popup must not ask the account anything.
+        expect(sent.some(m => m?.action === 'getFavoriteStores')).toBe(false)
+        expect(sent.some(m => m?.action === 'setFavoriteStore')).toBe(false)
+    })
+})
+
+describe('star toggle — round trip through the real service worker', () => {
+    /** Replays `message` against the REAL background.js onMessage handler in a
+     * fresh realm, with fetch stubbed, and reports what it did. */
+    async function replayThroughBackground(message, response) {
+        loadExtensionSource('background.js', [])
+        const [handler] = getOnMessageListeners()
+        const fetchMock = vi.fn(async () => ({
+            ok: true,
+            status: 200,
+            json: async () => response,
+        }))
+        globalThis.fetch = fetchMock
+        const reply = await new Promise(resolve =>
+            handler(message, {}, resolve),
+        )
+        return { fetchMock, reply }
+    }
+
+    it('a click on an unfollowed store sends setFavoriteStore, which the worker turns into a PUT', async () => {
+        const { renderCouponsView } = loadPopup()
+        const sent = stubMessaging({
+            getFavoriteStores: { favorites: [] },
+            setFavoriteStore: { ok: true, store: 'nike.com', favorited: true },
+        })
+
+        renderCouponsView(COUPONS, USER, DOMAIN)
+        await settle()
+        starButton().click()
+        await settle()
+
+        const toggle = sent.find(m => m?.action === 'setFavoriteStore')
+        expect(toggle).toEqual({
+            action: 'setFavoriteStore',
+            site: DOMAIN,
+            favorite: true,
+        })
+        // The star now shows the server's answer, not the optimistic guess.
+        expect(starButton().getAttribute('aria-pressed')).toBe('true')
+        expect(starButton().disabled).toBe(false)
+
+        // …and that exact message, unedited, drives the real worker.
+        const { fetchMock, reply } = await replayThroughBackground(toggle, {
+            ok: true,
+            store: 'nike.com',
+            favorited: true,
+        })
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+        const [url, opts] = fetchMock.mock.calls[0]
+        expect(url).toContain(
+            `/api/account/favorites/${encodeURIComponent(DOMAIN)}`,
+        )
+        expect(opts.method).toBe('PUT')
+        expect(reply).toEqual({ ok: true, store: 'nike.com', favorited: true })
+    })
+
+    it('a click on a followed store sends favorite:false, which the worker turns into a DELETE', async () => {
+        const { renderCouponsView } = loadPopup()
+        const sent = stubMessaging({
+            getFavoriteStores: { favorites: [{ store: 'nike.com' }] },
+            setFavoriteStore: { ok: true, store: 'nike.com', favorited: false },
+        })
+
+        renderCouponsView(COUPONS, USER, DOMAIN)
+        await settle()
+        starButton().click()
+        await settle()
+
+        const toggle = sent.find(m => m?.action === 'setFavoriteStore')
+        expect(toggle.favorite).toBe(false)
+        expect(starButton().getAttribute('aria-pressed')).toBe('false')
+
+        const { fetchMock } = await replayThroughBackground(toggle, {
+            ok: true,
+            store: 'nike.com',
+            favorited: false,
+        })
+        const [, opts] = fetchMock.mock.calls[0]
+        expect(opts.method).toBe('DELETE')
+    })
+
+    it('a rejected write puts the star back where it was', async () => {
+        const { renderCouponsView } = loadPopup()
+        stubMessaging({
+            getFavoriteStores: { favorites: [] },
+            setFavoriteStore: { error: 'HTTP 500' },
+        })
+
+        renderCouponsView(COUPONS, USER, DOMAIN)
+        await settle()
+        starButton().click()
+        await settle()
+
+        // Optimistic flip reverted — the popup never claims a follow the
+        // account did not record.
+        expect(starButton().getAttribute('aria-pressed')).toBe('false')
+        expect(starButton().disabled).toBe(false)
+    })
+
+    it('the worker answers a store it does not know about with unknown_action (the contract a rename would break)', async () => {
+        // Documents the failure mode the round-trip tests above exist to catch:
+        // if popup and background stop agreeing on the action string, the
+        // worker's fallback replies unknown_action and no request is ever made.
+        const { fetchMock, reply } = await replayThroughBackground(
+            { action: 'setFavouriteStore', site: DOMAIN, favorite: true },
+            {},
+        )
+        expect(reply).toEqual({ error: 'unknown_action' })
+        expect(fetchMock).not.toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
Follow a store and its best working codes are one click away — from the extension popup while you're on the store, or from that store's coupons page on the site.

Builds on the `favorite_stores` table and `withRoute`'s session handling from #168 (now on `main`), so this branch is a single commit on top of it.

## API

Three routes under `/api/account/favorites`, all `withRoute` with `auth: 'session'` (anonymous → 401, the handler never runs), `origin: true`, and `rateLimit` `mutation` on the writes / `read` on the list. No CORS or `OPTIONS` exports — the MV3 extension fetches with `host_permissions`, so its requests never preflight, the same standoff `coupons/[id]/report` documents.

| | |
|---|---|
| `GET /api/account/favorites` | `{ favorites: [{ store, createdAt }] }`, newest first |
| `PUT /api/account/favorites/:store` | `{ ok: true, store, favorited: true }` |
| `DELETE /api/account/favorites/:store` | `{ ok: true, store, favorited: false }` |

**Both writes are idempotent, in both directions.** The star is a toggle two surfaces can fire and the web page removes optimistically with an undo, so nothing may depend on how many times a request actually landed. A repeat `PUT` is a 200 (upsert with an empty `update`, so re-following never resets `created_at`), and a repeat `DELETE` is a 200 — `deleteMany` rather than `delete`, because `delete` on a missing composite key throws `P2025` and would turn a stale popup or a double-tap into a 500.

`notify_on_new` stays dormant: nothing in this branch reads or writes it, and there is no email code anywhere in it.

## The store-key vocabulary

`favorite_stores.store_name` is the registrable base domain `resolveStoreDomain()` produces — lowercase, `www.`/subdomains stripped, resolved against the Public Suffix List. `www.nike.com`, `shop.nike.com` and `https://nike.com/cart` all key **one** row.

That is deliberately the same vocabulary as `store_configs.store_name` (whose seed rows are `ebay.com`, `amazon.com`, `codecademy.com`) and the same value `/coupons/[store]` canonicalizes to, so a favorite joins to the apply-config on equality and to the catalog with `listStoreCoupons`'s own predicate — `site = <key> OR site LIKE '%.' || <key>` — with no second normalization anywhere. A row read back out of the table drops straight into a store-page href.

Normalization happens at the write boundary, so a stored row is always already normalized, and input that names no store is refused 422 rather than stored. `co.uk` is not a store: `storeDomain.ts`'s header records what happened the last time something treated a bare public suffix as one.

## Web

A **Follow this store** toggle in the hero of `/coupons/[store]`, signed-in only — optimistic, with an undo action on the toast when you unfollow, reverting through `promptSupportOnFailure` if the write is rejected. Signed out it renders nothing: a control whose only job is to bounce someone into a login form is worse than no control, and following is taught where it can actually be performed.

**Zero visual-regression risk.** `Header.tsx`, `site-card.tsx` and `coupon-card.tsx` are untouched. `CouponsSection` gained one optional `heroAction` slot; `/coupons` passes nothing, so its DOM is byte-identical and the eight baselined pages are unaffected. The star also renders nothing server-side, so the store page's crawler HTML is unchanged.

## Extension

One star in the coupons-view **header row** — not on coupon rows, which are themselves `role="button"` copy targets and would multiply the control by N. It sits inside the existing row and reuses `.coupons-logout-button`, so the header's height is unchanged: `popup-sizing.test.mjs` pins `.coupon-list`'s 320px cap against a measured ~279px of chrome stacked above it, and a header that grew by a row would slice the last coupon card inside `body`'s `overflow:hidden`.

It's `aria-pressed` (a toggle button, not a switch), signed-in only, and stays **disabled until the account answers** — an enabled star showing a guessed state invites a click that writes the opposite of what you're looking at. Two new service-worker actions carry it, so the bearer is still attached in the one place that ever attaches it. Dark mode comes free from the `--cm-*` tokens; the only new CSS is a three-property flex wrapper so the header row keeps its two children.

## Tests

- `apps/caramel-app/tests/unit/account-favorites.test.ts` — **31 tests**: the session gate on all three routes (401 *and* nothing reaches Prisma), idempotency both directions, the empty `update` clause, the five spellings of one store that must key one row, `mymemory.co.uk` keeping its registrable label, and seven kinds of garbage refused 422 without a write (including a malformed percent-escape, which an unguarded decode would have made a 500).
- `apps/caramel-extension/tests/popup-favorite-store.test.mjs` — **9 tests**: the star's three states, the logged-out popup being unchanged (no star, no wrapper, and no request to the account), the header-row structure the sizing arithmetic depends on, and the toggle round-tripping through the **real** `background.js` handler — the message the popup produced, replayed unedited into the worker, asserting the PUT/DELETE it turns into.

Suites: app 575 passing across 65 files (the 31 above included), extension 675 (666 → 675). `tsc`, eslint, oxlint, prettier and knip green in both workspaces; the pre-commit hook passes.

**Red-proofed.** Renaming the worker's `setFavoriteStore` action to `setFavoriteStoreX` — the exact silent drift the popup/background string contract invites, since the worker's fallback answers `{error:'unknown_action'}` and merely looks like a failed toggle — turns the two round-trip tests red (`expected "vi.fn()" to be called 1 times, but got 0 times`), then green again on restore. Separately, swapping `deleteMany` for `delete` in the unfollow path turns the two DELETE tests red with `expected 500 to be 200`.

## Size budgets

`popup.js` 54 → 60 KB and `background.js` 18 → 20 KB, each with a dated reason beside the number, per `.size-limit.js`'s own ratchet rule. These are raw source bytes, so comments are priced as if they ran; a trimming pass paid back what it could without deleting the two constraints (signed-in-only, and the star lives inside the existing header row) that would otherwise be re-decided wrongly. Measured 59.32 kB and 19.02 kB.
