### PR TITLE
feat(profile): rebuild /profile as an account home with overview, export and data-delete

### DIFF
--- a/apps/caramel-app/e2e/auth-flows.spec.ts
+++ b/apps/caramel-app/e2e/auth-flows.spec.ts
@@ -49,8 +49,12 @@ test.describe('Auth Flows — Login (real session)', () => {
         // a protected route that bounces unauthenticated visitors to /login, so
         // seeing the profile with the seeded email proves the session is real.
         await page.goto('/profile')
+        // /profile is an account HOME now: its <h1> is the user's own name, not
+        // the word "Profile". "Account details" is the stable landmark to wait
+        // on — it renders straight from the session, so it does not depend on
+        // the overview fetch resolving.
         await expect(
-            page.getByRole('heading', { name: 'Profile' }),
+            page.getByRole('heading', { name: 'Account details' }),
         ).toBeVisible({ timeout: 10000 })
         await expect(page.getByText(REAL_LOGIN_EMAIL).first()).toBeVisible()
     })
@@ -402,9 +406,16 @@ test.describe('Auth Flows — Protected Routes', () => {
 
         await page.goto('/profile')
 
-        await expect(page.getByText('Profile')).toBeVisible({ timeout: 5000 })
+        // The user's own name is the page's <h1> — the standalone "Profile"
+        // heading is gone. Both assertions below render from the session
+        // alone, which is the point: this test stubs only get-session, so
+        // /api/account/overview genuinely fails here and the page must still
+        // show real account content rather than collapsing to an error.
         await expect(
-            page.getByRole('heading', { name: 'carameluser' }),
+            page.getByRole('heading', { name: 'carameluser', level: 1 }),
+        ).toBeVisible({ timeout: 5000 })
+        await expect(
+            page.getByRole('heading', { name: 'Account details' }),
         ).toBeVisible()
         await expect(page.getByText('test@example.com').first()).toBeVisible()
     })

--- a/apps/caramel-app/src/app/api/account/data/delete/route.ts
+++ b/apps/caramel-app/src/app/api/account/data/delete/route.ts
@@ -1,0 +1,71 @@
+import { withRoute } from '@/lib/api/withRoute'
+import prisma from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+// POST /api/account/data/delete — the danger zone's "Delete my data".
+//
+// Removes the three login-features tables' rows for the caller: their synced
+// savings history, the stores they follow, and the coupon reports they made.
+//
+// WHAT IT DELIBERATELY DOES NOT DO:
+//  - It does NOT delete the account or the login. That is a larger job (Better
+//    Auth session teardown, extension session revocation, an email
+//    confirmation step) and is out of scope here. See the TODO in
+//    DataPrivacySection.tsx.
+//  - It does NOT flip the savings-sync preference. Turning sync OFF and
+//    DELETING history are two deliberately separate acts: a delete that also
+//    changed a setting the user never touched would make the danger zone do
+//    something it did not say it would.
+//
+// POST, never DELETE-with-no-body: this endpoint must not be reachable as a
+// bare unauthenticated-intent request. The literal confirmation string is
+// REQUIRED IN THE BODY and checked server-side, so the client-side
+// type-to-confirm dialog is a second lock rather than the only one — a
+// mis-issued request with no body is a 422 and destroys nothing.
+const DELETE_CONFIRMATION = 'DELETE'
+
+const DeleteDataBodySchema = z.object({
+    // z.literal so withRoute's body gate 422s anything else BEFORE the handler
+    // runs — the confirmation is enforced by the schema, not by a hand-written
+    // if inside the handler that a later edit could drop.
+    confirm: z.literal(DELETE_CONFIRMATION),
+})
+
+export const POST = withRoute(
+    {
+        method: 'POST',
+        routeName: 'account/data-delete',
+        rateLimit: 'mutation',
+        origin: true,
+        auth: 'session',
+        body: DeleteDataBodySchema,
+    },
+    async ({ session }) => {
+        if (!session?.user) {
+            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+        }
+        const userId = session.user.id
+
+        // ONE transaction. A partial delete is the worst outcome available
+        // here: the user is told their data is gone while some of it remains,
+        // and the counts the UI just showed them become a lie. If any of the
+        // three fails, Prisma rolls the whole interactive batch back and
+        // withRoute's catch turns it into a 500 + Sentry — nothing deleted,
+        // and the failure toast ("Nothing was removed") is then true.
+        const [savingsEvents, favoriteStores, couponReports] =
+            await prisma.$transaction([
+                prisma.savingsEvent.deleteMany({ where: { userId } }),
+                prisma.favoriteStore.deleteMany({ where: { userId } }),
+                prisma.couponReport.deleteMany({ where: { userId } }),
+            ])
+
+        return NextResponse.json({
+            deleted: {
+                savingsEvents: savingsEvents.count,
+                favoriteStores: favoriteStores.count,
+                couponReports: couponReports.count,
+            },
+        })
+    },
+)

--- a/apps/caramel-app/src/app/api/account/export/route.ts
+++ b/apps/caramel-app/src/app/api/account/export/route.ts
@@ -1,0 +1,117 @@
+import { withRoute } from '@/lib/api/withRoute'
+import prisma from '@/lib/prisma'
+import {
+    assertExportIsSafe,
+    buildAccountExport,
+    exportFilename,
+} from '@/lib/profile/accountExport'
+import { readSavingsSyncEnabled } from '@/lib/profile/savingsSyncPreference'
+import { NextResponse } from 'next/server'
+
+// GET /api/account/export — "Download your data".
+//
+// A plain GET returning `Content-Disposition: attachment` so the page can be a
+// bare `<a href download>`: no fetch, no blob, no client-side JSON assembly,
+// and therefore no second place where the export's contents are decided.
+// src/lib/profile/accountExport.ts owns the shape AND the never-include list;
+// this route only fetches rows and streams the result.
+//
+// Rate-limited on the `mutation` bucket rather than `read` despite being a GET:
+// it dumps every row a user owns, so it is the wrong endpoint to leave on the
+// 120/min read allowance.
+//
+// Every query is scoped by `userId: session.user.id`. `assertExportIsSafe`
+// runs on the built payload before it is serialized — a forbidden field throws
+// into withRoute's handler (500 + Sentry) instead of being sent.
+
+export const GET = withRoute(
+    {
+        method: 'GET',
+        routeName: 'account/export',
+        rateLimit: 'mutation',
+        origin: true,
+        auth: 'session',
+    },
+    async ({ session }) => {
+        if (!session?.user) {
+            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+        }
+        const userId = session.user.id
+
+        const [account, favoriteStores, savingsEvents, couponReports, sync] =
+            await Promise.all([
+                prisma.user.findUnique({
+                    where: { id: userId },
+                    // An EXPLICIT select, never a bare findUnique: the User row
+                    // carries `password`, `token` and `tokenExpiry`, and a
+                    // default select would have put all three in the download.
+                    select: {
+                        id: true,
+                        email: true,
+                        name: true,
+                        firstName: true,
+                        lastName: true,
+                        username: true,
+                        createdAt: true,
+                        emailVerified: true,
+                    },
+                }),
+                prisma.favoriteStore.findMany({
+                    where: { userId },
+                    orderBy: { createdAt: 'desc' },
+                    select: { storeName: true, createdAt: true },
+                }),
+                prisma.savingsEvent.findMany({
+                    where: { userId },
+                    orderBy: { occurredAt: 'desc' },
+                    select: {
+                        store: true,
+                        code: true,
+                        amountCents: true,
+                        currency: true,
+                        occurredAt: true,
+                    },
+                }),
+                prisma.couponReport.findMany({
+                    where: { userId },
+                    orderBy: { createdAt: 'desc' },
+                    select: {
+                        outcome: true,
+                        createdAt: true,
+                        // The store + code the user saw. NOT the coupon id.
+                        coupon: { select: { site: true, code: true } },
+                    },
+                }),
+                readSavingsSyncEnabled(userId),
+            ])
+
+        if (!account) {
+            // A live session whose user row is gone is a real inconsistency,
+            // not an empty export — say so rather than emitting a file with a
+            // null account block.
+            return NextResponse.json(
+                { error: 'Account not found' },
+                { status: 404 },
+            )
+        }
+
+        const payload = buildAccountExport({
+            account,
+            savingsSyncEnabled: sync,
+            favoriteStores,
+            savingsEvents,
+            couponReports,
+        })
+        assertExportIsSafe(payload)
+
+        return new NextResponse(JSON.stringify(payload, null, 2), {
+            status: 200,
+            headers: {
+                'Content-Type': 'application/json; charset=utf-8',
+                'Content-Disposition': `attachment; filename="${exportFilename()}"`,
+                // A personal data dump must never be stored by a shared cache.
+                'Cache-Control': 'no-store',
+            },
+        })
+    },
+)

--- a/apps/caramel-app/src/app/api/account/overview/route.ts
+++ b/apps/caramel-app/src/app/api/account/overview/route.ts
@@ -1,0 +1,176 @@
+import { withRoute } from '@/lib/api/withRoute'
+import { countCouponsForStores } from '@/lib/couponsRepo'
+import prisma from '@/lib/prisma'
+import { summarizeReports } from '@/lib/profile/reportImpact'
+import { readSavingsSyncEnabled } from '@/lib/profile/savingsSyncPreference'
+import { RECENT_EVENTS_LIMIT, type ProfileOverview } from '@/lib/profile/types'
+import { NextResponse } from 'next/server'
+
+// GET /api/account/overview — the ONE payload the account page reads.
+//
+// Four sections (savings, favorites, reports, the get-started checklist) are
+// served by one request on purpose: four fetches would give the page four
+// spinners and four independent failure modes, on a page whose whole job is to
+// answer "what has Caramel done for me". The shape is declared once in
+// src/lib/profile/types.ts and shared by the route, the hook and this route's
+// test — never re-typed.
+//
+// Reads the three login-features tables (savings_events, favorite_stores,
+// coupon_reports) DIRECTLY, so it has no dependency on the sibling PRs that
+// own the write routes for those tables: it renders correct empty data today
+// and correct populated data the moment they start writing.
+//
+// EVERY query is scoped by `userId: session.user.id`. There is no path through
+// this handler that reads another account's rows.
+
+export const GET = withRoute(
+    {
+        method: 'GET',
+        routeName: 'account/overview',
+        rateLimit: 'read',
+        origin: true,
+        auth: 'session',
+    },
+    async ({ session }) => {
+        if (!session?.user) {
+            // withRoute's `auth: 'session'` gate already 401s a missing
+            // session; this guard covers the malformed-session edge and
+            // narrows the type (same shape extension/me uses).
+            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+        }
+        const userId = session.user.id
+
+        const [
+            user,
+            savingsGroups,
+            savingsBounds,
+            recentEvents,
+            favoriteRows,
+            reportRows,
+            syncEnabled,
+        ] = await Promise.all([
+            prisma.user.findUnique({
+                where: { id: userId },
+                select: { createdAt: true },
+            }),
+            // ONE groupBy carries three of the four savings figures: per-
+            // currency totals, the distinct-store count, and the event count.
+            // Grouping by (currency, store) rather than two separate groupBys
+            // keeps them derived from the same snapshot — two queries could
+            // disagree if an event landed between them.
+            prisma.savingsEvent.groupBy({
+                by: ['currency', 'store'],
+                where: { userId },
+                _sum: { amountCents: true },
+                _count: { _all: true },
+            }),
+            prisma.savingsEvent.aggregate({
+                where: { userId },
+                _min: { occurredAt: true },
+            }),
+            prisma.savingsEvent.findMany({
+                where: { userId },
+                orderBy: { occurredAt: 'desc' },
+                take: RECENT_EVENTS_LIMIT,
+                select: {
+                    store: true,
+                    code: true,
+                    amountCents: true,
+                    currency: true,
+                    occurredAt: true,
+                },
+            }),
+            prisma.favoriteStore.findMany({
+                where: { userId },
+                orderBy: { createdAt: 'desc' },
+                select: { storeName: true, createdAt: true },
+            }),
+            // Joined to the coupon's catalog state so summarizeReports can
+            // tell a report our own later recheck AGREED with from one it
+            // did not. See reportImpact.ts for why that join is required.
+            prisma.couponReport.findMany({
+                where: { userId },
+                select: {
+                    outcome: true,
+                    createdAt: true,
+                    coupon: {
+                        select: {
+                            status: true,
+                            expired: true,
+                            updatedAt: true,
+                        },
+                    },
+                },
+            }),
+            readSavingsSyncEnabled(userId),
+        ])
+
+        // Per-currency totals. Deliberately NOT summed into one number: a
+        // single figure that adds dollars to euros is a fabricated claim about
+        // someone's money. Sorted desc so the page can render the largest
+        // group as its hero and the rest as secondary lines.
+        const totalsByCurrency = new Map<string, number>()
+        const distinctStores = new Set<string>()
+        let eventCount = 0
+        for (const group of savingsGroups) {
+            const current = totalsByCurrency.get(group.currency) ?? 0
+            totalsByCurrency.set(
+                group.currency,
+                current + (group._sum.amountCents ?? 0),
+            )
+            distinctStores.add(group.store)
+            eventCount += group._count._all
+        }
+        const totals = Array.from(
+            totalsByCurrency,
+            ([currency, minorUnits]) => ({
+                currency,
+                minorUnits,
+            }),
+        ).sort((a, b) => b.minorUnits - a.minorUnits)
+
+        // Live "12 codes right now" counts, one query for the whole list,
+        // sharing the catalog's own visibility + store-matching predicates
+        // (couponsRepo) so a favorite's count agrees with the store page it
+        // links to. A store absent from the map has NO count available —
+        // distinct from a real 0 — and the UI renders no count line at all.
+        const favoriteDomains = favoriteRows.map(row => row.storeName)
+        const couponCounts = await countCouponsForStores(favoriteDomains)
+
+        const reports = summarizeReports(reportRows)
+
+        const overview: ProfileOverview = {
+            memberSince: user?.createdAt.toISOString() ?? null,
+            // Both signals originate in the extension, so either one proves it
+            // is installed and working. This drives whether the page tells
+            // someone to "star a store in the extension" — advice that is a
+            // dead end for a user who has not installed it.
+            hasExtensionActivity: eventCount > 0 || reports.reportCount > 0,
+            savings: {
+                syncEnabled,
+                eventCount,
+                storeCount: distinctStores.size,
+                totals,
+                firstEventAt:
+                    savingsBounds._min.occurredAt?.toISOString() ?? null,
+                recentEvents: recentEvents.map(event => ({
+                    storeDomain: event.store,
+                    // An automatic discount carries no code; the row renders a
+                    // plain "automatic discount" instead of an empty chip.
+                    code: event.code === '' ? null : event.code,
+                    amountMinorUnits: event.amountCents,
+                    currency: event.currency,
+                    occurredAt: event.occurredAt.toISOString(),
+                })),
+            },
+            favorites: favoriteRows.map(row => ({
+                domain: row.storeName,
+                starredAt: row.createdAt.toISOString(),
+                couponCount: couponCounts.get(row.storeName) ?? null,
+            })),
+            reports,
+        }
+
+        return NextResponse.json(overview)
+    },
+)

--- a/apps/caramel-app/src/app/profile/ProfilePageClient.tsx
+++ b/apps/caramel-app/src/app/profile/ProfilePageClient.tsx
@@ -1,9 +1,25 @@
 'use client'
 
+import SectionSkeleton from '@/components/profile/SectionSkeleton'
 import { useSession } from '@/lib/auth/client'
-import { userInitial } from '@/lib/userInitial'
+import {
+    noticeBodyClasses,
+    noticeButtonClasses,
+    noticeClasses,
+    noticeTitleClasses,
+} from '@/lib/profile/profileStyles'
+import type { FavoriteStoreSummary } from '@/lib/profile/types'
+import { useProfileOverview } from '@/lib/profile/useProfileOverview'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
+import AccountDetailsCard from './sections/AccountDetailsCard'
+import AccountHeaderCard from './sections/AccountHeaderCard'
+import DataPrivacySection from './sections/DataPrivacySection'
+import FavoriteStoresSection from './sections/FavoriteStoresSection'
+import GetStartedChecklist from './sections/GetStartedChecklist'
+import ImpactStrip from './sections/ImpactStrip'
+import ReportsImpactSection from './sections/ReportsImpactSection'
+import SavingsSection from './sections/SavingsSection'
 
 export default function ProfilePageClient() {
     const { data: session, isPending } = useSession()
@@ -24,6 +40,12 @@ export default function ProfilePageClient() {
         }
     }, [mounted, session, isPending, router])
 
+    // Only fetch once we know there IS a session — firing an authenticated
+    // request before that turns every signed-out visit into a spurious 401.
+    const signedIn = Boolean(mounted && !isPending && session?.user)
+    const { overview, status, retry, patchOverview } =
+        useProfileOverview(signedIn)
+
     if (!mounted || isPending) {
         return (
             <main className="relative -mt-[6.7rem] w-full">
@@ -43,90 +65,127 @@ export default function ProfilePageClient() {
     }
 
     const user = session.user
-    const avatarLetter = userInitial(user)
+
+    function removeFavorite(domain: string) {
+        patchOverview(current => ({
+            ...current,
+            favorites: current.favorites.filter(f => f.domain !== domain),
+        }))
+    }
+
+    function restoreFavorite(store: FavoriteStoreSummary) {
+        patchOverview(current =>
+            current.favorites.some(f => f.domain === store.domain)
+                ? current
+                : {
+                      ...current,
+                      favorites: [store, ...current.favorites].sort((a, b) =>
+                          b.starredAt.localeCompare(a.starredAt),
+                      ),
+                  },
+        )
+    }
+
+    function applySyncChange(enabled: boolean) {
+        patchOverview(current => ({
+            ...current,
+            savings: { ...current.savings, syncEnabled: enabled },
+        }))
+    }
+
+    /** Back to the zero state, without a refetch: the delete is transactional
+     * and its counts are exactly these three collections. */
+    function applyDataDeleted() {
+        patchOverview(current => ({
+            ...current,
+            savings: {
+                ...current.savings,
+                eventCount: 0,
+                storeCount: 0,
+                totals: [],
+                firstEventAt: null,
+                recentEvents: [],
+            },
+            favorites: [],
+            reports: {
+                reportCount: 0,
+                confirmedCount: null,
+                shoppersHelped: null,
+            },
+        }))
+    }
+
+    // Every stat at zero => the checklist replaces the impact strip. This is
+    // the DEFAULT state for most people arriving here, not an edge case.
+    const isZeroState =
+        overview !== null &&
+        overview.savings.eventCount === 0 &&
+        overview.favorites.length === 0 &&
+        overview.reports.reportCount === 0
 
     return (
         <main className="relative -mt-[6.7rem] w-full">
-            <div className="container mx-auto px-4 py-16">
-                <div className="mx-auto max-w-2xl">
-                    <h1 className="mb-8 text-4xl font-bold text-caramel">
-                        Profile
-                    </h1>
+            <div className="container mx-auto px-4 py-16 md:py-12 xs:px-3 xs:py-8">
+                <div className="mx-auto max-w-3xl space-y-10 md:space-y-8">
+                    {/* Renders immediately from the session — never waits on
+                        the overview, so there is no whole-page spinner. */}
+                    <AccountHeaderCard
+                        user={user}
+                        memberSince={overview?.memberSince ?? null}
+                    />
 
-                    <div className="rounded-2xl border border-gray-100 bg-white p-8 shadow-lg dark:border-gray-800 dark:bg-darkerBg">
-                        <div className="mb-6 flex items-center gap-6">
-                            <div className="flex h-20 w-20 items-center justify-center rounded-full bg-caramel text-2xl font-semibold text-white ring-4 ring-caramel/15">
-                                {avatarLetter}
-                            </div>
-                            <div>
-                                <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
-                                    {user.firstName && user.lastName
-                                        ? `${user.firstName} ${user.lastName}`
-                                        : user.name}
-                                </h2>
-                                {user.email && (
-                                    <p className="text-gray-600 dark:text-gray-200">
-                                        {user.email}
-                                    </p>
-                                )}
-                            </div>
+                    {status === 'loading' ? (
+                        <SectionSkeleton />
+                    ) : status === 'error' ? (
+                        <div role="alert" className={noticeClasses}>
+                            <p className={noticeTitleClasses}>
+                                We couldn&apos;t load your savings and stores
+                            </p>
+                            <p className={noticeBodyClasses}>
+                                Nothing is lost — this is on our side. Try again
+                                in a moment.
+                            </p>
+                            <button
+                                type="button"
+                                onClick={retry}
+                                className={noticeButtonClasses}
+                            >
+                                Try again
+                            </button>
                         </div>
-
-                        <div className="space-y-4 border-t border-gray-100 pt-6 dark:border-gray-700">
-                            <div>
-                                <label className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                                    Email
-                                </label>
-                                <p className="mt-1 text-gray-900 dark:text-gray-100">
-                                    {user.email || 'Not provided'}
-                                </p>
-                            </div>
-
-                            {user.name && (
-                                <div>
-                                    <label className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                                        Name
-                                    </label>
-                                    <p className="mt-1 text-gray-900 dark:text-gray-100">
-                                        {user.name}
-                                    </p>
-                                </div>
+                    ) : overview ? (
+                        <>
+                            {isZeroState ? (
+                                <GetStartedChecklist overview={overview} />
+                            ) : (
+                                <ImpactStrip overview={overview} />
                             )}
 
-                            {(user.firstName || user.lastName) && (
-                                <div>
-                                    <label className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                                        First Name
-                                    </label>
-                                    <p className="mt-1 text-gray-900 dark:text-gray-100">
-                                        {user.firstName || 'Not provided'}
-                                    </p>
-                                </div>
-                            )}
+                            <SavingsSection
+                                savings={overview.savings}
+                                onSyncChange={applySyncChange}
+                            />
 
-                            {(user.firstName || user.lastName) && (
-                                <div>
-                                    <label className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                                        Last Name
-                                    </label>
-                                    <p className="mt-1 text-gray-900 dark:text-gray-100">
-                                        {user.lastName || 'Not provided'}
-                                    </p>
-                                </div>
-                            )}
+                            <FavoriteStoresSection
+                                favorites={overview.favorites}
+                                hasExtensionActivity={
+                                    overview.hasExtensionActivity
+                                }
+                                onRemove={removeFavorite}
+                                onRestore={restoreFavorite}
+                            />
 
-                            {user.username && (
-                                <div>
-                                    <label className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                                        Username
-                                    </label>
-                                    <p className="mt-1 text-gray-900 dark:text-gray-100">
-                                        {user.username}
-                                    </p>
-                                </div>
-                            )}
-                        </div>
-                    </div>
+                            <ReportsImpactSection reports={overview.reports} />
+                        </>
+                    ) : null}
+
+                    {/* Both render from the session, so they stay real content
+                        even when the overview failed. */}
+                    <AccountDetailsCard user={user} />
+                    <DataPrivacySection
+                        overview={overview}
+                        onDeleted={applyDataDeleted}
+                    />
                 </div>
             </div>
         </main>

--- a/apps/caramel-app/src/app/profile/ProfilePageClient.tsx
+++ b/apps/caramel-app/src/app/profile/ProfilePageClient.tsx
@@ -10,8 +10,9 @@ import {
 } from '@/lib/profile/profileStyles'
 import type { FavoriteStoreSummary } from '@/lib/profile/types'
 import { useProfileOverview } from '@/lib/profile/useProfileOverview'
+import { useReducedMotion } from '@/lib/reducedMotion'
 import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import AccountDetailsCard from './sections/AccountDetailsCard'
 import AccountHeaderCard from './sections/AccountHeaderCard'
 import DataPrivacySection from './sections/DataPrivacySection'
@@ -45,6 +46,37 @@ export default function ProfilePageClient() {
     const signedIn = Boolean(mounted && !isPending && session?.user)
     const { overview, status, retry, patchOverview } =
         useProfileOverview(signedIn)
+
+    // Honour a deep link (/profile#savings) ONCE the target section exists.
+    //
+    // The browser resolves the fragment during load, but the data-backed
+    // sections render only after the overview fetch resolves — so on a cold
+    // load the element the fragment names does not exist yet and the native
+    // scroll silently no-ops. The extension popup's "Manage account" link is a
+    // real entry point that deep-links here, so a fragment that quietly does
+    // nothing is a broken contract rather than a cosmetic miss.
+    //
+    // Guarded by a ref so this fires at most once: re-scrolling the page under
+    // someone who has since scrolled away (a favorite removal re-renders this
+    // tree) would be worse than not scrolling at all.
+    const deepLinkHandled = useRef(false)
+    const prefersReducedMotion = useReducedMotion()
+
+    useEffect(() => {
+        if (deepLinkHandled.current || status !== 'ready') return
+        const id = window.location.hash.slice(1)
+        if (!id) return
+        const target = document.getElementById(id)
+        if (!target) return
+        deepLinkHandled.current = true
+        target.scrollIntoView({
+            // globals.css sets `scroll-behavior: smooth`, which the app already
+            // disables under prefers-reduced-motion — match that here rather
+            // than forcing a smooth scroll past the preference.
+            behavior: prefersReducedMotion ? 'auto' : 'smooth',
+            block: 'start',
+        })
+    }, [status, prefersReducedMotion])
 
     if (!mounted || isPending) {
         return (

--- a/apps/caramel-app/src/app/profile/page.tsx
+++ b/apps/caramel-app/src/app/profile/page.tsx
@@ -1,8 +1,11 @@
 import type { Metadata } from 'next'
 import ProfilePageClient from './ProfilePageClient'
 
-const title = 'Profile | Caramel'
-const description = 'View and manage your Caramel profile'
+// The page is an account HOME, not a profile form — the metadata says so too.
+// `robots: noindex` stays: this is per-user content that must never be crawled.
+const title = 'Your account | Caramel'
+const description =
+    'Your savings, the stores you follow, and your Caramel data.'
 
 export const metadata: Metadata = {
     title,

--- a/apps/caramel-app/src/app/profile/sections/AccountDetailsCard.tsx
+++ b/apps/caramel-app/src/app/profile/sections/AccountDetailsCard.tsx
@@ -1,0 +1,60 @@
+import ProfileSection from '@/components/profile/ProfileSection'
+import { cardClasses, microLabelClasses } from '@/lib/profile/profileStyles'
+
+/**
+ * The original profile page's field list, kept intact.
+ *
+ * It renders entirely from the session, so it is real content while the
+ * overview is still loading — part of why this page no longer shows a
+ * whole-page spinner.
+ *
+ * Fields render only when they have a value, EXCEPT email (always shown, the
+ * account's identity) — the old page's behaviour, preserved: a column of "Not
+ * provided" rows is a form's idea of completeness, not information.
+ */
+export default function AccountDetailsCard({
+    user,
+}: {
+    user: {
+        name?: string | null
+        email?: string | null
+        firstName?: string | null
+        lastName?: string | null
+        username?: string | null
+    }
+}) {
+    const fields: { label: string; value: string }[] = [
+        { label: 'Email', value: user.email || 'Not provided' },
+    ]
+    if (user.name) fields.push({ label: 'Name', value: user.name })
+    if (user.firstName || user.lastName) {
+        fields.push({
+            label: 'First Name',
+            value: user.firstName || 'Not provided',
+        })
+        fields.push({
+            label: 'Last Name',
+            value: user.lastName || 'Not provided',
+        })
+    }
+    if (user.username) {
+        fields.push({ label: 'Username', value: user.username })
+    }
+
+    return (
+        <ProfileSection id="account" title="Account details">
+            <div className={cardClasses}>
+                <dl className="space-y-4">
+                    {fields.map(field => (
+                        <div key={field.label}>
+                            <dt className={microLabelClasses}>{field.label}</dt>
+                            <dd className="mt-1 break-words text-gray-900 dark:text-gray-100">
+                                {field.value}
+                            </dd>
+                        </div>
+                    ))}
+                </dl>
+            </div>
+        </ProfileSection>
+    )
+}

--- a/apps/caramel-app/src/app/profile/sections/AccountHeaderCard.tsx
+++ b/apps/caramel-app/src/app/profile/sections/AccountHeaderCard.tsx
@@ -1,0 +1,63 @@
+import { formatMonthYear } from '@/lib/profile/formatCurrency'
+import { cardClasses } from '@/lib/profile/profileStyles'
+import { userInitial } from '@/lib/userInitial'
+
+/**
+ * The page's identity block, and the owner of its single <h1>.
+ *
+ * The old standalone `<h1>Profile</h1>` is deliberately gone: the user's own
+ * name is this page's subject, and a page whose largest element says "Profile"
+ * reads as a form rather than a home.
+ *
+ * Renders immediately from the session — it never waits on the overview fetch,
+ * which is why the page has no whole-page spinner.
+ */
+export default function AccountHeaderCard({
+    user,
+    memberSince,
+}: {
+    user: {
+        name?: string | null
+        email?: string | null
+        firstName?: string | null
+        lastName?: string | null
+    }
+    /** ISO from the overview; the line is omitted entirely when absent. */
+    memberSince: string | null
+}) {
+    const avatarLetter = userInitial(user)
+    // Never render an empty heading: fall through name parts -> name -> the
+    // local part of the email.
+    const displayName =
+        (user.firstName && user.lastName
+            ? `${user.firstName} ${user.lastName}`
+            : user.name?.trim()) ||
+        user.email?.split('@')[0] ||
+        'Your account'
+    const since = formatMonthYear(memberSince)
+
+    return (
+        <div className={cardClasses}>
+            <div className="flex items-center gap-6 xs:gap-4">
+                <div className="flex h-20 w-20 shrink-0 items-center justify-center rounded-full bg-caramel text-2xl font-semibold text-white ring-4 ring-caramel/15 xs:h-16 xs:w-16 xs:text-xl">
+                    {avatarLetter}
+                </div>
+                <div className="min-w-0">
+                    <h1 className="truncate text-2xl font-semibold text-gray-900 dark:text-gray-100 xs:text-xl">
+                        {displayName}
+                    </h1>
+                    {user.email ? (
+                        <p className="truncate text-gray-600 dark:text-gray-400">
+                            {user.email}
+                        </p>
+                    ) : null}
+                    {since ? (
+                        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                            Saving with Caramel since {since}
+                        </p>
+                    ) : null}
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/apps/caramel-app/src/app/profile/sections/DataPrivacySection.tsx
+++ b/apps/caramel-app/src/app/profile/sections/DataPrivacySection.tsx
@@ -1,0 +1,180 @@
+'use client'
+
+import ConfirmDialog from '@/components/profile/ConfirmDialog'
+import ProfileSection from '@/components/profile/ProfileSection'
+import { promptSupportOnFailure } from '@/lib/feedback/promptSupportOnFailure'
+import {
+    bodyTextClasses,
+    cardClasses,
+    dangerButtonClasses,
+    dangerFenceClasses,
+    secondaryButtonClasses,
+    subHeadingClasses,
+} from '@/lib/profile/profileStyles'
+import type { ProfileOverview } from '@/lib/profile/types'
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+// Export + danger zone.
+//
+// TODO: ACCOUNT deletion (removing the login itself) is deliberately NOT here.
+// It is a larger job — Better Auth session teardown, extension session
+// revocation, an email confirmation step — and shipping a "delete my data"
+// button that quietly also deleted the account would be the worst possible
+// version of it. The copy below is explicit that the account stays. A later PR
+// adds account deletion as its own control in this section.
+
+/** The literal string the server also requires in the request body. Typed on
+ * a phone keyboard, so it is DELETE and not the account's email address. */
+const CONFIRM_WORD = 'DELETE'
+
+export default function DataPrivacySection({
+    overview,
+    onDeleted,
+}: {
+    /** null when the overview failed to load — the danger zone then refuses
+     * to offer a delete whose consequences it cannot state. */
+    overview: ProfileOverview | null
+    onDeleted: () => void
+}) {
+    const [dialogOpen, setDialogOpen] = useState(false)
+    const [busy, setBusy] = useState(false)
+
+    const savingsCount = overview?.savings.eventCount ?? 0
+    const favoritesCount = overview?.favorites.length ?? 0
+    const reportsCount = overview?.reports.reportCount ?? 0
+    const nothingToDelete =
+        savingsCount === 0 && favoritesCount === 0 && reportsCount === 0
+
+    async function deleteData() {
+        setBusy(true)
+        try {
+            const res = await fetch('/api/account/data/delete', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                credentials: 'include',
+                // The confirmation is required SERVER-side too: the typed
+                // dialog is a second lock, not the only one.
+                body: JSON.stringify({ confirm: CONFIRM_WORD }),
+            })
+            if (!res.ok) throw new Error(`Delete failed with ${res.status}`)
+            setDialogOpen(false)
+            toast.success('Your Caramel data has been deleted.')
+            onDeleted()
+        } catch (error) {
+            // The endpoint is transactional, so a failure genuinely means
+            // nothing was removed — the copy can say so without hedging.
+            toast.error(
+                "Couldn't delete your data. Nothing was removed — please try again.",
+            )
+            promptSupportOnFailure({
+                error,
+                operation: 'account_data_delete',
+            })
+        } finally {
+            setBusy(false)
+        }
+    }
+
+    // Only clauses with a real count appear, so the dialog never says
+    // "0 followed stores".
+    const clauses = [
+        savingsCount > 0
+            ? `${savingsCount} savings ${savingsCount === 1 ? 'event' : 'events'}`
+            : null,
+        favoritesCount > 0
+            ? `${favoritesCount} followed ${favoritesCount === 1 ? 'store' : 'stores'}`
+            : null,
+        reportsCount > 0
+            ? `${reportsCount} coupon ${reportsCount === 1 ? 'report' : 'reports'}`
+            : null,
+    ].filter((clause): clause is string => clause !== null)
+
+    return (
+        // `title` is a plain string prop, not JSX — an &amp; entity here would
+        // render literally.
+        <ProfileSection
+            id="data"
+            title="Data & privacy"
+            description="Everything Caramel holds for you, and how to get rid of it."
+        >
+            <div className="space-y-6">
+                <div className={cardClasses}>
+                    <h3 className={subHeadingClasses}>Download your data</h3>
+                    <p className={`${bodyTextClasses} mt-2`}>
+                        A single JSON file with your account details, the stores
+                        you follow, your synced savings, and the codes
+                        you&apos;ve reported. Yours to keep.
+                    </p>
+                    {/* A plain <a download>: the server sets
+                        Content-Disposition, so there is no fetch, no blob, and
+                        no second place that decides what the file contains. */}
+                    <a
+                        href="/api/account/export"
+                        download
+                        className={`${secondaryButtonClasses} mt-4`}
+                    >
+                        Download my data
+                    </a>
+                </div>
+
+                <div className={dangerFenceClasses}>
+                    <h3 className="text-lg font-semibold text-red-800 dark:text-red-300">
+                        Danger zone
+                    </h3>
+                    <div className="mt-4">
+                        <p className="font-semibold text-gray-900 dark:text-white">
+                            Delete my Caramel data
+                        </p>
+                        <p className={`${bodyTextClasses} mt-1`}>
+                            Removes the stores you follow, your synced savings
+                            history, and your coupon reports. Your account and
+                            sign-in stay. This can&apos;t be undone.
+                        </p>
+                        <button
+                            type="button"
+                            onClick={() => setDialogOpen(true)}
+                            disabled={nothingToDelete}
+                            className={`${dangerButtonClasses} mt-4 md:w-full xs:w-full`}
+                        >
+                            {nothingToDelete
+                                ? 'Nothing to delete'
+                                : 'Delete my data'}
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <ConfirmDialog
+                open={dialogOpen}
+                onClose={() => setDialogOpen(false)}
+                onConfirm={deleteData}
+                title="Delete your Caramel data?"
+                confirmLabel="Delete my data"
+                typeToConfirm={CONFIRM_WORD}
+                tone="danger"
+                busy={busy}
+                body={
+                    <>
+                        <p className={bodyTextClasses}>
+                            This permanently removes {clauses.join(', ')}. Your
+                            account stays, and Caramel keeps working —
+                            you&apos;ll just be starting from zero.
+                        </p>
+                        <p className={`${bodyTextClasses} mt-3`}>
+                            Want a copy first?{' '}
+                            <a
+                                href="/api/account/export"
+                                download
+                                className="font-semibold underline underline-offset-2"
+                            >
+                                Download your data
+                            </a>{' '}
+                            before you delete.
+                        </p>
+                    </>
+                }
+            />
+        </ProfileSection>
+    )
+}

--- a/apps/caramel-app/src/app/profile/sections/FavoriteStoresSection.tsx
+++ b/apps/caramel-app/src/app/profile/sections/FavoriteStoresSection.tsx
@@ -1,0 +1,197 @@
+'use client'
+
+import EmptyState from '@/components/profile/EmptyState'
+import ProfileSection from '@/components/profile/ProfileSection'
+import { CHROME_WEB_STORE_URL } from '@/lib/brandLinks'
+import { promptSupportOnFailure } from '@/lib/feedback/promptSupportOnFailure'
+import {
+    cardClasses,
+    linkRowFocusClasses,
+    listRowClasses,
+    secondaryButtonClasses,
+    tintedCardClasses,
+} from '@/lib/profile/profileStyles'
+import type { FavoriteStoreSummary } from '@/lib/profile/types'
+import Image from 'next/image'
+import Link from 'next/link'
+import { FaStar } from 'react-icons/fa'
+import { toast } from 'sonner'
+
+// Favorites live in a single card of ROWS, not a grid of SiteCard tiles:
+// these are a list the user scans, and eight big gradient tiles would make a
+// wall out of it.
+//
+// The star is NOT added to SiteCard (/supported-stores) or CouponCard
+// (/coupons) — both are visual-regression baselined, and starring there would
+// turn a profile PR into an eight-baseline diff. Grid-wide starring is its own
+// later PR with an intentional baseline update.
+//
+// The PUT/DELETE routes are owned by the favorites PR (feat/login-favorites);
+// their contract is fixed: `/api/account/favorites/:store`, idempotent, the
+// segment being the normalized registrable domain that favorite_stores.
+// store_name already holds — so the value read out of the overview drops
+// straight in with no re-normalizing.
+
+function faviconFor(domain: string): string {
+    return `https://www.google.com/s2/favicons?sz=128&domain_url=${encodeURIComponent(
+        domain,
+    )}`
+}
+
+export default function FavoriteStoresSection({
+    favorites,
+    hasExtensionActivity,
+    onRemove,
+    onRestore,
+}: {
+    favorites: FavoriteStoreSummary[]
+    hasExtensionActivity: boolean
+    /** Optimistically drop the row from the loaded overview. */
+    onRemove: (domain: string) => void
+    /** Put it back — undo, or a failed delete. */
+    onRestore: (store: FavoriteStoreSummary) => void
+}) {
+    async function callFavorite(domain: string, method: 'PUT' | 'DELETE') {
+        const res = await fetch(
+            `/api/account/favorites/${encodeURIComponent(domain)}`,
+            { method, credentials: 'include' },
+        )
+        if (!res.ok) throw new Error(`${method} favorite failed: ${res.status}`)
+    }
+
+    async function restore(store: FavoriteStoreSummary) {
+        onRestore(store)
+        try {
+            await callFavorite(store.domain, 'PUT')
+        } catch (error) {
+            // The row is back on screen but the server disagrees — drop it
+            // again rather than leave a row that will vanish on next load.
+            onRemove(store.domain)
+            toast.error("Couldn't remove that store. It's still on your list.")
+            promptSupportOnFailure({
+                error,
+                operation: 'favorite_store_restore',
+            })
+        }
+    }
+
+    async function unstar(store: FavoriteStoreSummary) {
+        // Optimistic: the row leaves immediately. Undo is NOT optional here —
+        // the star is a small target beside a full-row link, and a mis-tap
+        // that silently destroys the row is exactly what this invites.
+        onRemove(store.domain)
+        toast(`Removed ${store.domain} from your stores.`, {
+            action: { label: 'Undo', onClick: () => void restore(store) },
+        })
+        try {
+            await callFavorite(store.domain, 'DELETE')
+        } catch (error) {
+            onRestore(store)
+            toast.error("Couldn't remove that store. It's still on your list.")
+            promptSupportOnFailure({
+                error,
+                operation: 'favorite_store_remove',
+            })
+        }
+    }
+
+    return (
+        <ProfileSection
+            id="favorites"
+            title="Stores you follow"
+            description="Your starred stores, with their best working codes."
+        >
+            {favorites.length === 0 ? (
+                <div className={tintedCardClasses}>
+                    <EmptyState
+                        icon="⭐"
+                        heading="Follow the stores you shop"
+                        body="Star a store and its best working codes are always one click away — in the extension and here."
+                        footnote={
+                            hasExtensionActivity
+                                ? "Two ways to star a store: open the Caramel extension while you're on a store and tap the star, or find the store on our site and star it there."
+                                : 'Get the Caramel extension first — starring happens while you shop, right from the popup.'
+                        }
+                        actions={
+                            <>
+                                <Link
+                                    href="/supported-stores"
+                                    className={secondaryButtonClasses}
+                                >
+                                    Browse supported stores
+                                </Link>
+                                {/* Telling someone without the extension to
+                                    use it is a dead end — give them the way
+                                    to get it. */}
+                                {hasExtensionActivity ? null : (
+                                    <a
+                                        href={CHROME_WEB_STORE_URL}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className={secondaryButtonClasses}
+                                    >
+                                        Get the extension
+                                    </a>
+                                )}
+                            </>
+                        }
+                    />
+                </div>
+            ) : (
+                <div className={cardClasses}>
+                    {favorites.map(store => (
+                        <div key={store.domain} className={listRowClasses}>
+                            <Link
+                                href={`/coupons/${encodeURIComponent(store.domain)}`}
+                                className={`flex min-w-0 flex-1 items-center gap-4 ${linkRowFocusClasses}`}
+                            >
+                                <Image
+                                    src={faviconFor(store.domain)}
+                                    alt=""
+                                    width={40}
+                                    height={40}
+                                    className="h-10 w-10 shrink-0 rounded-lg"
+                                    unoptimized
+                                />
+                                <div className="min-w-0">
+                                    <p className="truncate font-medium text-gray-900 dark:text-white">
+                                        {store.domain}
+                                    </p>
+                                    {/* Only ever a REAL count — no "0 codes"
+                                        and no placeholder. */}
+                                    {store.couponCount !== null &&
+                                    store.couponCount > 0 ? (
+                                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                                            {store.couponCount}{' '}
+                                            {store.couponCount === 1
+                                                ? 'code'
+                                                : 'codes'}{' '}
+                                            right now
+                                        </p>
+                                    ) : null}
+                                </div>
+                            </Link>
+                            {/* Sized for two controls so the dormant
+                                "notify me" toggle can land here later without
+                                reflowing the row. */}
+                            <div className="flex shrink-0 items-center gap-1">
+                                <button
+                                    type="button"
+                                    onClick={() => void unstar(store)}
+                                    aria-pressed={true}
+                                    aria-label={`Remove ${store.domain} from your stores`}
+                                    className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-caramel transition hover:bg-caramel/10"
+                                >
+                                    <FaStar
+                                        aria-hidden="true"
+                                        className="h-5 w-5"
+                                    />
+                                </button>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </ProfileSection>
+    )
+}

--- a/apps/caramel-app/src/app/profile/sections/GetStartedChecklist.tsx
+++ b/apps/caramel-app/src/app/profile/sections/GetStartedChecklist.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+import ProfileSection from '@/components/profile/ProfileSection'
+import { CHROME_WEB_STORE_URL } from '@/lib/brandLinks'
+import {
+    bodyTextClasses,
+    secondaryButtonClasses,
+    tintedCardClasses,
+} from '@/lib/profile/profileStyles'
+import type { ProfileOverview } from '@/lib/profile/types'
+import Link from 'next/link'
+import { HiCheckCircle } from 'react-icons/hi'
+
+/**
+ * The zero state. Renders INSTEAD of the impact strip when every stat is zero,
+ * which is how most people arrive at this page.
+ *
+ * Steps the user has already done render with a filled check and no CTA — the
+ * list is a path, not a nag. It never says "0 of 3 complete".
+ */
+export default function GetStartedChecklist({
+    overview,
+}: {
+    overview: ProfileOverview
+}) {
+    const steps = [
+        {
+            key: 'install',
+            done: overview.hasExtensionActivity,
+            title: 'Install the Caramel extension',
+            body: 'Caramel finds and applies codes at checkout for you.',
+            cta: { label: 'Get the extension', href: CHROME_WEB_STORE_URL },
+        },
+        {
+            key: 'follow',
+            done: overview.favorites.length > 0,
+            title: 'Follow the stores you shop',
+            body: 'Star a store to keep its best working codes one click away.',
+            cta: { label: 'Browse stores', href: '/supported-stores' },
+        },
+        {
+            key: 'sync',
+            done: overview.savings.syncEnabled,
+            title: 'Turn on savings sync',
+            body: 'See everything Caramel has saved you, on every browser you sign in to.',
+            cta: { label: 'Set up sync', href: '#savings' },
+        },
+    ]
+
+    return (
+        <ProfileSection
+            id="get-started"
+            title="Get started with Caramel"
+            description="Three things that make Caramel worth having."
+        >
+            <div className={tintedCardClasses}>
+                <ol className="space-y-5">
+                    {steps.map(step => (
+                        <li
+                            key={step.key}
+                            className="flex items-start gap-4 xs:gap-3"
+                        >
+                            {step.done ? (
+                                <HiCheckCircle
+                                    aria-hidden="true"
+                                    className="mt-0.5 h-6 w-6 shrink-0 text-caramel"
+                                />
+                            ) : (
+                                <span
+                                    aria-hidden="true"
+                                    className="mt-0.5 h-6 w-6 shrink-0 rounded-full border-2 border-caramel/40"
+                                />
+                            )}
+                            <div className="min-w-0 flex-1">
+                                <p className="font-semibold text-gray-900 dark:text-white">
+                                    {step.title}
+                                </p>
+                                <p className={`${bodyTextClasses} mt-1`}>
+                                    {step.body}
+                                </p>
+                                {step.done ? null : (
+                                    <div className="mt-3">
+                                        {step.cta.href.startsWith('http') ? (
+                                            <a
+                                                href={step.cta.href}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                className={
+                                                    secondaryButtonClasses
+                                                }
+                                            >
+                                                {step.cta.label}
+                                            </a>
+                                        ) : (
+                                            <Link
+                                                href={step.cta.href}
+                                                className={
+                                                    secondaryButtonClasses
+                                                }
+                                            >
+                                                {step.cta.label}
+                                            </Link>
+                                        )}
+                                    </div>
+                                )}
+                            </div>
+                            {/* Screen readers get the state the check icon
+                                conveys visually. */}
+                            <span className="sr-only">
+                                {step.done ? 'Done' : 'Not done yet'}
+                            </span>
+                        </li>
+                    ))}
+                </ol>
+            </div>
+        </ProfileSection>
+    )
+}

--- a/apps/caramel-app/src/app/profile/sections/ImpactStrip.tsx
+++ b/apps/caramel-app/src/app/profile/sections/ImpactStrip.tsx
@@ -1,0 +1,77 @@
+import StatTile from '@/components/profile/StatTile'
+import { formatMoney } from '@/lib/profile/formatCurrency'
+import type { ProfileOverview } from '@/lib/profile/types'
+
+/**
+ * The above-the-fold impact numbers.
+ *
+ * Only tiles with a REAL, non-zero number render, and if none do the whole
+ * strip returns null so the get-started checklist takes its place. There is no
+ * `$0.00` hero and no grid of zeroes anywhere on this page — a zero state
+ * built out of empty stat tiles reads as a broken page.
+ *
+ * The savings tile shows the LARGEST currency group only. Currencies are never
+ * summed together (see the route), so the tile names one real total rather
+ * than inventing a combined one; the savings section below carries the full
+ * per-currency breakdown.
+ *
+ * Grid note: these are MAX-width breakpoints — `grid-cols-3` is the desktop
+ * layout and `md:`/`xs:` step it down on smaller screens.
+ */
+export default function ImpactStrip({
+    overview,
+}: {
+    overview: ProfileOverview
+}) {
+    const { savings, favorites, reports } = overview
+    const topTotal = savings.totals[0]
+
+    const tiles: React.ReactNode[] = []
+
+    if (savings.syncEnabled && topTotal && topTotal.minorUnits > 0) {
+        tiles.push(
+            <StatTile
+                key="saved"
+                label="Saved with Caramel"
+                value={formatMoney(topTotal.minorUnits, topTotal.currency)}
+                hint={
+                    savings.totals.length > 1
+                        ? `plus ${savings.totals.length - 1} more ${
+                              savings.totals.length - 1 === 1
+                                  ? 'currency'
+                                  : 'currencies'
+                          }`
+                        : undefined
+                }
+            />,
+        )
+    }
+
+    if (favorites.length > 0) {
+        tiles.push(
+            <StatTile
+                key="follow"
+                label="Stores you follow"
+                value={String(favorites.length)}
+            />,
+        )
+    }
+
+    if (reports.reportCount > 0) {
+        tiles.push(
+            <StatTile
+                key="reports"
+                label="Coupons you've reported"
+                value={String(reports.reportCount)}
+            />,
+        )
+    }
+
+    if (tiles.length === 0) return null
+
+    return (
+        <div className="grid grid-cols-3 gap-4 md:grid-cols-2 xs:grid-cols-1">
+            {tiles}
+        </div>
+    )
+}

--- a/apps/caramel-app/src/app/profile/sections/ReportsImpactSection.tsx
+++ b/apps/caramel-app/src/app/profile/sections/ReportsImpactSection.tsx
@@ -1,0 +1,90 @@
+import ProfileSection from '@/components/profile/ProfileSection'
+import {
+    bodyTextClasses,
+    cardClasses,
+    subHeadingClasses,
+} from '@/lib/profile/profileStyles'
+import { selectReportTier, type ReportImpact } from '@/lib/profile/reportImpact'
+
+// "Your reports" — impact without invented numbers.
+//
+// The whole section is a fall-through over what the backend can actually
+// derive (see selectReportTier). The tier-C line names OTHER PEOPLE'S
+// behaviour, so it renders only from a genuine downstream count and only at
+// >= 10; below that it is technically true and rhetorically worse than
+// silence, because it makes a real contribution sound trivial.
+//
+// The section HIDES ENTIRELY at zero reports. A block reading "you've made 0
+// reports" is nag copy for a feature the user reaches from the extension, not
+// from this page.
+//
+// CONTRAST: the numbers are `text-gray-900 dark:text-white`, NOT text-caramel.
+// Bold body text at 16px does not clear the 18.66px-bold AA-large floor, so
+// caramel numerals here would fail — caramel stays on the heading. This is
+// flagged because the tempting version is the failing one.
+//
+// No list of individual reports: a user does not want to relive twelve "this
+// code didn't work" submissions, and rendering them invites "why is this one
+// still listed".
+
+function Count({ children }: { children: React.ReactNode }) {
+    return (
+        <strong className="font-bold text-gray-900 dark:text-white">
+            {children}
+        </strong>
+    )
+}
+
+export default function ReportsImpactSection({
+    reports,
+}: {
+    reports: ReportImpact
+}) {
+    const tier = selectReportTier(reports)
+    if (tier === 'none') return null
+
+    const codes = (
+        <Count>
+            {reports.reportCount} {reports.reportCount === 1 ? 'code' : 'codes'}
+        </Count>
+    )
+
+    return (
+        <ProfileSection id="reports" title="Your reports">
+            <div className={cardClasses}>
+                <h3 className={subHeadingClasses}>
+                    {tier === 'C'
+                        ? 'Your reports are working'
+                        : 'Thanks for reporting'}
+                </h3>
+                <p className={`${bodyTextClasses} mt-2`}>
+                    {tier === 'A' ? (
+                        <>
+                            You&apos;ve told us about {codes}. Every report
+                            makes the next shopper&apos;s checkout a little less
+                            annoying.
+                        </>
+                    ) : tier === 'B' ? (
+                        <>
+                            You&apos;ve told us about {codes}, and{' '}
+                            <Count>{reports.confirmedCount}</Count> matched what
+                            we found when we checked. That&apos;s what keeps the
+                            list honest.
+                        </>
+                    ) : (
+                        <>
+                            You&apos;ve told us about {codes}. Since then,{' '}
+                            <Count>
+                                {reports.shoppersHelped}{' '}
+                                {reports.shoppersHelped === 1
+                                    ? 'shopper'
+                                    : 'shoppers'}
+                            </Count>{' '}
+                            used a code your report helped us get right.
+                        </>
+                    )}
+                </p>
+            </div>
+        </ProfileSection>
+    )
+}

--- a/apps/caramel-app/src/app/profile/sections/SavingsSection.tsx
+++ b/apps/caramel-app/src/app/profile/sections/SavingsSection.tsx
@@ -1,0 +1,322 @@
+'use client'
+
+import ProfileSection from '@/components/profile/ProfileSection'
+import SwitchField from '@/components/profile/SwitchField'
+import { promptSupportOnFailure } from '@/lib/feedback/promptSupportOnFailure'
+import {
+    formatEventDate,
+    formatMoney,
+    formatMonthYear,
+} from '@/lib/profile/formatCurrency'
+import {
+    bodyTextClasses,
+    cardClasses,
+    codeChipClasses,
+    listRowClasses,
+    microLabelClasses,
+    noticeBodyClasses,
+    noticeClasses,
+    noticeTitleClasses,
+    secondaryButtonClasses,
+    subHeadingClasses,
+    tintedCardClasses,
+} from '@/lib/profile/profileStyles'
+import type { ProfileOverview } from '@/lib/profile/types'
+import Image from 'next/image'
+import Link from 'next/link'
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+// The savings section. TWO HARD BANS, both about what this page must not
+// become (see the blueprint's §3.4):
+//
+//   NO CHART. recharts is in the dependency list; a line over four savings
+//   events is noise, and a chart is the single strongest "financial dashboard"
+//   signal there is.
+//   NO TABLE. No <table>, no column headers, no right-aligned numeric column.
+//
+// What it is instead: one warm hero number and a short list of moments.
+//
+// TODO(feat/login-savings): `PATCH /api/account/savings-sync` is owned by the
+// savings-sync PR and does not exist on this branch. The toggle below already
+// speaks its contract ({ enabled } -> { savingsSyncEnabled }); until that route
+// lands a toggle attempt fails loudly through the failure path below — which is
+// the SAME behaviour the spec requires for any failed toggle (switch does not
+// move, error toast, support prompt), so nothing here is a mock.
+
+const FAVICON_SIZE = 128
+const INITIAL_ROWS = 5
+
+function faviconFor(domain: string): string {
+    // Built exactly as site-card.tsx does — same source, same size param.
+    return `https://www.google.com/s2/favicons?sz=${FAVICON_SIZE}&domain_url=${encodeURIComponent(
+        domain,
+    )}`
+}
+
+export default function SavingsSection({
+    savings,
+    onSyncChange,
+}: {
+    savings: ProfileOverview['savings']
+    /** Told the confirmed server value so the parent can fold it into the
+     * loaded overview — this component never assumes its own write landed. */
+    onSyncChange: (enabled: boolean) => void
+}) {
+    const [busy, setBusy] = useState(false)
+    const [expanded, setExpanded] = useState(false)
+    const [announcement, setAnnouncement] = useState('')
+
+    async function toggleSync(next: boolean) {
+        setBusy(true)
+        try {
+            const res = await fetch('/api/account/savings-sync', {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                credentials: 'include',
+                body: JSON.stringify({ enabled: next }),
+            })
+            if (!res.ok) {
+                throw new Error(`Sync toggle failed with ${res.status}`)
+            }
+            const data = (await res.json()) as { savingsSyncEnabled: boolean }
+            // Trust the PERSISTED value, never the value we asked for.
+            onSyncChange(data.savingsSyncEnabled)
+            if (data.savingsSyncEnabled) {
+                toast.success('Savings sync is on.')
+                setAnnouncement('Savings sync is on')
+            } else {
+                toast.success(
+                    'Savings sync is off. Your history is still in your account.',
+                )
+                setAnnouncement('Savings sync is off')
+            }
+        } catch (error) {
+            // Do NOT move the switch — the parent state is untouched, so the
+            // knob stays where it was.
+            toast.error("Couldn't change that setting. Please try again.")
+            promptSupportOnFailure({
+                error,
+                operation: 'savings_sync_toggle',
+            })
+        } finally {
+            setBusy(false)
+        }
+    }
+
+    const hasEvents = savings.eventCount > 0
+    const [heroTotal, ...otherTotals] = savings.totals
+    const sinceLabel = formatMonthYear(savings.firstEventAt)
+    const visibleEvents = expanded
+        ? savings.recentEvents
+        : savings.recentEvents.slice(0, INITIAL_ROWS)
+
+    return (
+        <ProfileSection
+            id="savings"
+            title="Your savings"
+            description={
+                savings.syncEnabled
+                    ? 'What Caramel has taken off your checkouts.'
+                    : 'Kept on this device unless you turn on sync.'
+            }
+            action={
+                <SwitchField
+                    id="savings-sync"
+                    checked={savings.syncEnabled}
+                    onChange={next => void toggleSync(next)}
+                    busy={busy}
+                    label="Sync my savings"
+                    description="Store your savings on your Caramel account instead of just this device."
+                />
+            }
+        >
+            {/* aria-checked alone does not announce on change in every screen
+                reader; this live region does. */}
+            <p role="status" aria-live="polite" className="sr-only">
+                {announcement}
+            </p>
+
+            {!savings.syncEnabled ? (
+                <SyncOffBody savings={savings} />
+            ) : !hasEvents ? (
+                <div className={tintedCardClasses}>
+                    <h3 className={subHeadingClasses}>Sync is on</h3>
+                    <p className={`${bodyTextClasses} mt-2`}>
+                        Nothing to show yet. The next time Caramel lands a code
+                        for you, it&apos;ll turn up here.
+                    </p>
+                    <p className="mt-3 text-xs leading-relaxed text-gray-600 dark:text-gray-400">
+                        Sync starts from here. Codes you used before now stay on
+                        the device that recorded them.
+                    </p>
+                </div>
+            ) : (
+                <div className={cardClasses}>
+                    <p className="text-sm font-medium text-gray-600 dark:text-gray-400">
+                        You&apos;ve saved
+                    </p>
+                    <p className="mt-1 text-5xl font-extrabold tracking-tight text-caramel md:text-4xl">
+                        {heroTotal
+                            ? formatMoney(
+                                  heroTotal.minorUnits,
+                                  heroTotal.currency,
+                              )
+                            : null}
+                    </p>
+                    <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                        across {savings.storeCount}{' '}
+                        {savings.storeCount === 1 ? 'store' : 'stores'}
+                        {sinceLabel ? ` since ${sinceLabel}` : ''}
+                    </p>
+                    {/* Currencies are NEVER summed — each extra group gets its
+                        own honest line instead of being folded into the hero. */}
+                    {otherTotals.map(total => (
+                        <p
+                            key={total.currency}
+                            className="mt-1 text-sm text-gray-600 dark:text-gray-400"
+                        >
+                            plus {formatMoney(total.minorUnits, total.currency)}{' '}
+                            at stores that price in {total.currency}
+                        </p>
+                    ))}
+
+                    <div className="mt-8 border-t border-gray-100 pt-6 dark:border-gray-800">
+                        <p className={microLabelClasses}>Recent savings</p>
+                        <div className="mt-3">
+                            {visibleEvents.map((event, index) => {
+                                const when = formatEventDate(event.occurredAt)
+                                return (
+                                    <div
+                                        key={`${event.occurredAt}-${event.storeDomain}-${index}`}
+                                        className={listRowClasses}
+                                    >
+                                        <Image
+                                            src={faviconFor(event.storeDomain)}
+                                            alt=""
+                                            width={40}
+                                            height={40}
+                                            className="h-10 w-10 shrink-0 rounded-lg"
+                                            unoptimized
+                                        />
+                                        <div className="min-w-0 flex-1">
+                                            <p className="truncate font-medium text-gray-900 dark:text-white">
+                                                {event.storeDomain}
+                                            </p>
+                                            <div className="mt-1 flex items-center gap-2">
+                                                {event.code ? (
+                                                    <span
+                                                        className={
+                                                            codeChipClasses
+                                                        }
+                                                    >
+                                                        {event.code}
+                                                    </span>
+                                                ) : (
+                                                    <span className="text-xs text-gray-500 dark:text-gray-400">
+                                                        automatic discount
+                                                    </span>
+                                                )}
+                                                {when ? (
+                                                    <span className="text-xs text-gray-500 dark:text-gray-400">
+                                                        {when}
+                                                    </span>
+                                                ) : null}
+                                            </div>
+                                        </div>
+                                        {/* The one place green belongs: this
+                                            is a saving, not a charge. */}
+                                        <p className="shrink-0 font-semibold text-green-700 dark:text-green-400">
+                                            −
+                                            {formatMoney(
+                                                event.amountMinorUnits,
+                                                event.currency,
+                                            )}
+                                        </p>
+                                    </div>
+                                )
+                            })}
+                        </div>
+                        {savings.recentEvents.length > INITIAL_ROWS ? (
+                            <button
+                                type="button"
+                                onClick={() => setExpanded(v => !v)}
+                                className={`${secondaryButtonClasses} mt-4`}
+                            >
+                                {expanded
+                                    ? 'Show less'
+                                    : `Show all ${savings.recentEvents.length}`}
+                            </button>
+                        ) : null}
+                    </div>
+                </div>
+            )}
+        </ProfileSection>
+    )
+}
+
+/**
+ * Sync OFF. Two different bodies, because "never turned it on" and "turned it
+ * off after syncing" are different situations:
+ *
+ *  - Never on  -> the pitch.
+ *  - Was on, has history -> a notice confirming the history SURVIVED. Toggling
+ *    off means "stop sending more", not "erase what I have"; deleting on
+ *    toggle-off would make the control non-reversible in practice and
+ *    contradict the pitch copy that promises it is. Deletion is a separate,
+ *    deliberate act and lives in the danger zone.
+ */
+function SyncOffBody({ savings }: { savings: ProfileOverview['savings'] }) {
+    if (savings.eventCount > 0) {
+        return (
+            <div className={noticeClasses} role="status">
+                <p className={noticeTitleClasses}>Sync is off.</p>
+                <p className={noticeBodyClasses}>
+                    New savings stay on your device. The {savings.eventCount}{' '}
+                    {savings.eventCount === 1 ? 'event' : 'events'} already in
+                    your account are still here —{' '}
+                    <Link
+                        href="#data"
+                        className="font-semibold underline underline-offset-2"
+                    >
+                        delete them from Data &amp; privacy
+                    </Link>
+                    .
+                </p>
+            </div>
+        )
+    }
+
+    return (
+        <div className={tintedCardClasses}>
+            <h3 className={subHeadingClasses}>Turn on savings sync</h3>
+            <p className={`${bodyTextClasses} mt-2`}>
+                Right now Caramel keeps your savings on this device only. Turn
+                on sync and your total follows you to every browser you sign in
+                to.
+            </p>
+            <dl className="mt-4 space-y-2">
+                <div className={bodyTextClasses}>
+                    <dt className="inline font-semibold">What gets synced:</dt>{' '}
+                    <dd className="inline">
+                        the store, the code that worked, how much it saved, and
+                        when.
+                    </dd>
+                </div>
+                <div className={bodyTextClasses}>
+                    <dt className="inline font-semibold">What never does:</dt>{' '}
+                    <dd className="inline">
+                        what you bought, your cart, or your order details.
+                    </dd>
+                </div>
+            </dl>
+            <p className={`${bodyTextClasses} mt-4`}>
+                You can turn this off whenever you like.
+            </p>
+            <p className="mt-4 text-xs leading-relaxed text-gray-600 dark:text-gray-400">
+                Not synced? Your savings still count — they&apos;re just stored
+                in the extension on this device.
+            </p>
+        </div>
+    )
+}

--- a/apps/caramel-app/src/app/profile/sections/SavingsSection.tsx
+++ b/apps/caramel-app/src/app/profile/sections/SavingsSection.tsx
@@ -37,12 +37,11 @@ import { toast } from 'sonner'
 //
 // What it is instead: one warm hero number and a short list of moments.
 //
-// TODO(feat/login-savings): `PATCH /api/account/savings-sync` is owned by the
-// savings-sync PR and does not exist on this branch. The toggle below already
-// speaks its contract ({ enabled } -> { savingsSyncEnabled }); until that route
-// lands a toggle attempt fails loudly through the failure path below — which is
-// the SAME behaviour the spec requires for any failed toggle (switch does not
-// move, error toast, support prompt), so nothing here is a mock.
+// The switch writes `PATCH /api/account/savings-sync` ({ enabled } ->
+// { savingsSyncEnabled }) and renders the PERSISTED value it reads back, never
+// its own optimistic guess — the route is the single authority for consent, and
+// a switch showing "on" while the account says "off" is the exact drift that
+// authority exists to prevent.
 
 const FAVICON_SIZE = 128
 const INITIAL_ROWS = 5

--- a/apps/caramel-app/src/components/profile/ConfirmDialog.tsx
+++ b/apps/caramel-app/src/components/profile/ConfirmDialog.tsx
@@ -1,0 +1,139 @@
+'use client'
+
+// inputClasses/primaryButtonClasses come straight from authStyles: the confirm
+// input IS the same control as an auth input, and a second copy is exactly the
+// drift authStyles.ts was created to end.
+import {
+    inputClasses,
+    primaryButtonClasses,
+} from '@/components/auth/authStyles'
+import {
+    cardClasses,
+    dangerButtonClasses,
+    secondaryButtonClasses,
+    subHeadingClasses,
+} from '@/lib/profile/profileStyles'
+import { useEffect, useId, useRef, useState } from 'react'
+
+/**
+ * Confirmation modal built on the native <dialog>, with the same mechanics as
+ * SupportDialog: `showModal()` gives focus trap, Escape, and focus restore for
+ * free, and a click whose target IS the dialog element (rather than the panel
+ * inside it) is a backdrop click.
+ *
+ * `typeToConfirm` keeps the confirm button disabled until the user types the
+ * exact string. It is `DELETE`, not the account's email address: typing your
+ * own email is punishing on a phone keyboard, and this page's mobile entry
+ * point is the extension popup.
+ *
+ * Focus lands on the INPUT, never on the destructive button — a dialog that
+ * opens with "Delete" focused is one Enter keypress from an accident.
+ */
+export default function ConfirmDialog({
+    open,
+    onClose,
+    onConfirm,
+    title,
+    body,
+    confirmLabel,
+    typeToConfirm,
+    tone = 'default',
+    busy,
+}: {
+    open: boolean
+    onClose: () => void
+    onConfirm: () => void | Promise<void>
+    title: string
+    body: React.ReactNode
+    confirmLabel: string
+    /** When set, the confirm button stays disabled until the user types this
+     * exact string. */
+    typeToConfirm?: string
+    tone?: 'default' | 'danger'
+    busy?: boolean
+}) {
+    const dialogRef = useRef<HTMLDialogElement>(null)
+    const inputRef = useRef<HTMLInputElement>(null)
+    const [typed, setTyped] = useState('')
+    const headingId = useId()
+    const promptId = useId()
+
+    useEffect(() => {
+        const dlg = dialogRef.current
+        if (!dlg) return
+        if (open && !dlg.open) {
+            setTyped('')
+            dlg.showModal()
+            // showModal focuses the first tabbable child; for a destructive
+            // dialog that must be the text input, so steer it explicitly.
+            inputRef.current?.focus()
+        }
+        if (!open && dlg.open) dlg.close()
+    }, [open])
+
+    const confirmDisabled =
+        busy || (typeToConfirm !== undefined && typed !== typeToConfirm)
+
+    return (
+        <dialog
+            ref={dialogRef}
+            onClose={onClose}
+            onClick={e => {
+                if (e.target === dialogRef.current) onClose()
+            }}
+            aria-labelledby={headingId}
+            className="w-[92vw] max-w-md bg-transparent p-0 backdrop:bg-black/60 backdrop:backdrop-blur-sm"
+        >
+            {open ? (
+                <div className={cardClasses}>
+                    <h2 id={headingId} className={subHeadingClasses}>
+                        {title}
+                    </h2>
+                    <div className="mt-3">{body}</div>
+
+                    {typeToConfirm !== undefined ? (
+                        <div className="mt-5">
+                            <label
+                                htmlFor={`${promptId}-input`}
+                                className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300"
+                            >
+                                Type {typeToConfirm} to confirm.
+                            </label>
+                            <input
+                                ref={inputRef}
+                                id={`${promptId}-input`}
+                                type="text"
+                                autoComplete="off"
+                                value={typed}
+                                onChange={e => setTyped(e.target.value)}
+                                className={inputClasses}
+                            />
+                        </div>
+                    ) : null}
+
+                    <div className="mt-6 flex items-center justify-end gap-3 md:flex-col-reverse md:items-stretch">
+                        <button
+                            type="button"
+                            onClick={onClose}
+                            className={secondaryButtonClasses}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => void onConfirm()}
+                            disabled={confirmDisabled}
+                            className={
+                                tone === 'danger'
+                                    ? dangerButtonClasses
+                                    : `${primaryButtonClasses} w-auto px-4 py-2.5 text-sm`
+                            }
+                        >
+                            {confirmLabel}
+                        </button>
+                    </div>
+                </div>
+            ) : null}
+        </dialog>
+    )
+}

--- a/apps/caramel-app/src/components/profile/EmptyState.tsx
+++ b/apps/caramel-app/src/components/profile/EmptyState.tsx
@@ -1,0 +1,48 @@
+import { bodyTextClasses, subHeadingClasses } from '@/lib/profile/profileStyles'
+
+/**
+ * The teaching empty state: an icon, a headline, body copy, and the actions
+ * that make the emptiness go away.
+ *
+ * This page's DEFAULT state is empty — most people arrive with no savings, no
+ * favorites and no reports — so an empty section is the common case, not an
+ * edge case. It never says "no data": it says what the feature is for and how
+ * to start it.
+ */
+export default function EmptyState({
+    icon,
+    heading,
+    body,
+    footnote,
+    actions,
+}: {
+    /** Decorative — the heading already names the thing. */
+    icon: React.ReactNode
+    heading: string
+    body: string
+    footnote?: string
+    actions?: React.ReactNode
+}) {
+    return (
+        <div className="text-center">
+            <div
+                aria-hidden="true"
+                className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-caramel/10 text-2xl text-caramel dark:bg-caramel/20"
+            >
+                {icon}
+            </div>
+            <h3 className={subHeadingClasses}>{heading}</h3>
+            <p className={`${bodyTextClasses} mx-auto mt-2 max-w-md`}>{body}</p>
+            {footnote ? (
+                <p className="mx-auto mt-3 max-w-md text-xs leading-relaxed text-gray-600 dark:text-gray-400">
+                    {footnote}
+                </p>
+            ) : null}
+            {actions ? (
+                <div className="mt-5 flex flex-wrap items-center justify-center gap-3">
+                    {actions}
+                </div>
+            ) : null}
+        </div>
+    )
+}

--- a/apps/caramel-app/src/components/profile/ProfileSection.tsx
+++ b/apps/caramel-app/src/components/profile/ProfileSection.tsx
@@ -1,0 +1,51 @@
+import {
+    sectionDescriptionClasses,
+    sectionHeadingClasses,
+} from '@/lib/profile/profileStyles'
+
+/**
+ * The <section> + <h2> + description + optional heading-row control that every
+ * account-page section is wrapped in.
+ *
+ * `scroll-mt-28` keeps the sticky floating header off the heading when a
+ * section is deep-linked (`/profile#savings` — the extension popup's "Manage
+ * account" link lands there). globals.css sets `scroll-behavior: smooth`, so
+ * that works with no JS.
+ *
+ * Heading level is fixed at h2 on purpose: the account header card owns the
+ * page's single h1 (the user's name), and sub-blocks inside a section use h3.
+ * No level is skipped.
+ */
+export default function ProfileSection({
+    id,
+    title,
+    description,
+    action,
+    children,
+}: {
+    id: string
+    title: string
+    description?: string
+    /** Right-aligned control in the heading row (e.g. the sync switch). */
+    action?: React.ReactNode
+    children: React.ReactNode
+}) {
+    return (
+        <section id={id} className="scroll-mt-28">
+            <div className="mb-4 flex items-start justify-between gap-4 md:flex-col md:gap-3">
+                <div className="min-w-0">
+                    <h2 className={sectionHeadingClasses}>{title}</h2>
+                    {description ? (
+                        <p className={sectionDescriptionClasses}>
+                            {description}
+                        </p>
+                    ) : null}
+                </div>
+                {action ? (
+                    <div className="shrink-0 md:self-start">{action}</div>
+                ) : null}
+            </div>
+            {children}
+        </section>
+    )
+}

--- a/apps/caramel-app/src/components/profile/SectionSkeleton.tsx
+++ b/apps/caramel-app/src/components/profile/SectionSkeleton.tsx
@@ -1,0 +1,33 @@
+import { cardClasses } from '@/lib/profile/profileStyles'
+
+/**
+ * Loading placeholder shaped like the section it stands in for.
+ *
+ * Only the DATA-BACKED sections skeleton. The account header and Account
+ * details render immediately from the session, which is already in memory — a
+ * centered "Loading…" for the whole page (the old behaviour) is why this page
+ * used to feel like a form rather than a home.
+ *
+ * `motion-reduce:animate-none` because `animate-pulse` is a Tailwind animation
+ * and the app's global reduced-motion handling covers scrolling only.
+ */
+export default function SectionSkeleton() {
+    return (
+        <div
+            role="status"
+            aria-label="Loading your account"
+            className={cardClasses}
+        >
+            <div className="h-4 w-24 animate-pulse rounded bg-gray-200 motion-reduce:animate-none dark:bg-gray-700" />
+            <div className="mt-3 h-10 w-48 animate-pulse rounded bg-gray-200 motion-reduce:animate-none dark:bg-gray-700" />
+            <div className="mt-6 space-y-4">
+                {[0, 1, 2].map(i => (
+                    <div key={i} className="flex items-center gap-4">
+                        <div className="h-10 w-10 shrink-0 animate-pulse rounded-lg bg-gray-200 motion-reduce:animate-none dark:bg-gray-700" />
+                        <div className="h-4 flex-1 animate-pulse rounded bg-gray-200 motion-reduce:animate-none dark:bg-gray-700" />
+                    </div>
+                ))}
+            </div>
+        </div>
+    )
+}

--- a/apps/caramel-app/src/components/profile/StatTile.tsx
+++ b/apps/caramel-app/src/components/profile/StatTile.tsx
@@ -1,0 +1,36 @@
+import { microLabelClasses } from '@/lib/profile/profileStyles'
+
+/**
+ * One impact number in the strip above the fold.
+ *
+ * `text-3xl` (30px) is load-bearing, not decoration: `text-caramel` measures
+ * 3.19:1 on white, which is AA for large text ONLY (>=24px). Shrinking this
+ * value's type size silently drops the tile below the contrast floor.
+ *
+ * A tile is only ever rendered for a real, non-zero number — the strip omits
+ * itself entirely at zero rather than showing a wall of 0s (the checklist
+ * takes its place).
+ */
+export default function StatTile({
+    label,
+    value,
+    hint,
+}: {
+    label: string
+    value: string
+    hint?: string
+}) {
+    return (
+        <div className="rounded-2xl border border-gray-100 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-darkerBg">
+            <p className={microLabelClasses}>{label}</p>
+            <p className="mt-1.5 text-3xl font-bold tracking-tight text-caramel">
+                {value}
+            </p>
+            {hint ? (
+                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    {hint}
+                </p>
+            ) : null}
+        </div>
+    )
+}

--- a/apps/caramel-app/src/components/profile/SwitchField.tsx
+++ b/apps/caramel-app/src/components/profile/SwitchField.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+/**
+ * A real switch — `<button role="switch">`, not a styled checkbox.
+ *
+ * Two deliberate behaviours:
+ *
+ * 1. NOT OPTIMISTIC. The knob does not move until the server confirms. A
+ *    switch that flips instantly and then snaps back is a worse experience
+ *    than a 300ms wait, because the user has already been told the setting
+ *    changed. `busy` dims the knob to show work is happening.
+ *
+ * 2. The focus ring is INHERITED. globals.css styles
+ *    `:where(a, button, [role='button'], summary):focus-visible` with a 2px
+ *    caramel outline, and a `<button role="switch">` still matches `button` —
+ *    so this component adds no ring of its own, on purpose. Adding one would
+ *    render two competing rings.
+ *
+ * Hit area: the `-m-2 p-2` pair grows the target past the 44px minimum without
+ * changing the switch's visual size or the row's layout.
+ */
+export default function SwitchField({
+    id,
+    checked,
+    onChange,
+    label,
+    description,
+    disabled,
+    busy,
+}: {
+    id: string
+    checked: boolean
+    onChange: (next: boolean) => void
+    label: string
+    description?: string
+    disabled?: boolean
+    busy?: boolean
+}) {
+    return (
+        <div className="flex items-start gap-3">
+            <div className="min-w-0">
+                <p
+                    id={`${id}-label`}
+                    className="text-sm font-semibold text-gray-900 dark:text-white"
+                >
+                    {label}
+                </p>
+                {description ? (
+                    <p
+                        id={`${id}-desc`}
+                        className="mt-0.5 max-w-xs text-xs leading-relaxed text-gray-600 dark:text-gray-400"
+                    >
+                        {description}
+                    </p>
+                ) : null}
+            </div>
+            <button
+                type="button"
+                role="switch"
+                id={id}
+                aria-checked={checked}
+                aria-labelledby={`${id}-label`}
+                aria-describedby={description ? `${id}-desc` : undefined}
+                disabled={disabled || busy}
+                onClick={() => onChange(!checked)}
+                className="-m-2 shrink-0 p-2 disabled:cursor-not-allowed disabled:opacity-70"
+            >
+                <span
+                    aria-hidden="true"
+                    className={`flex h-6 w-11 items-center rounded-full transition-colors duration-200 ${
+                        checked ? 'bg-caramel' : 'bg-gray-300 dark:bg-gray-600'
+                    }`}
+                >
+                    <span
+                        className={`h-5 w-5 rounded-full bg-white shadow transition-transform duration-200 motion-reduce:transition-none ${
+                            checked ? 'translate-x-5' : 'translate-x-0.5'
+                        } ${busy ? 'opacity-60' : ''}`}
+                    />
+                </span>
+            </button>
+        </div>
+    )
+}

--- a/apps/caramel-app/src/lib/couponsRepo.ts
+++ b/apps/caramel-app/src/lib/couponsRepo.ts
@@ -232,6 +232,47 @@ export async function getCouponStats(): Promise<StatsRow> {
     return rows[0] ?? { total: 0, expired: 0 }
 }
 
+/**
+ * api/account/overview GET — live "12 codes right now" counts for the stores a
+ * user follows, one query for the whole list.
+ *
+ * Lives here rather than in the account route for the same reason every other
+ * catalog read does: it must share `visibleCouponsWhere()` and the
+ * `site = store OR site LIKE '%.' || store` store-matching predicate with
+ * listStoreCoupons, or the count under a favorite would disagree with the
+ * store page that favorite links to. A second hand-written copy of either
+ * predicate is exactly the F-006 drift this module exists to prevent.
+ *
+ * `stores` are already-normalized registrable domains (resolveStoreDomain
+ * output, the same vocabulary favorite_stores.store_name stores). UNNEST turns
+ * the array into rows so a LEFT JOIN can report a genuine 0 for a followed
+ * store with no live codes — the caller distinguishes "0 codes" from "no count
+ * available" and the UI renders neither as a placeholder.
+ */
+export async function countCouponsForStores(
+    stores: string[],
+): Promise<Map<string, number>> {
+    if (stores.length === 0) return new Map()
+    const rawRows = await prisma.$queryRaw(Prisma.sql`
+        SELECT f.store AS site, COUNT(c.id)::int AS coupon_count
+        FROM UNNEST(${stores}::text[]) AS f(store)
+        LEFT JOIN coupons c
+               ON (c.site = f.store OR c.site LIKE '%.' || f.store)
+              AND ${visibleCouponsWhere()}
+        GROUP BY f.store
+    `)
+    const rows = parseCouponRows(
+        SiteCountRowSchema,
+        rawRows,
+        'account.favorite-counts',
+    )
+    const counts = new Map<string, number>()
+    for (const row of rows) {
+        if (row.site) counts.set(row.site, row.coupon_count)
+    }
+    return counts
+}
+
 /** api/coupons/stores/route.ts GET — store-name autocomplete; q-present/absent branch is a genuinely different query (ILIKE vs. no filter), not just an optional param. */
 export async function listStoreOptions(
     q: string,

--- a/apps/caramel-app/src/lib/profile/accountExport.ts
+++ b/apps/caramel-app/src/lib/profile/accountExport.ts
@@ -1,0 +1,211 @@
+// src/lib/profile/accountExport.ts
+//
+// Builds the "download my data" JSON, and enforces what may never be in it.
+//
+// This file is deliberately a pure builder plus a guard, with no Prisma and no
+// HTTP: the route fetches rows, this shapes them, and the same guard the route
+// runs is what the unit test asserts. A leak here is a privacy breach in a
+// PUBLIC repo, so the never-include list is a CHECK that fails the request,
+// not a comment that asks the next author to be careful.
+//
+// NEVER in the export:
+//   - password hashes / any credential material
+//   - session or bearer tokens, OAuth access/refresh tokens, verification
+//     tokens
+//   - any other user's identifiers
+//   - internal catalog row ids (a coupon's primary key tells the user nothing
+//     and hands out our catalog's internal keyspace)
+//
+// The export therefore names a coupon by the STORE and CODE the user actually
+// saw, never by `couponId`. Adding a field to this file means adding it to the
+// contract; adding a forbidden one makes the request throw.
+
+/** Key names that must never appear anywhere in an export payload, at any
+ * depth. Compared case-insensitively so `passwordHash` and `PasswordHash` are
+ * both caught. */
+export const FORBIDDEN_EXPORT_KEYS: readonly string[] = [
+    'password',
+    'passwordhash',
+    'hash',
+    'salt',
+    'token',
+    'tokenexpiry',
+    'accesstoken',
+    'refreshtoken',
+    'idtoken',
+    'sessiontoken',
+    'secret',
+    'apikey',
+    'couponid',
+    'userid',
+    'id_token',
+    'access_token',
+    'refresh_token',
+]
+
+/** Keys that are legitimately named `id` but are the user's OWN account id —
+ * the one identifier a data export is supposed to contain. */
+const ALLOWED_ID_PATHS = new Set(['account.id'])
+
+export interface AccountExport {
+    /** ISO — when this file was produced. */
+    exportedAt: string
+    account: {
+        id: string
+        email: string | null
+        name: string | null
+        firstName: string | null
+        lastName: string | null
+        username: string | null
+        createdAt: string
+        emailVerified: boolean
+    }
+    preferences: {
+        savingsSyncEnabled: boolean
+    }
+    favoriteStores: { domain: string; starredAt: string }[]
+    savingsEvents: {
+        storeDomain: string
+        code: string | null
+        amountMinorUnits: number
+        currency: string
+        occurredAt: string
+    }[]
+    couponReports: {
+        storeDomain: string | null
+        code: string | null
+        outcome: string
+        reportedAt: string
+    }[]
+}
+
+/**
+ * Walks a payload and returns the dotted paths of every key that violates the
+ * never-include list. Empty array = clean.
+ *
+ * Array indices collapse to `[]` so a 400-event export reports
+ * `savingsEvents[].couponId` once rather than 400 times.
+ */
+export function collectForbiddenKeys(value: unknown, path = ''): string[] {
+    if (Array.isArray(value)) {
+        const found = new Set<string>()
+        for (const item of value) {
+            for (const hit of collectForbiddenKeys(item, `${path}[]`)) {
+                found.add(hit)
+            }
+        }
+        return Array.from(found)
+    }
+    if (value === null || typeof value !== 'object') return []
+
+    const hits: string[] = []
+    for (const [key, child] of Object.entries(
+        value as Record<string, unknown>,
+    )) {
+        const childPath = path ? `${path}.${key}` : key
+        const normalized = key.toLowerCase()
+        const isForbidden =
+            FORBIDDEN_EXPORT_KEYS.includes(normalized) ||
+            (normalized === 'id' && !ALLOWED_ID_PATHS.has(childPath))
+        if (isForbidden) hits.push(childPath)
+        hits.push(...collectForbiddenKeys(child, childPath))
+    }
+    return hits
+}
+
+/**
+ * The guard the export route runs on every response before it is serialized.
+ *
+ * Throwing (rather than stripping) is the point: a silently-stripped field
+ * would let a leak sit in the builder unnoticed until the strip list drifted.
+ * withRoute's try/catch turns this into a 500 + Sentry, which is the correct
+ * outcome for "we were about to hand someone data we promised never to send".
+ */
+export function assertExportIsSafe(payload: AccountExport): void {
+    const violations = collectForbiddenKeys(payload)
+    if (violations.length > 0) {
+        throw new Error(
+            `Account export contains forbidden fields: ${violations.join(', ')}`,
+        )
+    }
+}
+
+export interface AccountExportInput {
+    account: {
+        id: string
+        email: string | null
+        name: string | null
+        firstName: string | null
+        lastName: string | null
+        username: string | null
+        createdAt: Date
+        emailVerified: boolean
+    }
+    savingsSyncEnabled: boolean
+    favoriteStores: { storeName: string; createdAt: Date }[]
+    savingsEvents: {
+        store: string
+        code: string
+        amountCents: number
+        currency: string
+        occurredAt: Date
+    }[]
+    couponReports: {
+        outcome: string
+        createdAt: Date
+        coupon: { site: string | null; code: string } | null
+    }[]
+}
+
+/**
+ * Shapes fetched rows into the export contract.
+ *
+ * Note what is dropped on the way through: `SavingsEvent.id`,
+ * `SavingsEvent.couponId`, `SavingsEvent.clientEventId`, `CouponReport.id`,
+ * `CouponReport.couponId`, `FavoriteStore.userId` and `Coupon.id`. Every one
+ * is an internal key that says nothing to the person reading their own data.
+ */
+export function buildAccountExport(
+    input: AccountExportInput,
+    now: Date = new Date(),
+): AccountExport {
+    return {
+        exportedAt: now.toISOString(),
+        account: {
+            id: input.account.id,
+            email: input.account.email,
+            name: input.account.name,
+            firstName: input.account.firstName,
+            lastName: input.account.lastName,
+            username: input.account.username,
+            createdAt: input.account.createdAt.toISOString(),
+            emailVerified: input.account.emailVerified,
+        },
+        preferences: {
+            savingsSyncEnabled: input.savingsSyncEnabled,
+        },
+        favoriteStores: input.favoriteStores.map(row => ({
+            domain: row.storeName,
+            starredAt: row.createdAt.toISOString(),
+        })),
+        savingsEvents: input.savingsEvents.map(row => ({
+            storeDomain: row.store,
+            code: row.code === '' ? null : row.code,
+            amountMinorUnits: row.amountCents,
+            currency: row.currency,
+            occurredAt: row.occurredAt.toISOString(),
+        })),
+        couponReports: input.couponReports.map(row => ({
+            // Named by what the user saw, never by the catalog's row id.
+            storeDomain: row.coupon?.site ?? null,
+            code: row.coupon?.code ?? null,
+            outcome: row.outcome,
+            reportedAt: row.createdAt.toISOString(),
+        })),
+    }
+}
+
+/** `caramel-data-2026-08-09.json` — the filename the browser saves. */
+export function exportFilename(now: Date = new Date()): string {
+    return `caramel-data-${now.toISOString().slice(0, 10)}.json`
+}

--- a/apps/caramel-app/src/lib/profile/formatCurrency.ts
+++ b/apps/caramel-app/src/lib/profile/formatCurrency.ts
@@ -1,0 +1,48 @@
+/**
+ * Money on the account page. Amounts arrive as integer minor units + an ISO
+ * currency code so nothing rounds on the wire.
+ *
+ * Always two fraction digits: a lifetime total rendered as "$127" when the real
+ * figure is $127.40 is a rounded claim about someone's money.
+ */
+export function formatMoney(minorUnits: number, currency: string): string {
+    return new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency,
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+    }).format(minorUnits / 100)
+}
+
+/**
+ * "March 2026" — the month-and-year form used by "Saving with Caramel since …"
+ * and the savings hero's "since …". Returns null for a missing or unparseable
+ * timestamp so the caller drops the whole line instead of rendering
+ * "since Invalid Date".
+ */
+export function formatMonthYear(iso: string | null | undefined): string | null {
+    if (!iso) return null
+    const parsed = Date.parse(iso)
+    if (Number.isNaN(parsed)) return null
+    return new Intl.DateTimeFormat('en-US', {
+        month: 'long',
+        year: 'numeric',
+    }).format(new Date(parsed))
+}
+
+/**
+ * Short date for a savings row ("12 Mar"), or the year too when the event is
+ * from a previous calendar year. Returns null on an unparseable value — the
+ * row then renders without a date rather than with a broken one.
+ */
+export function formatEventDate(iso: string): string | null {
+    const parsed = Date.parse(iso)
+    if (Number.isNaN(parsed)) return null
+    const date = new Date(parsed)
+    const sameYear = date.getFullYear() === new Date().getFullYear()
+    return new Intl.DateTimeFormat('en-US', {
+        day: 'numeric',
+        month: 'short',
+        ...(sameYear ? {} : { year: 'numeric' }),
+    }).format(date)
+}

--- a/apps/caramel-app/src/lib/profile/profileStyles.ts
+++ b/apps/caramel-app/src/lib/profile/profileStyles.ts
@@ -1,0 +1,85 @@
+/**
+ * One source of truth for account-page styling — same reason authStyles.ts
+ * exists (see its header): the section cards, tiles and danger controls below
+ * each appear in three or more section files, and three copies is how they
+ * drift. Any visual change to the account page happens here once.
+ *
+ * CONTRAST NOTE (do not "simplify" these): #ea6925 on white measures 3.19:1,
+ * which is AA for LARGE text only (>=24px, or >=18.66px bold). Every caramel
+ * text token below is therefore attached to a >=text-2xl/3xl class. Body copy
+ * is gray-700/gray-300 on purpose.
+ *
+ * BREAKPOINT NOTE: this app's Tailwind screens are MAX-widths
+ * (tailwind.config.ts) — unprefixed is the DESKTOP style and `md:`/`xs:` are
+ * the small-screen overrides. `p-8 md:p-6 xs:p-5` shrinks on phones; it does
+ * not grow on desktop.
+ */
+
+/** The standard raised card. Matches the existing profile card + header dropdown. */
+export const cardClasses =
+    'rounded-2xl border border-gray-100 bg-white p-8 shadow-lg dark:border-gray-800 dark:bg-darkerBg md:p-6 xs:p-5'
+
+/** Warm-tinted card for sections that pitch rather than report (checklist, sync pitch). */
+export const tintedCardClasses =
+    'rounded-2xl border border-caramel/20 bg-gradient-to-br from-caramel/5 via-orange-50/20 to-caramel/5 p-8 shadow-md dark:border-caramel/30 dark:from-caramel/10 dark:via-orange-900/10 dark:to-caramel/10 md:p-6 xs:p-5'
+
+/** Section heading. text-2xl clears the 24px AA-large floor for text-caramel. */
+export const sectionHeadingClasses =
+    'text-2xl font-bold tracking-tight text-gray-900 dark:text-white'
+
+export const sectionDescriptionClasses =
+    'mt-1 text-sm leading-relaxed text-gray-600 dark:text-gray-400'
+
+/** Sub-heading inside a section card (Export, Danger zone) — always an <h3>. */
+export const subHeadingClasses =
+    'text-lg font-semibold text-gray-900 dark:text-white'
+
+/** Body copy. gray-700 on white = 10.3:1; gray-300 on darkerBg = 11.4:1. */
+export const bodyTextClasses =
+    'text-sm leading-relaxed text-gray-700 dark:text-gray-300'
+
+/** Secondary button — the auth social button minus its icon layout. */
+export const secondaryButtonClasses =
+    'inline-flex items-center justify-center gap-2 rounded-xl border border-gray-300 bg-white px-4 py-2.5 text-sm font-semibold text-gray-700 shadow-sm transition duration-200 hover:border-caramel hover:bg-caramel/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/50 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:bg-darkBg dark:text-gray-200 dark:shadow-none dark:hover:border-caramel/60 dark:hover:bg-caramel/10 dark:focus-visible:ring-offset-darkerBg'
+
+/** Destructive button. Red-700 on white = 4.8:1; red-300 on darkBg = 6.4:1. */
+export const dangerButtonClasses =
+    'inline-flex items-center justify-center gap-2 rounded-xl border border-red-300 bg-white px-4 py-2.5 text-sm font-semibold text-red-700 shadow-sm transition duration-200 hover:border-red-500 hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500/50 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-900/60 dark:bg-darkBg dark:text-red-300 dark:shadow-none dark:hover:bg-red-950/40 dark:focus-visible:ring-offset-darkerBg'
+
+/** The fence around the delete control. Deliberately not a card — it should
+ * read as a different, more dangerous surface than everything above it. */
+export const dangerFenceClasses =
+    'rounded-2xl border border-red-200 bg-red-50/50 p-6 dark:border-red-900/50 dark:bg-red-950/20 xs:p-5'
+
+/** Rows inside a list card. Last row drops its divider. */
+export const listRowClasses =
+    'flex items-center gap-4 border-b border-gray-100 py-4 first:pt-0 last:border-b-0 last:pb-0 dark:border-gray-800'
+
+/** Monospace code chip — the coupon code in a savings row. */
+export const codeChipClasses =
+    'rounded-md bg-gray-100 px-2 py-0.5 font-mono text-xs font-semibold tracking-wide text-gray-700 dark:bg-white/10 dark:text-gray-200'
+
+/** The uppercase micro-label idiom already used by the profile card and
+ * FeaturesSection. gray-500 on white = 4.6:1; on dark it MUST step to
+ * gray-400 (gray-500 on darkerBg is 3.5:1 and fails). */
+export const microLabelClasses =
+    'text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400'
+
+/** Inline notice — the same alert idiom LoginPageClient uses. */
+export const noticeClasses =
+    'rounded-xl border border-orange-300 bg-orange-50 p-4 dark:border-caramel/40 dark:bg-caramel/10'
+
+export const noticeTitleClasses =
+    'text-sm font-semibold text-orange-800 dark:text-orange-200'
+
+export const noticeBodyClasses =
+    'mt-1 text-sm text-orange-700 dark:text-orange-300'
+
+/** The notice's own button (LoginPageClient's verification-alert button). */
+export const noticeButtonClasses =
+    'mt-3 rounded-lg border border-orange-300 bg-white px-4 py-2 text-sm font-semibold text-caramel shadow-sm transition duration-200 hover:bg-orange-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel/50 focus-visible:ring-offset-2 dark:border-caramel/40 dark:bg-darkBg dark:shadow-none dark:hover:bg-caramel/10 dark:focus-visible:ring-offset-darkerBg'
+
+/** Focus ring for a non-button interactive (the favorites row Link). Buttons
+ * get theirs free from globals.css — do not add a competing ring there. */
+export const linkRowFocusClasses =
+    'rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-caramel focus-visible:ring-offset-2 dark:focus-visible:ring-offset-darkerBg'

--- a/apps/caramel-app/src/lib/profile/reportImpact.ts
+++ b/apps/caramel-app/src/lib/profile/reportImpact.ts
@@ -1,0 +1,120 @@
+// src/lib/profile/reportImpact.ts
+//
+// Derives the "your reports" numbers the account page is allowed to state.
+//
+// This is the section most likely to ship a FALSE CLAIM, so the rule is
+// mechanical: the page may render only numbers derivable from real records.
+// There are three copy tiers and the page renders the highest tier the data
+// genuinely supports — never higher:
+//
+//   A  reportCount only                 → thanks framing, no impact claim
+//   B  + confirmedCount                 → "N matched what we found"
+//   C  + shoppersHelped (>= 10)         → "helped N shoppers"
+//
+// `shoppersHelped` is HARD-NULL here and that is deliberate, not an oversight:
+// it would require a count of DISTINCT OTHER USERS who used a coupon whose
+// state a given user's report changed. Nothing in this schema records who used
+// a coupon — `Coupon.timesUsed` and `CouponSignal.workCount` are anonymous
+// aggregates with no user attribution and no link back to the report that
+// preceded them. Deriving "shoppers helped" from reportCount times anything,
+// or from an aggregate counter, would be a fabricated public claim about
+// another person's behaviour. If a real attribution table ever exists, count
+// from IT and not from these. Until then tier C never renders.
+
+/** Tier-C floor. "You helped 2 shoppers" is true and rhetorically worse than
+ * silence — it makes a real contribution sound trivial. Below this the page
+ * falls back to tier B (or A). */
+export const SHOPPERS_HELPED_MIN = 10
+
+/** One report joined to the catalog state of the coupon it was about. */
+export interface ReportWithCouponState {
+    outcome: string
+    createdAt: Date
+    coupon: {
+        status: string
+        expired: boolean
+        /** The catalog's last-write stamp — the verification pipeline's
+         * only-if-newer authority (see Coupon.updatedAt in schema.prisma). */
+        updatedAt: Date
+    } | null
+}
+
+/**
+ * A report is CONFIRMED when our own catalog was written AFTER the report and
+ * landed in a state that agrees with what the user told us.
+ *
+ * Both halves are load-bearing:
+ *  - "after" (`coupon.updatedAt > report.createdAt`) is what makes this a
+ *    RECHECK rather than a restatement of the state that was already there
+ *    when they reported. Without it every report about an already-valid coupon
+ *    would count itself as confirmed.
+ *  - "agrees" is direction-aware: a `worked` report is confirmed by a live,
+ *    unexpired, valid coupon; a `failed` report is confirmed by the catalog
+ *    having since expired or de-validated it.
+ *
+ * A report whose coupon row is gone (or absent from the join) is NOT counted —
+ * we cannot say our recheck agreed with something we can no longer see.
+ */
+export function isConfirmedReport(report: ReportWithCouponState): boolean {
+    const { coupon } = report
+    if (!coupon) return false
+    if (coupon.updatedAt.getTime() <= report.createdAt.getTime()) return false
+
+    const catalogSaysUsable = coupon.status === 'valid' && !coupon.expired
+    if (report.outcome === 'worked') return catalogSaysUsable
+    if (report.outcome === 'failed') return !catalogSaysUsable
+    // An outcome outside the route's two-value vocabulary confirms nothing.
+    return false
+}
+
+export interface ReportImpact {
+    reportCount: number
+    confirmedCount: number | null
+    shoppersHelped: number | null
+}
+
+/** Which copy tier the data supports. `'none'` = render no section at all. */
+export type ReportTier = 'none' | 'A' | 'B' | 'C'
+
+/**
+ * Picks the HIGHEST tier the payload genuinely supports, as a fall-through
+ * chain rather than a feature flag: a tier is unlocked by its number being
+ * present and meaningful, so a field that goes missing (or a count that drops
+ * below the floor) silently degrades the copy instead of rendering a claim
+ * with a hole in it.
+ */
+export function selectReportTier(reports: ReportImpact): ReportTier {
+    if (reports.reportCount < 1) return 'none'
+    if (
+        reports.shoppersHelped !== null &&
+        reports.shoppersHelped >= SHOPPERS_HELPED_MIN
+    ) {
+        return 'C'
+    }
+    if (reports.confirmedCount !== null && reports.confirmedCount >= 1) {
+        return 'B'
+    }
+    return 'A'
+}
+
+/**
+ * Folds a user's reports into the contract's `reports` block.
+ *
+ * `confirmedCount` is null — not 0 — when the user has no reports at all: with
+ * nothing to confirm there is no confirmation RATE to state, and a literal
+ * "0 matched what we found" reads as an accusation. Zero confirmations out of
+ * real reports, on the other hand, is a true and renderable 0.
+ */
+export function summarizeReports(
+    reports: ReportWithCouponState[],
+): ReportImpact {
+    if (reports.length === 0) {
+        return { reportCount: 0, confirmedCount: null, shoppersHelped: null }
+    }
+    return {
+        reportCount: reports.length,
+        confirmedCount: reports.filter(isConfirmedReport).length,
+        // See the module header: no per-user usage attribution exists.
+        shoppersHelped: null,
+    }
+}

--- a/apps/caramel-app/src/lib/profile/savingsSyncPreference.ts
+++ b/apps/caramel-app/src/lib/profile/savingsSyncPreference.ts
@@ -1,33 +1,27 @@
 // src/lib/profile/savingsSyncPreference.ts
 //
 // The ONE place the account page learns whether a user has opted into cloud
-// savings sync. It is a module rather than an inline read so that wiring it to
-// its real storage is a one-line change in one file.
+// savings sync. It is a module rather than an inline read so that every
+// consumer (the overview payload, the export's `preferences` block) resolves
+// the flag exactly one way.
 //
-// TODO(feat/login-savings): this must read `users.savings_sync_enabled` — the
-// additive `User.savingsSyncEnabled Boolean @default(false)` column owned by
-// the savings-sync PR (feat/login-savings), which also ships
-// `PATCH /api/account/savings-sync`. That column does NOT exist on this branch
-// (feat/profile-revamp is cut from feat/login-foundation), so referencing it
-// here would not compile. When the two PRs meet, replace the body below with:
+// READ IT FROM THE TABLE, NEVER FROM THE SESSION. better-auth projects only
+// the fields it knows about onto `session.user`, so a custom column arrives
+// there as `undefined` — falsy, and therefore indistinguishable from a real
+// "off". Every account would silently render as sync-off while the table said
+// otherwise. `PATCH /api/account/savings-sync` writes this column and reads it
+// back for the same reason: `users.savings_sync_enabled` is the single
+// authority, and chrome.storage.sync is only a cache of it.
 //
-//     const row = await prisma.user.findUnique({
-//         where: { id: userId },
-//         select: { savingsSyncEnabled: true },
-//     })
-//     return row?.savingsSyncEnabled ?? false
-//
-// and delete this comment. Read it from Prisma, NOT from the better-auth
-// session: `auth.api.getSession()` only returns fields better-auth knows
-// about, so a custom column arrives there as `undefined` — falsy, and every
-// user would silently render as sync-off.
-//
-// Returning false today is not a placeholder or a guess, it is the true
-// value: on this branch nothing can set the preference (no column, no PATCH
-// route), so every account genuinely has sync off and the savings section
-// correctly renders its opt-in pitch. The account page therefore behaves
-// correctly standalone and lights up the moment the column lands.
+// A missing user row resolves to false rather than throwing: the caller is
+// already handling a live session whose row it separately verifies (the export
+// route 404s on it), and an absent row genuinely carries no consent.
+import prisma from '@/lib/prisma'
+
 export async function readSavingsSyncEnabled(userId: string): Promise<boolean> {
-    void userId
-    return false
+    const row = await prisma.user.findUnique({
+        where: { id: userId },
+        select: { savingsSyncEnabled: true },
+    })
+    return row?.savingsSyncEnabled ?? false
 }

--- a/apps/caramel-app/src/lib/profile/savingsSyncPreference.ts
+++ b/apps/caramel-app/src/lib/profile/savingsSyncPreference.ts
@@ -1,0 +1,33 @@
+// src/lib/profile/savingsSyncPreference.ts
+//
+// The ONE place the account page learns whether a user has opted into cloud
+// savings sync. It is a module rather than an inline read so that wiring it to
+// its real storage is a one-line change in one file.
+//
+// TODO(feat/login-savings): this must read `users.savings_sync_enabled` — the
+// additive `User.savingsSyncEnabled Boolean @default(false)` column owned by
+// the savings-sync PR (feat/login-savings), which also ships
+// `PATCH /api/account/savings-sync`. That column does NOT exist on this branch
+// (feat/profile-revamp is cut from feat/login-foundation), so referencing it
+// here would not compile. When the two PRs meet, replace the body below with:
+//
+//     const row = await prisma.user.findUnique({
+//         where: { id: userId },
+//         select: { savingsSyncEnabled: true },
+//     })
+//     return row?.savingsSyncEnabled ?? false
+//
+// and delete this comment. Read it from Prisma, NOT from the better-auth
+// session: `auth.api.getSession()` only returns fields better-auth knows
+// about, so a custom column arrives there as `undefined` — falsy, and every
+// user would silently render as sync-off.
+//
+// Returning false today is not a placeholder or a guess, it is the true
+// value: on this branch nothing can set the preference (no column, no PATCH
+// route), so every account genuinely has sync off and the savings section
+// correctly renders its opt-in pitch. The account page therefore behaves
+// correctly standalone and lights up the moment the column lands.
+export async function readSavingsSyncEnabled(userId: string): Promise<boolean> {
+    void userId
+    return false
+}

--- a/apps/caramel-app/src/lib/profile/types.ts
+++ b/apps/caramel-app/src/lib/profile/types.ts
@@ -1,0 +1,74 @@
+// src/lib/profile/types.ts
+//
+// The ONE shape GET /api/account/overview returns and the whole account page
+// consumes. It lives here (not inside the route) because four separate
+// sections read it and the route, the hook, the sections and the route test
+// must all agree character-for-character — a second hand-typed copy is how a
+// field silently becomes optional on one side.
+//
+// Deliberately one request for four sections: four fetches would produce four
+// spinners and four independent failure modes on a page whose whole job is to
+// answer "what has Caramel done for me".
+
+/** One currency's total. NEVER added to another currency's. */
+export interface SavingsTotal {
+    currency: string
+    minorUnits: number
+}
+
+export interface SavingsEventSummary {
+    storeDomain: string
+    /** null for an automatic discount that carried no code. */
+    code: string | null
+    amountMinorUnits: number
+    currency: string
+    /** ISO. */
+    occurredAt: string
+}
+
+export interface FavoriteStoreSummary {
+    domain: string
+    /** ISO. */
+    starredAt: string
+    /** null when no live catalog count is available — the UI then renders NO
+     * count line at all rather than a placeholder or a zero. */
+    couponCount: number | null
+}
+
+export interface ProfileOverview {
+    /** ISO — drives "Saving with Caramel since March 2026". */
+    memberSince: string | null
+    /** True when this account has ever produced extension-side activity (a
+     * synced saving or a report). Drives whether the page tells someone to
+     * "star a store in the extension" — advice that is a dead end for a user
+     * who has not installed it. */
+    hasExtensionActivity: boolean
+    savings: {
+        syncEnabled: boolean
+        eventCount: number
+        storeCount: number
+        /** Grouped by currency, sorted desc by minorUnits. NEVER summed
+         * across currencies — a single number that adds dollars to euros is
+         * a fabricated figure. */
+        totals: SavingsTotal[]
+        /** ISO — the oldest event, drives "since March 2026". */
+        firstEventAt: string | null
+        /** Server caps this list; the page slices it further for display. */
+        recentEvents: SavingsEventSummary[]
+    }
+    favorites: FavoriteStoreSummary[]
+    reports: {
+        reportCount: number
+        /** null when not derivable from real records — the UI then falls to a
+         * lower copy tier rather than inventing the number. */
+        confirmedCount: number | null
+        /** null unless it is a genuine downstream count of OTHER users helped.
+         * Never derived from reportCount by a multiplier or an assumption. */
+        shoppersHelped: number | null
+    }
+}
+
+/** Server cap on `savings.recentEvents`. The page shows 5 and expands to the
+ * rest client-side, so the cap bounds the payload without adding pagination
+ * chrome to a list that is almost never long. */
+export const RECENT_EVENTS_LIMIT = 25

--- a/apps/caramel-app/src/lib/profile/useProfileOverview.ts
+++ b/apps/caramel-app/src/lib/profile/useProfileOverview.ts
@@ -1,0 +1,89 @@
+'use client'
+
+import { promptSupportOnFailure } from '@/lib/feedback/promptSupportOnFailure'
+import type { ProfileOverview } from '@/lib/profile/types'
+import { useCallback, useEffect, useState } from 'react'
+
+// The single data hook for the account page. One request, one shape, one
+// failure mode — see the route's header for why four sections share one fetch.
+//
+// No SWR/react-query here: this page fetches exactly one endpoint, once, for a
+// signed-in user, and adding a cache layer for that would be more machinery
+// than the problem has.
+
+export type OverviewStatus = 'loading' | 'ready' | 'error'
+
+export interface UseProfileOverviewResult {
+    overview: ProfileOverview | null
+    status: OverviewStatus
+    /** Re-run the fetch (the error notice's "Try again"). */
+    retry: () => void
+    /**
+     * Apply a local change to the loaded overview — used for optimistic
+     * favorite removal and for folding a confirmed sync-toggle response back
+     * in, so the page never needs a full refetch to stay honest. A no-op when
+     * nothing is loaded yet.
+     */
+    patchOverview: (
+        update: (current: ProfileOverview) => ProfileOverview,
+    ) => void
+}
+
+/**
+ * @param enabled false while the session is still resolving — the page must
+ * not fire an authenticated request before it knows there is a session, or
+ * every signed-out visit would produce a spurious 401.
+ */
+export function useProfileOverview(enabled: boolean): UseProfileOverviewResult {
+    const [overview, setOverview] = useState<ProfileOverview | null>(null)
+    const [status, setStatus] = useState<OverviewStatus>('loading')
+    const [attempt, setAttempt] = useState(0)
+
+    useEffect(() => {
+        if (!enabled) return
+        let cancelled = false
+
+        setStatus('loading')
+        void (async () => {
+            try {
+                const res = await fetch('/api/account/overview', {
+                    credentials: 'include',
+                })
+                if (!res.ok) {
+                    throw new Error(
+                        `Overview request failed with ${res.status}`,
+                    )
+                }
+                const data = (await res.json()) as ProfileOverview
+                if (cancelled) return
+                setOverview(data)
+                setStatus('ready')
+            } catch (error) {
+                if (cancelled) return
+                setStatus('error')
+                // A user-visible failure: the savings and stores sections
+                // visibly do not load. Reported once per session per
+                // operation by promptSupportOnFailure's own rate limit.
+                promptSupportOnFailure({
+                    error,
+                    operation: 'profile_overview_load',
+                })
+            }
+        })()
+
+        return () => {
+            cancelled = true
+        }
+    }, [enabled, attempt])
+
+    const retry = useCallback(() => setAttempt(n => n + 1), [])
+
+    const patchOverview = useCallback(
+        (update: (current: ProfileOverview) => ProfileOverview) => {
+            setOverview(current => (current ? update(current) : current))
+        },
+        [],
+    )
+
+    return { overview, status, retry, patchOverview }
+}

--- a/apps/caramel-app/tests/unit/account-data-delete.test.ts
+++ b/apps/caramel-app/tests/unit/account-data-delete.test.ts
@@ -1,0 +1,170 @@
+// Static import — vitest hoists the vi.mock calls below above it. A top-level
+// `await import` would trip TS1378 under this tsconfig.
+import { POST } from '@/app/api/account/data/delete/route'
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// POST /api/account/data/delete — the danger zone.
+//
+// Three properties this file exists to keep true:
+//   1. The literal confirmation string is required SERVER-side. The typed
+//      dialog is a second lock, not the only one.
+//   2. It deletes only the caller's rows, and only the three login-features
+//      tables — never the account, never the sync preference.
+//   3. It is TRANSACTIONAL: a partial failure leaves nothing deleted, which is
+//      what makes the failure toast ("Nothing was removed") a true statement.
+
+const { prismaMock, transactionMock } = vi.hoisted(() => {
+    const transactionMock = vi.fn()
+    return {
+        transactionMock,
+        prismaMock: {
+            $transaction: transactionMock,
+            savingsEvent: { deleteMany: vi.fn(() => ({ op: 'savings' })) },
+            favoriteStore: { deleteMany: vi.fn(() => ({ op: 'favorites' })) },
+            couponReport: { deleteMany: vi.fn(() => ({ op: 'reports' })) },
+            user: { update: vi.fn() },
+        },
+    }
+})
+vi.mock('@/lib/prisma', () => ({ default: prismaMock }))
+
+const { getSessionMock } = vi.hoisted(() => ({
+    getSessionMock: vi.fn(
+        async (_opts: { headers: Headers }) => null as unknown,
+    ),
+}))
+vi.mock('@/lib/auth/auth', () => ({
+    auth: { api: { getSession: getSessionMock } },
+}))
+
+vi.mock('@/lib/rateLimit', async importOriginal => {
+    const actual = await importOriginal<typeof import('@/lib/rateLimit')>()
+    return { ...actual, checkRateLimit: vi.fn(async () => null) }
+})
+
+const USER_ID = 'user-under-test'
+
+function deleteRequest(body: unknown) {
+    return new NextRequest('http://localhost/api/account/data/delete', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+    })
+}
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    getSessionMock.mockResolvedValue({ user: { id: USER_ID } })
+    transactionMock.mockResolvedValue([
+        { count: 14 },
+        { count: 6 },
+        { count: 7 },
+    ])
+})
+
+describe('POST /api/account/data/delete — the confirmation gate', () => {
+    it('deletes and reports real counts when the confirmation string is present', async () => {
+        const res = await POST(deleteRequest({ confirm: 'DELETE' }))
+
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({
+            deleted: { savingsEvents: 14, favoriteStores: 6, couponReports: 7 },
+        })
+        expect(transactionMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('a request with NO body is a 422 and destroys nothing', async () => {
+        // The endpoint must never be reachable as a bare
+        // unauthenticated-intent request.
+        const res = await POST(
+            new NextRequest('http://localhost/api/account/data/delete', {
+                method: 'POST',
+            }),
+        )
+
+        expect(res.status).toBe(422)
+        expect(transactionMock).not.toHaveBeenCalled()
+        expect(prismaMock.savingsEvent.deleteMany).not.toHaveBeenCalled()
+    })
+
+    it('the WRONG confirmation string is a 422 and destroys nothing', async () => {
+        for (const confirm of ['delete', 'Delete', 'DELETE ', 'yes', '']) {
+            vi.clearAllMocks()
+            const res = await POST(deleteRequest({ confirm }))
+            expect(res.status, `confirm=${JSON.stringify(confirm)}`).toBe(422)
+            expect(transactionMock).not.toHaveBeenCalled()
+        }
+    })
+
+    it('a missing confirm field is a 422', async () => {
+        const res = await POST(deleteRequest({ somethingElse: true }))
+        expect(res.status).toBe(422)
+        expect(transactionMock).not.toHaveBeenCalled()
+    })
+
+    it('an anonymous caller gets 401 even WITH the confirmation string', async () => {
+        getSessionMock.mockResolvedValue(null)
+        const res = await POST(deleteRequest({ confirm: 'DELETE' }))
+
+        expect(res.status).toBe(401)
+        expect(transactionMock).not.toHaveBeenCalled()
+    })
+})
+
+describe('POST /api/account/data/delete — scope', () => {
+    it('scopes all three deletes to the caller and to nothing else', async () => {
+        await POST(deleteRequest({ confirm: 'DELETE' }))
+
+        expect(prismaMock.savingsEvent.deleteMany).toHaveBeenCalledWith({
+            where: { userId: USER_ID },
+        })
+        expect(prismaMock.favoriteStore.deleteMany).toHaveBeenCalledWith({
+            where: { userId: USER_ID },
+        })
+        expect(prismaMock.couponReport.deleteMany).toHaveBeenCalledWith({
+            where: { userId: USER_ID },
+        })
+    })
+
+    it('does NOT delete the account and does NOT touch the sync preference', async () => {
+        await POST(deleteRequest({ confirm: 'DELETE' }))
+
+        // Toggling sync off and deleting history are deliberately separate
+        // acts — a delete that also changed a setting the user never touched
+        // would make the danger zone do something it did not say it would.
+        expect(prismaMock.user.update).not.toHaveBeenCalled()
+        expect(prismaMock).not.toHaveProperty('user.delete')
+    })
+})
+
+describe('POST /api/account/data/delete — transactional', () => {
+    it('runs all three deletes inside ONE $transaction, never as loose awaits', async () => {
+        await POST(deleteRequest({ confirm: 'DELETE' }))
+
+        const batch = transactionMock.mock.calls[0]![0]
+        expect(Array.isArray(batch)).toBe(true)
+        expect(batch).toHaveLength(3)
+        // The delete builders were invoked to BUILD the batch, and their
+        // results were handed to $transaction rather than awaited separately.
+        expect(batch).toEqual([
+            { op: 'savings' },
+            { op: 'favorites' },
+            { op: 'reports' },
+        ])
+    })
+
+    it('a partial failure deletes NOTHING and surfaces as a 500', async () => {
+        // Prisma rolls the interactive batch back; withRoute's catch turns the
+        // throw into a 500 + Sentry. The user is never told their data is gone
+        // while some of it remains.
+        transactionMock.mockRejectedValue(
+            new Error('deadlock detected on favorite_stores'),
+        )
+
+        const res = await POST(deleteRequest({ confirm: 'DELETE' }))
+        expect(res.status).toBe(500)
+        // No second, non-transactional cleanup path exists to "finish the job".
+        expect(transactionMock).toHaveBeenCalledTimes(1)
+    })
+})

--- a/apps/caramel-app/tests/unit/account-export.test.ts
+++ b/apps/caramel-app/tests/unit/account-export.test.ts
@@ -290,6 +290,24 @@ describe('GET /api/account/export', () => {
         }
     })
 
+    it('the preferences block reflects the users table, not the session', async () => {
+        // Same custom-column trap as the overview: a session cannot be trusted
+        // to carry savingsSyncEnabled, so the export reads it from the row.
+        getSessionMock.mockResolvedValue({
+            user: { id: USER_ID, savingsSyncEnabled: false },
+            session: { id: 'sess' },
+        })
+        prismaMock.user.findUnique.mockResolvedValue({
+            ...ACCOUNT_ROW,
+            savingsSyncEnabled: true,
+        })
+
+        const body = (await (
+            await GET(exportRequest())
+        ).json()) as AccountExport
+        expect(body.preferences).toEqual({ savingsSyncEnabled: true })
+    })
+
     it('an anonymous caller gets 401 and nothing is read', async () => {
         getSessionMock.mockResolvedValue(null)
         const res = await GET(exportRequest())

--- a/apps/caramel-app/tests/unit/account-export.test.ts
+++ b/apps/caramel-app/tests/unit/account-export.test.ts
@@ -1,0 +1,320 @@
+// Static import — vitest hoists the vi.mock calls below above it. A top-level
+// `await import` would trip TS1378 under this tsconfig.
+import { GET } from '@/app/api/account/export/route'
+import {
+    buildAccountExport,
+    collectForbiddenKeys,
+    exportFilename,
+    type AccountExport,
+} from '@/lib/profile/accountExport'
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// GET /api/account/export — "Download your data".
+//
+// The never-include list is the point of this file. This is a PUBLIC repo and
+// the endpoint hands a user a file built from their own User row, which carries
+// `password`, `token` and `tokenExpiry` — a bare `findUnique` would have put
+// all three in the download. The guard is asserted three ways: the walker
+// itself, the built payload, and the route's actual response body.
+
+const { prismaMock } = vi.hoisted(() => ({
+    prismaMock: {
+        user: { findUnique: vi.fn() },
+        favoriteStore: { findMany: vi.fn() },
+        savingsEvent: { findMany: vi.fn() },
+        couponReport: { findMany: vi.fn() },
+    },
+}))
+vi.mock('@/lib/prisma', () => ({ default: prismaMock }))
+
+const { getSessionMock } = vi.hoisted(() => ({
+    getSessionMock: vi.fn(
+        async (_opts: { headers: Headers }) => null as unknown,
+    ),
+}))
+vi.mock('@/lib/auth/auth', () => ({
+    auth: { api: { getSession: getSessionMock } },
+}))
+
+vi.mock('@/lib/rateLimit', async importOriginal => {
+    const actual = await importOriginal<typeof import('@/lib/rateLimit')>()
+    return { ...actual, checkRateLimit: vi.fn(async () => null) }
+})
+
+const USER_ID = 'user-under-test'
+const CREATED_AT = new Date('2026-03-14T10:00:00.000Z')
+
+function exportRequest() {
+    return new NextRequest('http://localhost/api/account/export', {
+        method: 'GET',
+    })
+}
+
+const ACCOUNT_ROW = {
+    id: USER_ID,
+    email: 'shopper@example.com',
+    name: 'Sam Shopper',
+    firstName: 'Sam',
+    lastName: 'Shopper',
+    username: 'sam',
+    createdAt: CREATED_AT,
+    emailVerified: true,
+}
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    getSessionMock.mockResolvedValue({ user: { id: USER_ID } })
+    prismaMock.user.findUnique.mockResolvedValue(ACCOUNT_ROW)
+    prismaMock.favoriteStore.findMany.mockResolvedValue([
+        {
+            storeName: 'nike.com',
+            createdAt: new Date('2026-05-01T00:00:00.000Z'),
+        },
+    ])
+    prismaMock.savingsEvent.findMany.mockResolvedValue([
+        {
+            store: 'nike.com',
+            code: 'SAVE10',
+            amountCents: 700,
+            currency: 'USD',
+            occurredAt: new Date('2026-06-01T12:00:00.000Z'),
+        },
+        {
+            store: 'gap.com',
+            code: '',
+            amountCents: 800,
+            currency: 'USD',
+            occurredAt: new Date('2026-05-20T12:00:00.000Z'),
+        },
+    ])
+    prismaMock.couponReport.findMany.mockResolvedValue([
+        {
+            outcome: 'failed',
+            createdAt: new Date('2026-05-10T12:00:00.000Z'),
+            coupon: { site: 'gap.com', code: 'NOPE20' },
+        },
+    ])
+})
+
+describe('collectForbiddenKeys — the never-include walker', () => {
+    it('a clean payload has no violations', () => {
+        expect(collectForbiddenKeys({ account: { email: 'a@b.c' } })).toEqual(
+            [],
+        )
+    })
+
+    it('catches credential material at any depth, case-insensitively', () => {
+        expect(
+            collectForbiddenKeys({ account: { PasswordHash: 'x' } }),
+        ).toContain('account.PasswordHash')
+        expect(collectForbiddenKeys({ a: { b: { token: 't' } } })).toContain(
+            'a.b.token',
+        )
+        expect(
+            collectForbiddenKeys({ oauth: { refresh_token: 'r' } }),
+        ).toContain('oauth.refresh_token')
+    })
+
+    it('catches internal row ids while allowing the account id the export exists to carry', () => {
+        expect(collectForbiddenKeys({ account: { id: 'u1' } })).toEqual([])
+        expect(
+            collectForbiddenKeys({ savingsEvents: [{ id: 'evt_1' }] }),
+        ).toContain('savingsEvents[].id')
+        expect(
+            collectForbiddenKeys({ couponReports: [{ couponId: 'c1' }] }),
+        ).toContain('couponReports[].couponId')
+    })
+
+    it('collapses array indices so a 400-row export reports a violation ONCE', () => {
+        const hits = collectForbiddenKeys({
+            savingsEvents: Array.from({ length: 400 }, () => ({
+                couponId: 'c1',
+            })),
+        })
+        expect(hits).toEqual(['savingsEvents[].couponId'])
+    })
+
+    it("catches another user's identifier leaking in as userId", () => {
+        expect(
+            collectForbiddenKeys({ favoriteStores: [{ userId: 'someone' }] }),
+        ).toContain('favoriteStores[].userId')
+    })
+})
+
+describe('buildAccountExport — the shape', () => {
+    it('produces the documented contract and drops every internal key on the way through', () => {
+        const payload = buildAccountExport(
+            {
+                account: ACCOUNT_ROW,
+                savingsSyncEnabled: false,
+                favoriteStores: [
+                    {
+                        storeName: 'nike.com',
+                        createdAt: new Date('2026-05-01T00:00:00.000Z'),
+                    },
+                ],
+                savingsEvents: [
+                    {
+                        store: 'nike.com',
+                        code: 'SAVE10',
+                        amountCents: 700,
+                        currency: 'USD',
+                        occurredAt: new Date('2026-06-01T12:00:00.000Z'),
+                    },
+                ],
+                couponReports: [
+                    {
+                        outcome: 'failed',
+                        createdAt: new Date('2026-05-10T12:00:00.000Z'),
+                        coupon: { site: 'gap.com', code: 'NOPE20' },
+                    },
+                ],
+            },
+            new Date('2026-08-09T14:03:00.000Z'),
+        )
+
+        expect(payload).toEqual({
+            exportedAt: '2026-08-09T14:03:00.000Z',
+            account: {
+                id: USER_ID,
+                email: 'shopper@example.com',
+                name: 'Sam Shopper',
+                firstName: 'Sam',
+                lastName: 'Shopper',
+                username: 'sam',
+                createdAt: CREATED_AT.toISOString(),
+                emailVerified: true,
+            },
+            preferences: { savingsSyncEnabled: false },
+            favoriteStores: [
+                { domain: 'nike.com', starredAt: '2026-05-01T00:00:00.000Z' },
+            ],
+            savingsEvents: [
+                {
+                    storeDomain: 'nike.com',
+                    code: 'SAVE10',
+                    amountMinorUnits: 700,
+                    currency: 'USD',
+                    occurredAt: '2026-06-01T12:00:00.000Z',
+                },
+            ],
+            couponReports: [
+                {
+                    // Named by what the user SAW, never by the catalog row id.
+                    storeDomain: 'gap.com',
+                    code: 'NOPE20',
+                    outcome: 'failed',
+                    reportedAt: '2026-05-10T12:00:00.000Z',
+                },
+            ],
+        })
+    })
+
+    it('a report whose coupon row is gone still exports, with nulls rather than a crash', () => {
+        const payload = buildAccountExport({
+            account: ACCOUNT_ROW,
+            savingsSyncEnabled: false,
+            favoriteStores: [],
+            savingsEvents: [],
+            couponReports: [
+                {
+                    outcome: 'worked',
+                    createdAt: new Date('2026-05-10T12:00:00.000Z'),
+                    coupon: null,
+                },
+            ],
+        })
+        expect(payload.couponReports[0]).toMatchObject({
+            storeDomain: null,
+            code: null,
+        })
+    })
+
+    it('names the file by date', () => {
+        expect(exportFilename(new Date('2026-08-09T23:59:00.000Z'))).toBe(
+            'caramel-data-2026-08-09.json',
+        )
+    })
+})
+
+describe('GET /api/account/export', () => {
+    it('returns the payload as a downloadable attachment that no cache may store', async () => {
+        const res = await GET(exportRequest())
+
+        expect(res.status).toBe(200)
+        expect(res.headers.get('Content-Disposition')).toMatch(
+            /^attachment; filename="caramel-data-\d{4}-\d{2}-\d{2}\.json"$/,
+        )
+        expect(res.headers.get('Cache-Control')).toBe('no-store')
+        expect(res.headers.get('Content-Type')).toContain('application/json')
+    })
+
+    it('the ACTUAL response body carries nothing from the never-include list', async () => {
+        const res = await GET(exportRequest())
+        // Assert 200 FIRST. Without this the test passes vacuously when the
+        // route 500s (an error body has no forbidden keys either) — which is
+        // exactly what happens when assertExportIsSafe catches a leak, so the
+        // one test that must go red on a leak would have stayed green.
+        expect(res.status).toBe(200)
+        const body = (await res.json()) as AccountExport
+        expect(collectForbiddenKeys(body)).toEqual([])
+
+        // Belt and braces against the walker itself being wrong: the three
+        // User columns that must never travel, checked by name in the raw text.
+        const raw = JSON.stringify(body)
+        expect(raw).not.toContain('password')
+        expect(raw).not.toContain('tokenExpiry')
+        expect(raw).not.toContain('"token"')
+    })
+
+    it('selects User columns EXPLICITLY — a bare findUnique would export password + token', async () => {
+        await GET(exportRequest())
+        const args = prismaMock.user.findUnique.mock.calls[0]![0]
+        expect(args.select).toBeDefined()
+        expect(args.select).not.toHaveProperty('password')
+        expect(args.select).not.toHaveProperty('token')
+        expect(args.select).not.toHaveProperty('tokenExpiry')
+    })
+
+    it('scopes every collection query to the calling user', async () => {
+        await GET(exportRequest())
+        for (const model of [
+            prismaMock.favoriteStore.findMany,
+            prismaMock.savingsEvent.findMany,
+            prismaMock.couponReport.findMany,
+        ]) {
+            expect(model).toHaveBeenCalledWith(
+                expect.objectContaining({ where: { userId: USER_ID } }),
+            )
+        }
+    })
+
+    it('an anonymous caller gets 401 and nothing is read', async () => {
+        getSessionMock.mockResolvedValue(null)
+        const res = await GET(exportRequest())
+
+        expect(res.status).toBe(401)
+        expect(prismaMock.savingsEvent.findMany).not.toHaveBeenCalled()
+    })
+
+    it('a live session whose user row is gone is a 404, not a file with a null account', async () => {
+        prismaMock.user.findUnique.mockResolvedValue(null)
+        const res = await GET(exportRequest())
+        expect(res.status).toBe(404)
+    })
+
+    it('an empty account exports empty collections, not a malformed file', async () => {
+        prismaMock.favoriteStore.findMany.mockResolvedValue([])
+        prismaMock.savingsEvent.findMany.mockResolvedValue([])
+        prismaMock.couponReport.findMany.mockResolvedValue([])
+
+        const body = (await (
+            await GET(exportRequest())
+        ).json()) as AccountExport
+        expect(body.favoriteStores).toEqual([])
+        expect(body.savingsEvents).toEqual([])
+        expect(body.couponReports).toEqual([])
+        expect(body.account.id).toBe(USER_ID)
+    })
+})

--- a/apps/caramel-app/tests/unit/account-overview.test.ts
+++ b/apps/caramel-app/tests/unit/account-overview.test.ts
@@ -63,7 +63,12 @@ function overviewRequest() {
 
 /** The empty-everything DB: what a brand-new account really looks like. */
 function stubEmptyDatabase() {
-    prismaMock.user.findUnique.mockResolvedValue({ createdAt: MEMBER_SINCE })
+    // One mock serves both reads of the users row: the route's own
+    // createdAt lookup and readSavingsSyncEnabled's flag lookup.
+    prismaMock.user.findUnique.mockResolvedValue({
+        createdAt: MEMBER_SINCE,
+        savingsSyncEnabled: false,
+    })
     prismaMock.savingsEvent.groupBy.mockResolvedValue([])
     prismaMock.savingsEvent.aggregate.mockResolvedValue({
         _min: { occurredAt: null },
@@ -314,13 +319,40 @@ describe('GET /api/account/overview — populated aggregates', () => {
         expect(body.reports.reportCount).toBe(1)
     })
 
-    it('syncEnabled is false while the preference column is unavailable — a true value, not a guess', async () => {
+    it('syncEnabled reflects the users table', async () => {
+        prismaMock.user.findUnique.mockResolvedValue({
+            createdAt: MEMBER_SINCE,
+            savingsSyncEnabled: true,
+        })
         const body = (await (
             await GET(overviewRequest())
         ).json()) as ProfileOverview
-        // On this branch nothing can set the preference (no column, no PATCH
-        // route), so every account genuinely has sync off. See
-        // savingsSyncPreference.ts's TODO for the one-line wiring.
-        expect(body.savings.syncEnabled).toBe(false)
+        expect(body.savings.syncEnabled).toBe(true)
+    })
+
+    it('reads the sync flag from the users table, NEVER off the session object', async () => {
+        // better-auth projects only the fields it knows onto session.user, so
+        // a custom column arrives there as undefined — falsy, and therefore
+        // indistinguishable from a real "off". A session that CLAIMS the flag
+        // must not be believed. Mirrors the protection the savings-sync PR
+        // pinned on GET /api/extension/me.
+        getSessionMock.mockResolvedValue({
+            user: { id: USER_ID, savingsSyncEnabled: false },
+            session: { id: 'sess' },
+        })
+        prismaMock.user.findUnique.mockResolvedValue({
+            createdAt: MEMBER_SINCE,
+            savingsSyncEnabled: true,
+        })
+
+        const body = (await (
+            await GET(overviewRequest())
+        ).json()) as ProfileOverview
+        expect(body.savings.syncEnabled).toBe(true)
+        expect(prismaMock.user.findUnique).toHaveBeenCalledWith(
+            expect.objectContaining({
+                select: expect.objectContaining({ savingsSyncEnabled: true }),
+            }),
+        )
     })
 })

--- a/apps/caramel-app/tests/unit/account-overview.test.ts
+++ b/apps/caramel-app/tests/unit/account-overview.test.ts
@@ -1,0 +1,326 @@
+// Static import of the route under test — vitest hoists every vi.mock below
+// above this, so the route sees the mocks (same shape coupons-report.test.ts
+// uses). A top-level `await import` would trip TS1378 under this tsconfig.
+import { GET } from '@/app/api/account/overview/route'
+import type { ProfileOverview } from '@/lib/profile/types'
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// GET /api/account/overview — the ONE payload the account page reads.
+//
+// The DEFAULT user has zero of everything, so the zero-data contract is
+// asserted FIRST and in full: a page built against a populated fixture ships a
+// zero state that reads as a broken page.
+//
+// Mocking follows coupons-report.test.ts: mock @/lib/prisma, keep
+// isOriginAllowed real (a no-Origin request passes), stub only the rate-limit
+// round trip, and drive the exported GET with a constructed NextRequest.
+
+const { prismaMock } = vi.hoisted(() => ({
+    prismaMock: {
+        user: { findUnique: vi.fn() },
+        savingsEvent: {
+            groupBy: vi.fn(),
+            aggregate: vi.fn(),
+            findMany: vi.fn(),
+        },
+        favoriteStore: { findMany: vi.fn() },
+        couponReport: { findMany: vi.fn() },
+    },
+}))
+vi.mock('@/lib/prisma', () => ({ default: prismaMock }))
+
+const { countCouponsForStoresMock } = vi.hoisted(() => ({
+    countCouponsForStoresMock: vi.fn(async () => new Map<string, number>()),
+}))
+vi.mock('@/lib/couponsRepo', () => ({
+    countCouponsForStores: countCouponsForStoresMock,
+}))
+
+const { getSessionMock } = vi.hoisted(() => ({
+    getSessionMock: vi.fn(
+        async (_opts: { headers: Headers }) => null as unknown,
+    ),
+}))
+vi.mock('@/lib/auth/auth', () => ({
+    auth: { api: { getSession: getSessionMock } },
+}))
+
+vi.mock('@/lib/rateLimit', async importOriginal => {
+    const actual = await importOriginal<typeof import('@/lib/rateLimit')>()
+    return { ...actual, checkRateLimit: vi.fn(async () => null) }
+})
+
+const USER_ID = 'user-under-test'
+const OTHER_USER_ID = 'someone-else'
+const MEMBER_SINCE = new Date('2026-03-14T10:00:00.000Z')
+
+function overviewRequest() {
+    return new NextRequest('http://localhost/api/account/overview', {
+        method: 'GET',
+    })
+}
+
+/** The empty-everything DB: what a brand-new account really looks like. */
+function stubEmptyDatabase() {
+    prismaMock.user.findUnique.mockResolvedValue({ createdAt: MEMBER_SINCE })
+    prismaMock.savingsEvent.groupBy.mockResolvedValue([])
+    prismaMock.savingsEvent.aggregate.mockResolvedValue({
+        _min: { occurredAt: null },
+    })
+    prismaMock.savingsEvent.findMany.mockResolvedValue([])
+    prismaMock.favoriteStore.findMany.mockResolvedValue([])
+    prismaMock.couponReport.findMany.mockResolvedValue([])
+    countCouponsForStoresMock.mockResolvedValue(new Map())
+}
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    getSessionMock.mockResolvedValue({ user: { id: USER_ID } })
+    stubEmptyDatabase()
+})
+
+describe('GET /api/account/overview — the zero-data user (the DEFAULT)', () => {
+    it('returns the exact empty contract: no nulls-as-zeroes, no invented numbers', async () => {
+        const res = await GET(overviewRequest())
+        expect(res.status).toBe(200)
+
+        const body = (await res.json()) as ProfileOverview
+        expect(body).toEqual({
+            memberSince: MEMBER_SINCE.toISOString(),
+            hasExtensionActivity: false,
+            savings: {
+                syncEnabled: false,
+                eventCount: 0,
+                storeCount: 0,
+                totals: [],
+                firstEventAt: null,
+                recentEvents: [],
+            },
+            favorites: [],
+            reports: {
+                reportCount: 0,
+                // null, NOT 0 — with nothing to confirm there is no
+                // confirmation rate to state.
+                confirmedCount: null,
+                shoppersHelped: null,
+            },
+        })
+    })
+
+    it('totals is an EMPTY ARRAY, never a zero-valued entry — the page must never render a $0.00 hero', async () => {
+        const body = (await (
+            await GET(overviewRequest())
+        ).json()) as ProfileOverview
+        expect(body.savings.totals).toEqual([])
+    })
+
+    it('skips the catalog count query entirely when there are no favorites', async () => {
+        await GET(overviewRequest())
+        expect(countCouponsForStoresMock).toHaveBeenCalledWith([])
+    })
+})
+
+describe('GET /api/account/overview — authentication and scoping', () => {
+    it('an anonymous caller gets 401 and no query runs', async () => {
+        getSessionMock.mockResolvedValue(null)
+        const res = await GET(overviewRequest())
+
+        expect(res.status).toBe(401)
+        expect(prismaMock.savingsEvent.groupBy).not.toHaveBeenCalled()
+        expect(prismaMock.favoriteStore.findMany).not.toHaveBeenCalled()
+        expect(prismaMock.couponReport.findMany).not.toHaveBeenCalled()
+    })
+
+    it('EVERY row query is scoped to the calling user', async () => {
+        await GET(overviewRequest())
+
+        // If any of these loses its userId filter, the endpoint starts
+        // serving other people's savings — assert all of them, every time.
+        expect(prismaMock.savingsEvent.groupBy).toHaveBeenCalledWith(
+            expect.objectContaining({ where: { userId: USER_ID } }),
+        )
+        expect(prismaMock.savingsEvent.aggregate).toHaveBeenCalledWith(
+            expect.objectContaining({ where: { userId: USER_ID } }),
+        )
+        expect(prismaMock.savingsEvent.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({ where: { userId: USER_ID } }),
+        )
+        expect(prismaMock.favoriteStore.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({ where: { userId: USER_ID } }),
+        )
+        expect(prismaMock.couponReport.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({ where: { userId: USER_ID } }),
+        )
+        expect(prismaMock.user.findUnique).toHaveBeenCalledWith(
+            expect.objectContaining({ where: { id: USER_ID } }),
+        )
+        expect(
+            JSON.stringify(prismaMock.savingsEvent.groupBy.mock.calls),
+        ).not.toContain(OTHER_USER_ID)
+    })
+
+    it('caps the recent-events list server-side', async () => {
+        await GET(overviewRequest())
+        expect(prismaMock.savingsEvent.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({ take: 25 }),
+        )
+    })
+})
+
+describe('GET /api/account/overview — populated aggregates', () => {
+    beforeEach(() => {
+        // Three currencies across four stores. EUR is deliberately the biggest
+        // group so the sort is proven to be by amount, not by insertion or
+        // alphabet.
+        prismaMock.savingsEvent.groupBy.mockResolvedValue([
+            {
+                currency: 'USD',
+                store: 'nike.com',
+                _sum: { amountCents: 1200 },
+                _count: { _all: 2 },
+            },
+            {
+                currency: 'USD',
+                store: 'gap.com',
+                _sum: { amountCents: 800 },
+                _count: { _all: 1 },
+            },
+            {
+                currency: 'EUR',
+                store: 'zalando.de',
+                _sum: { amountCents: 5000 },
+                _count: { _all: 3 },
+            },
+            {
+                currency: 'GBP',
+                store: 'asos.com',
+                _sum: { amountCents: 450 },
+                _count: { _all: 1 },
+            },
+        ])
+        prismaMock.savingsEvent.aggregate.mockResolvedValue({
+            _min: { occurredAt: new Date('2026-04-02T09:00:00.000Z') },
+        })
+        prismaMock.savingsEvent.findMany.mockResolvedValue([
+            {
+                store: 'nike.com',
+                code: 'SAVE10',
+                amountCents: 700,
+                currency: 'USD',
+                occurredAt: new Date('2026-06-01T12:00:00.000Z'),
+            },
+            {
+                store: 'gap.com',
+                code: '',
+                amountCents: 800,
+                currency: 'USD',
+                occurredAt: new Date('2026-05-20T12:00:00.000Z'),
+            },
+        ])
+        prismaMock.favoriteStore.findMany.mockResolvedValue([
+            {
+                storeName: 'nike.com',
+                createdAt: new Date('2026-05-01T00:00:00.000Z'),
+            },
+            {
+                storeName: 'obscure.example',
+                createdAt: new Date('2026-04-01T00:00:00.000Z'),
+            },
+        ])
+        countCouponsForStoresMock.mockResolvedValue(new Map([['nike.com', 12]]))
+    })
+
+    it('groups totals BY CURRENCY and never sums across them', async () => {
+        const body = (await (
+            await GET(overviewRequest())
+        ).json()) as ProfileOverview
+
+        // Sorted desc by amount: EUR 5000, USD 2000 (1200+800), GBP 450.
+        expect(body.savings.totals).toEqual([
+            { currency: 'EUR', minorUnits: 5000 },
+            { currency: 'USD', minorUnits: 2000 },
+            { currency: 'GBP', minorUnits: 450 },
+        ])
+        // The grand total 7450 must appear NOWHERE — adding euros to dollars
+        // is a fabricated figure.
+        const summed = body.savings.totals.reduce(
+            (acc, total) => acc + total.minorUnits,
+            0,
+        )
+        expect(summed).toBe(7450)
+        expect(
+            body.savings.totals.some(total => total.minorUnits === 7450),
+        ).toBe(false)
+    })
+
+    it('counts events and DISTINCT stores across currency groups', async () => {
+        const body = (await (
+            await GET(overviewRequest())
+        ).json()) as ProfileOverview
+        expect(body.savings.eventCount).toBe(7)
+        expect(body.savings.storeCount).toBe(4)
+        expect(body.savings.firstEventAt).toBe('2026-04-02T09:00:00.000Z')
+    })
+
+    it('maps an empty code to null so the row renders "automatic discount"', async () => {
+        const body = (await (
+            await GET(overviewRequest())
+        ).json()) as ProfileOverview
+        expect(body.savings.recentEvents[0]?.code).toBe('SAVE10')
+        expect(body.savings.recentEvents[1]?.code).toBeNull()
+        expect(body.savings.recentEvents[1]?.storeDomain).toBe('gap.com')
+    })
+
+    it('a favorite with no catalog count gets null, NOT 0 — the UI omits the line rather than claiming zero codes', async () => {
+        const body = (await (
+            await GET(overviewRequest())
+        ).json()) as ProfileOverview
+        expect(body.favorites).toEqual([
+            {
+                domain: 'nike.com',
+                starredAt: '2026-05-01T00:00:00.000Z',
+                couponCount: 12,
+            },
+            {
+                domain: 'obscure.example',
+                starredAt: '2026-04-01T00:00:00.000Z',
+                couponCount: null,
+            },
+        ])
+    })
+
+    it('hasExtensionActivity is true once any savings event exists', async () => {
+        const body = (await (
+            await GET(overviewRequest())
+        ).json()) as ProfileOverview
+        expect(body.hasExtensionActivity).toBe(true)
+    })
+
+    it('hasExtensionActivity is true from REPORTS alone, with no savings at all', async () => {
+        stubEmptyDatabase()
+        prismaMock.couponReport.findMany.mockResolvedValue([
+            {
+                outcome: 'worked',
+                createdAt: new Date('2026-05-01T00:00:00.000Z'),
+                coupon: null,
+            },
+        ])
+
+        const body = (await (
+            await GET(overviewRequest())
+        ).json()) as ProfileOverview
+        expect(body.hasExtensionActivity).toBe(true)
+        expect(body.reports.reportCount).toBe(1)
+    })
+
+    it('syncEnabled is false while the preference column is unavailable — a true value, not a guess', async () => {
+        const body = (await (
+            await GET(overviewRequest())
+        ).json()) as ProfileOverview
+        // On this branch nothing can set the preference (no column, no PATCH
+        // route), so every account genuinely has sync off. See
+        // savingsSyncPreference.ts's TODO for the one-line wiring.
+        expect(body.savings.syncEnabled).toBe(false)
+    })
+})

--- a/apps/caramel-app/tests/unit/profile-report-impact.test.ts
+++ b/apps/caramel-app/tests/unit/profile-report-impact.test.ts
@@ -1,0 +1,275 @@
+import {
+    isConfirmedReport,
+    selectReportTier,
+    SHOPPERS_HELPED_MIN,
+    summarizeReports,
+    type ReportWithCouponState,
+} from '@/lib/profile/reportImpact'
+import { describe, expect, it } from 'vitest'
+
+// The account page's "your reports" section is the one most likely to ship a
+// FALSE CLAIM about a user's impact, so its arithmetic is pinned here rather
+// than only exercised through the route.
+//
+// Two things these tests exist to keep true:
+//   1. "confirmed" means our own LATER recheck agreed — not that the coupon
+//      happens to be valid now.
+//   2. The "helped N shoppers" line never renders from an invented number, and
+//      never below the N >= 10 floor.
+
+const REPORTED_AT = new Date('2026-03-01T00:00:00.000Z')
+const RECHECKED_AFTER = new Date('2026-03-05T00:00:00.000Z')
+const RECHECKED_BEFORE = new Date('2026-02-20T00:00:00.000Z')
+
+function report(
+    overrides: Partial<ReportWithCouponState> & {
+        coupon?: ReportWithCouponState['coupon']
+    } = {},
+): ReportWithCouponState {
+    return {
+        outcome: 'worked',
+        createdAt: REPORTED_AT,
+        coupon: {
+            status: 'valid',
+            expired: false,
+            updatedAt: RECHECKED_AFTER,
+        },
+        ...overrides,
+    }
+}
+
+describe('isConfirmedReport — a recheck that AGREED, not a restatement', () => {
+    it('"worked" + a later recheck that left the coupon valid and unexpired → confirmed', () => {
+        expect(isConfirmedReport(report())).toBe(true)
+    })
+
+    it('"failed" + a later recheck that expired the coupon → confirmed', () => {
+        expect(
+            isConfirmedReport(
+                report({
+                    outcome: 'failed',
+                    coupon: {
+                        status: 'valid',
+                        expired: true,
+                        updatedAt: RECHECKED_AFTER,
+                    },
+                }),
+            ),
+        ).toBe(true)
+    })
+
+    it('"failed" + a later recheck that de-validated the coupon → confirmed', () => {
+        expect(
+            isConfirmedReport(
+                report({
+                    outcome: 'failed',
+                    coupon: {
+                        status: 'invalid',
+                        expired: false,
+                        updatedAt: RECHECKED_AFTER,
+                    },
+                }),
+            ),
+        ).toBe(true)
+    })
+
+    it('"worked" but our later recheck DISAGREED (coupon now expired) → not confirmed', () => {
+        expect(
+            isConfirmedReport(
+                report({
+                    coupon: {
+                        status: 'valid',
+                        expired: true,
+                        updatedAt: RECHECKED_AFTER,
+                    },
+                }),
+            ),
+        ).toBe(false)
+    })
+
+    it('the catalog was last written BEFORE the report → not confirmed (no recheck happened)', () => {
+        // This is the load-bearing half: without the "after" requirement every
+        // report about an already-valid coupon would confirm itself, and the
+        // section would claim a verification that never ran.
+        expect(
+            isConfirmedReport(
+                report({
+                    coupon: {
+                        status: 'valid',
+                        expired: false,
+                        updatedAt: RECHECKED_BEFORE,
+                    },
+                }),
+            ),
+        ).toBe(false)
+    })
+
+    it('a recheck at exactly the report timestamp → not confirmed (strictly later, not >=)', () => {
+        expect(
+            isConfirmedReport(
+                report({
+                    coupon: {
+                        status: 'valid',
+                        expired: false,
+                        updatedAt: REPORTED_AT,
+                    },
+                }),
+            ),
+        ).toBe(false)
+    })
+
+    it('the coupon row is gone → not confirmed (we cannot agree with what we cannot see)', () => {
+        expect(isConfirmedReport(report({ coupon: null }))).toBe(false)
+    })
+
+    it('an outcome outside the route vocabulary confirms nothing', () => {
+        expect(isConfirmedReport(report({ outcome: 'maybe' }))).toBe(false)
+    })
+})
+
+describe('summarizeReports', () => {
+    it('a user with no reports gets nulls, NOT zeroes, for the derived counts', () => {
+        // With nothing to confirm there is no confirmation rate to state, and
+        // "0 matched what we found" reads as an accusation.
+        expect(summarizeReports([])).toEqual({
+            reportCount: 0,
+            confirmedCount: null,
+            shoppersHelped: null,
+        })
+    })
+
+    it('counts reports and the subset our recheck agreed with', () => {
+        const summary = summarizeReports([
+            report(),
+            report(),
+            report({
+                coupon: {
+                    status: 'valid',
+                    expired: false,
+                    updatedAt: RECHECKED_BEFORE,
+                },
+            }),
+        ])
+        expect(summary.reportCount).toBe(3)
+        expect(summary.confirmedCount).toBe(2)
+    })
+
+    it('zero confirmations out of REAL reports is a true, renderable 0', () => {
+        const summary = summarizeReports([
+            report({
+                coupon: {
+                    status: 'valid',
+                    expired: false,
+                    updatedAt: RECHECKED_BEFORE,
+                },
+            }),
+        ])
+        expect(summary.reportCount).toBe(1)
+        expect(summary.confirmedCount).toBe(0)
+    })
+
+    it('shoppersHelped is ALWAYS null — no per-user usage attribution exists', () => {
+        // Guard against a future "improvement" that derives this from
+        // reportCount, Coupon.timesUsed or CouponSignal.workCount. All three
+        // are anonymous aggregates; a number built from them would be a
+        // fabricated public claim about other people's behaviour.
+        expect(summarizeReports([report()]).shoppersHelped).toBeNull()
+        expect(
+            summarizeReports(Array.from({ length: 50 }, () => report()))
+                .shoppersHelped,
+        ).toBeNull()
+    })
+})
+
+describe('selectReportTier — highest tier the data genuinely supports', () => {
+    it('no reports → no section at all', () => {
+        expect(
+            selectReportTier({
+                reportCount: 0,
+                confirmedCount: null,
+                shoppersHelped: null,
+            }),
+        ).toBe('none')
+    })
+
+    it('reports only → tier A (thanks framing, no impact claim)', () => {
+        expect(
+            selectReportTier({
+                reportCount: 7,
+                confirmedCount: null,
+                shoppersHelped: null,
+            }),
+        ).toBe('A')
+    })
+
+    it('confirmedCount 0 falls back to tier A, not a "0 matched" claim', () => {
+        expect(
+            selectReportTier({
+                reportCount: 7,
+                confirmedCount: 0,
+                shoppersHelped: null,
+            }),
+        ).toBe('A')
+    })
+
+    it('a real confirmedCount → tier B', () => {
+        expect(
+            selectReportTier({
+                reportCount: 7,
+                confirmedCount: 5,
+                shoppersHelped: null,
+            }),
+        ).toBe('B')
+    })
+
+    it(`shoppersHelped below the floor of ${SHOPPERS_HELPED_MIN} is SUPPRESSED — falls to tier B`, () => {
+        // "You helped 2 shoppers" is technically true and rhetorically worse
+        // than silence: it makes a real contribution sound trivial.
+        expect(
+            selectReportTier({
+                reportCount: 7,
+                confirmedCount: 5,
+                shoppersHelped: 2,
+            }),
+        ).toBe('B')
+        expect(
+            selectReportTier({
+                reportCount: 7,
+                confirmedCount: 5,
+                shoppersHelped: SHOPPERS_HELPED_MIN - 1,
+            }),
+        ).toBe('B')
+    })
+
+    it('suppressed shoppersHelped with no confirmedCount falls all the way to tier A', () => {
+        expect(
+            selectReportTier({
+                reportCount: 7,
+                confirmedCount: null,
+                shoppersHelped: 3,
+            }),
+        ).toBe('A')
+    })
+
+    it(`shoppersHelped at exactly ${SHOPPERS_HELPED_MIN} → tier C`, () => {
+        expect(
+            selectReportTier({
+                reportCount: 7,
+                confirmedCount: 5,
+                shoppersHelped: SHOPPERS_HELPED_MIN,
+            }),
+        ).toBe('C')
+    })
+
+    it('the tier chain degrades on a MISSING field rather than rendering a hole', () => {
+        // A payload that loses confirmedCount must drop to A, never render
+        // tier-B copy with an empty number in it.
+        expect(
+            selectReportTier({
+                reportCount: 4,
+                confirmedCount: null,
+                shoppersHelped: null,
+            }),
+        ).toBe('A')
+    })
+})


### PR DESCRIPTION
Rebuilds `/profile` from a field dump into an account home, and adds the three account-data endpoints it needs. Follows the profile UX blueprint; sibling PRs (#170 favorites, savings-sync, reports) light up their sections on merge without further changes here.

## What changed

**The page** — `/profile` was an `<h1>Profile</h1>` over a list of account fields. It is now: account header (owns the page's single `<h1>`, the user's own name) → impact strip *or* get-started checklist → savings → favorites → reports → account details → data & privacy.

**The zero state is the design, not a fallback.** Most people arrive with no savings, no favorites and no reports, so that path was built first: a three-step checklist replaces the impact strip when every stat is zero. There is no `$0.00` hero and no grid of empty tiles anywhere.

**Loading no longer blanks the page.** The account header and Account details render immediately from the session; only the data-backed sections skeleton. On an overview failure those two stay real content and the rest collapses to one retryable notice.

## Endpoints

| Route | Shape |
|---|---|
| `GET /api/account/overview` | `ProfileOverview` (`src/lib/profile/types.ts`) — `memberSince`, `hasExtensionActivity`, `savings{syncEnabled,eventCount,storeCount,totals[],firstEventAt,recentEvents[]}`, `favorites[]`, `reports{reportCount,confirmedCount,shoppersHelped}` |
| `GET /api/account/export` | `application/json` + `Content-Disposition: attachment; filename="caramel-data-YYYY-MM-DD.json"`, `Cache-Control: no-store` |
| `POST /api/account/data/delete` | body `{ confirm: "DELETE" }` → `{ deleted: { savingsEvents, favoriteStores, couponReports } }` |

All three are `withRoute` with `auth: 'session'`; `origin: true`; `rateLimit: 'read'` on overview, `'mutation'` on export (it dumps every row a user owns) and delete. Overview reads the three foundation tables directly, so it does not depend on the sibling PRs' write routes.

## Honesty constraints, enforced rather than commented

- **Multi-currency totals are grouped, never summed.** A single figure adding dollars to euros is a fabricated number; the route returns `totals[]` sorted desc and the page renders the largest as hero plus one line per remaining currency. Pinned by a test that asserts the grand total appears nowhere.
- **"Helped N shoppers" cannot render.** `shoppersHelped` is hard-null: it would need a count of distinct *other* users whose purchase a given report influenced, and nothing records who used a coupon (`Coupon.timesUsed` / `CouponSignal.workCount` are anonymous aggregates with no link back to a report). Tier selection is a fall-through chain, and tier C is additionally floored at N ≥ 10. A test pins the null against a future "improvement" that derives it from `reportCount`.
- **"Confirmed" means our own *later* recheck agreed** — `coupon.updatedAt > report.createdAt` **and** the catalog state matches the report's direction. Without the "later" half every report about an already-valid coupon would confirm itself.
- **Export never-include list is a runtime check.** `assertExportIsSafe` walks the payload and throws (500 + Sentry) rather than stripping — password hashes, tokens, other users' identifiers, internal catalog row ids. The `User` select is explicit because a bare `findUnique` would have put `password`, `token` and `tokenExpiry` in the download.
- **Toggling sync off does not delete history**, and the UI says so with the real event count. Deletion is a separate, deliberate act in the danger zone.
- **Counts with no data render nothing**, never a placeholder: a favorite with no live catalog count gets `null` (not `0`) and the row omits the line entirely.

## Delete semantics

Removes the caller's rows in `savings_events`, `favorite_stores`, `coupon_reports` in one `$transaction`. It does **not** delete the account (loud `TODO` in `DataPrivacySection.tsx` — Better Auth teardown + extension session revocation + email confirmation is its own PR) and does **not** flip the sync preference. Confirmation is a `z.literal('DELETE')` on the body, so the typed dialog is a second lock and a no-body request is a 422 that destroys nothing.

## Visual-regression scope

`Header.tsx`, `site-card.tsx`, `coupon-card.tsx`, `providers.tsx`, `tailwind.config.ts` and `globals.css` are untouched, and `/profile` has no baseline — **zero diffs on the eight baselined pages**. `prisma/schema.prisma` and `prisma/migrations/` are also untouched.

## Cross-PR seam

`src/lib/profile/savingsSyncPreference.ts` is the one place the page learns the sync preference. `users.savings_sync_enabled` and `PATCH /api/account/savings-sync` belong to the savings PR and do not exist on this branch, so it returns `false` — which is the *true* value here (nothing can set it), not a placeholder. The file carries the exact one-line replacement, including the trap that the column must be read from Prisma and not from the session object, where a custom column arrives `undefined`.

`countCouponsForStores` was added to `couponsRepo.ts` rather than the route so the favorites count shares `visibleCouponsWhere()` and the `site = store OR site LIKE '%.' || store` predicate with `listStoreCoupons` — a favorite's count agreeing with the store page it links to.

## Tests

`pnpm --filter caramel-app test` → **68 files, 601 passed** (was 544; +57).

- `account-overview.test.ts` (12) — zero-data contract asserted first and in full, per-currency grouping/sort, distinct store + event counts, `null` vs `0` coupon counts, empty-code → `automatic discount`, per-query user scoping, 401.
- `account-export.test.ts` (15) — walker behaviour, built shape, response headers, explicit `User` select, never-include list on the real response body.
- `account-data-delete.test.ts` (11) — confirmation gate (no body / wrong case / missing field all 422 with nothing deleted), caller-only scope, no account or preference write, one `$transaction`, partial failure → 500 and nothing removed.
- `profile-report-impact.test.ts` (19) — confirmation semantics and the full tier chain incl. the N < 10 suppression.

**Red-proof:** added `couponId: 'cmp_internal_catalog_row_id'` to the export's `savingsEvents` mapping. Three tests went red — the shape test, the header test (via the runtime guard's 500), and the never-include test — then restored to green. That run also exposed a real weakness: the never-include test passed vacuously on a 500, so it now asserts `status === 200` first, which is what made it go red on the second pass.

Gates green locally: `type-check`, `lint`, `prettier-check`, `knip`, `test`, root `oxlint` and `prettier-check:root` all exit 0.
