### PR TITLE
feat(savings): opt-in cloud savings sync from the extension to the account

### DIFF
--- a/apps/caramel-app/prisma/migrations/20260809231500_savings_sync_preference/migration.sql
+++ b/apps/caramel-app/prisma/migrations/20260809231500_savings_sync_preference/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+-- Opt-in cloud savings sync. NOT NULL DEFAULT false so every existing row is
+-- backfilled to "has not consented" — the only safe reading of silence.
+ALTER TABLE "public"."users" ADD COLUMN     "savings_sync_enabled" BOOLEAN NOT NULL DEFAULT false;

--- a/apps/caramel-app/prisma/schema.prisma
+++ b/apps/caramel-app/prisma/schema.prisma
@@ -71,6 +71,19 @@ model User {
   deletedAt         DateTime?
   role              Role?           @default(USER)
   status            UserStatus      @default(NOT_VERIFIED)
+
+  // Opt-in cloud savings sync. DEFAULT FALSE, and the default is the whole
+  // point: this flag is consent to upload a shopping record (store, code,
+  // amount, time), so a `true` default would be consent nobody gave. The
+  // extension will not push a single event until this is on AND the device's
+  // own `syncSavings` setting is on.
+  //
+  // Lives on User rather than in extension storage because it is the ONE
+  // authority two surfaces have to agree on — the popup switch and the
+  // /profile switch — and a device-local flag cannot be read or changed by
+  // the website. chrome.storage.sync is the cache; this column is the truth.
+  savingsSyncEnabled Boolean        @default(false) @map("savings_sync_enabled")
+
   accounts          Account[]
   sessions          Session[]
   couponReports     CouponReport[]

--- a/apps/caramel-app/src/app/api/account/savings-sync/route.ts
+++ b/apps/caramel-app/src/app/api/account/savings-sync/route.ts
@@ -1,0 +1,53 @@
+import { withRoute } from '@/lib/api/withRoute'
+import prisma from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+// PATCH /api/account/savings-sync — the opt-in consent switch itself.
+//
+// ONE authority, two surfaces: the extension popup's "Sync my savings" row and
+// the website's /profile switch both write here, and both read the result back
+// rather than trusting their own optimistic value. A device-local flag could
+// not do this — the website cannot read extension storage, so a second copy of
+// the truth would let the two surfaces disagree about whether a shopper had
+// consented to uploading their shopping record.
+//
+// Turning this OFF stops new events being accepted-and-pushed; it deliberately
+// does NOT delete history. "Stop sending more" and "erase what you have" are
+// different requests, and conflating them would make the switch irreversible in
+// practice while the UI promises the opposite. Deletion is its own explicit act
+// on /profile's danger zone.
+const SavingsSyncBodySchema = z.object({
+    enabled: z.boolean(),
+})
+
+export const PATCH = withRoute(
+    {
+        method: 'PATCH',
+        routeName: 'account/savings-sync',
+        rateLimit: 'mutation',
+        origin: true,
+        auth: 'session',
+        body: SavingsSyncBodySchema,
+    },
+    async ({ body, session }) => {
+        if (!session?.user) {
+            // withRoute's auth gate already 401s a missing session; this guard
+            // covers the malformed-session edge (and narrows the type).
+            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+        }
+
+        const updated = await prisma.user.update({
+            where: { id: session.user.id },
+            data: { savingsSyncEnabled: body.enabled },
+            select: { savingsSyncEnabled: true },
+        })
+
+        // The PERSISTED value, not the requested one. A client that renders its
+        // own optimistic guess can show a switch that is on while the account
+        // says off — the exact drift a single authority exists to prevent.
+        return NextResponse.json({
+            savingsSyncEnabled: updated.savingsSyncEnabled,
+        })
+    },
+)

--- a/apps/caramel-app/src/app/api/account/savings/route.ts
+++ b/apps/caramel-app/src/app/api/account/savings/route.ts
@@ -1,0 +1,271 @@
+import { withRoute } from '@/lib/api/withRoute'
+import prisma from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+// POST /api/account/savings — the extension's opt-in cloud savings sync.
+//
+// The extension records every measured win to device storage first and pushes
+// here afterwards, in batches, only when BOTH the device's `syncSavings`
+// setting and the account's `savings_sync_enabled` column are on. `auth:
+// 'session'` rather than 'optional': a savings event with no owner is not a
+// degraded record, it is a meaningless one — there is nowhere to put it and
+// nobody to show it to. Rate-limited + origin-gated like every other mutation;
+// no CORS/OPTIONS export for the same reason coupons/[id]/report has none —
+// the MV3 service worker fetches with host_permissions and never preflights.
+//
+// ── BATCH SEMANTICS (decided, do not re-litigate) ────────────────────────────
+// TWO layers, because they answer two different questions.
+//
+// 1. The ENVELOPE is all-or-nothing (422, whole batch refused). A body that is
+//    not `{ events: [...] }`, an empty array, or one over SAVINGS_BATCH_MAX is
+//    a broken client, not a bad row — the extension builds these batches
+//    itself. Silently truncating an oversized batch would drop events the
+//    caller believed it had handed over, which is exactly the failure this
+//    endpoint exists to prevent.
+//
+// 2. Individual EVENTS are per-item. One malformed row must not cost the nine
+//    good rows beside it — the client's only recovery from a 422 would be to
+//    retry the same doomed batch forever, or drop all ten.
+//
+// Per-item does NOT mean per-item-silent. Every submitted clientEventId comes
+// back in exactly one of `stored` or `rejected`, and `rejected` carries the
+// reason. The client is never left to infer what happened to a row.
+//
+// The status code describes the REQUEST, not the rows: a well-formed batch is
+// 200 even when every row in it was rejected. The rows' fates are the body.
+//
+// ── IDEMPOTENCY ──────────────────────────────────────────────────────────────
+// `clientEventId` is a client-generated UUID stamped once, at the moment the
+// saving is recorded on the device, and reused unchanged for every retry. It
+// is UNIQUE in the table, so a replayed batch — a lost response, a popup
+// catch-up sweep racing the recording-moment push, two devices flushing the
+// same roamed queue — writes nothing the second time and still reports those
+// ids as stored.
+const SAVINGS_BATCH_MAX = 100
+
+// $100,000 in cents. Not a policy on how much a coupon may save — a tripwire
+// for a price parser that read "1.299,00" as 129900 or a currency as cents.
+// A saving above this is a bug report, not a saving, and banking it would
+// corrupt a lifetime total the user is asked to trust.
+const AMOUNT_CENTS_MAX = 10_000_000
+
+// occurredAt is client-reported wall-clock, so it is checked against a window
+// rather than trusted. Forward: a device clock may legitimately run a few
+// minutes fast, but an event "happening" tomorrow would sort above every real
+// one forever. Backward: `t: entry.t || Date.now()` upstream means a corrupted
+// timestamp degrades to 0 (epoch), and 1970 in a savings list is noise, not
+// history.
+const CLOCK_SKEW_MS = 5 * 60 * 1000
+const OCCURRED_AT_FLOOR_MS = Date.UTC(2020, 0, 1)
+
+const BatchEnvelopeSchema = z.object({
+    events: z.array(z.unknown()).min(1).max(SAVINGS_BATCH_MAX),
+})
+
+const SavingsEventSchema = z
+    .object({
+        clientEventId: z.string().trim().min(1).max(64),
+        // Denormalized: the store/code/amount are the human-readable record and
+        // must survive the catalog row being expired or re-ingested.
+        store: z.string().trim().min(1).max(255),
+        // Empty is legitimate — an automatic discount saves money with no code.
+        code: z.string().trim().max(128).optional().default(''),
+        // The catalog coupon this win came from, when the apply flow knew it.
+        couponId: z.string().trim().min(1).max(128).nullable().optional(),
+        amountCents: z.number().int().positive().max(AMOUNT_CENTS_MAX),
+        currency: z
+            .string()
+            .trim()
+            .regex(/^[A-Za-z]{3}$/),
+        occurredAt: z.string().trim().min(1),
+    })
+    .superRefine((value, ctx) => {
+        const ms = Date.parse(value.occurredAt)
+        if (!Number.isFinite(ms)) {
+            ctx.addIssue({
+                code: 'custom',
+                path: ['occurredAt'],
+                message: 'is not a parseable timestamp',
+            })
+            return
+        }
+        if (ms > Date.now() + CLOCK_SKEW_MS) {
+            ctx.addIssue({
+                code: 'custom',
+                path: ['occurredAt'],
+                message: 'is in the future',
+            })
+        }
+        if (ms < OCCURRED_AT_FLOOR_MS) {
+            ctx.addIssue({
+                code: 'custom',
+                path: ['occurredAt'],
+                message: 'is implausibly old',
+            })
+        }
+    })
+
+interface RejectedEvent {
+    /** Position in the submitted array — the only handle a caller has on a row
+     * whose clientEventId failed to parse. */
+    index: number
+    clientEventId: string | null
+    reason: string
+}
+
+interface PreparedEvent {
+    userId: string
+    couponId: string | null
+    store: string
+    code: string
+    amountCents: number
+    currency: string
+    occurredAt: Date
+    clientEventId: string
+}
+
+/** The clientEventId of a row that failed validation, when it is readable at
+ * all — so a client can mark THAT entry rejected instead of guessing by index. */
+function readClientEventId(raw: unknown): string | null {
+    if (typeof raw !== 'object' || raw === null) return null
+    const value = (raw as { clientEventId?: unknown }).clientEventId
+    return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+export const POST = withRoute(
+    {
+        method: 'POST',
+        routeName: 'account/savings',
+        rateLimit: 'mutation',
+        origin: true,
+        auth: 'session',
+        body: BatchEnvelopeSchema,
+    },
+    async ({ body, session }) => {
+        if (!session?.user) {
+            // withRoute's auth gate already 401s a missing session; this guard
+            // covers the malformed-session edge (and narrows the type).
+            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+        }
+        const userId = session.user.id
+
+        const candidates: PreparedEvent[] = []
+        const rejected: RejectedEvent[] = []
+        // A batch that repeats an id is not an error — the id still ends up
+        // stored, from its first occurrence — but it must not reach createMany
+        // twice. Deduping here rather than leaning on ON CONFLICT keeps the
+        // behavior ours and testable instead of a Postgres implementation
+        // detail.
+        const seenInBatch = new Set<string>()
+
+        body.events.forEach((raw, index) => {
+            const parsed = SavingsEventSchema.safeParse(raw)
+            if (!parsed.success) {
+                const issue = parsed.error.issues[0]
+                const field = issue?.path.join('.') || 'event'
+                rejected.push({
+                    index,
+                    clientEventId: readClientEventId(raw),
+                    reason: `${field}: ${issue?.message ?? 'is invalid'}`,
+                })
+                return
+            }
+            const event = parsed.data
+            if (seenInBatch.has(event.clientEventId)) return
+            seenInBatch.add(event.clientEventId)
+            candidates.push({
+                userId,
+                couponId: event.couponId ?? null,
+                store: event.store,
+                code: event.code,
+                amountCents: event.amountCents,
+                // Uppercased at the boundary so 'usd' and 'USD' never become two
+                // currency groups on the profile page's per-currency totals.
+                currency: event.currency.toUpperCase(),
+                occurredAt: new Date(event.occurredAt),
+                clientEventId: event.clientEventId,
+            })
+        })
+
+        const storedIds = candidates.map(candidate => candidate.clientEventId)
+        if (!storedIds.length) {
+            return NextResponse.json({
+                accepted: 0,
+                duplicates: 0,
+                stored: [],
+                rejected,
+            })
+        }
+
+        // savings_events.coupon_id is a real FK onto the catalog `coupons`
+        // table, and the extension reports whatever id the apply flow held —
+        // which can name a row that has since been expired out of the catalog,
+        // or one this deployment has not ingested yet. Inserting it would raise
+        // a foreign-key violation that fails the ENTIRE createMany, losing
+        // every good event in the batch over a broken link. So unknown ids are
+        // dropped to null: store/code/amount are denormalized precisely so the
+        // saving survives the catalog row not existing. Nothing user-visible is
+        // lost, so this is not a per-item rejection.
+        const referencedCouponIds = Array.from(
+            new Set(
+                candidates
+                    .map(candidate => candidate.couponId)
+                    .filter((id): id is string => Boolean(id)),
+            ),
+        )
+        if (referencedCouponIds.length) {
+            const known = new Set(
+                (
+                    await prisma.coupon.findMany({
+                        where: { id: { in: referencedCouponIds } },
+                        select: { id: true },
+                    })
+                ).map(row => row.id),
+            )
+            for (const candidate of candidates) {
+                if (candidate.couponId && !known.has(candidate.couponId)) {
+                    candidate.couponId = null
+                }
+            }
+        }
+
+        // Deliberately NOT scoped by userId: client_event_id is globally
+        // unique, so a row belonging to anyone at all blocks the insert. Asking
+        // the question the constraint actually asks is what keeps `accepted`
+        // and `duplicates` honest.
+        const alreadyStored = new Set(
+            (
+                await prisma.savingsEvent.findMany({
+                    where: { clientEventId: { in: storedIds } },
+                    select: { clientEventId: true },
+                })
+            ).map(row => row.clientEventId),
+        )
+        const toInsert = candidates.filter(
+            candidate => !alreadyStored.has(candidate.clientEventId),
+        )
+
+        // skipDuplicates still matters with the SELECT above: two concurrent
+        // flushes of the same queue both read "not stored" and both insert. The
+        // loser silently writes nothing instead of 500ing, and its ids are
+        // still reported stored — because they are.
+        const { count } = toInsert.length
+            ? await prisma.savingsEvent.createMany({
+                  data: toInsert,
+                  skipDuplicates: true,
+              })
+            : { count: 0 }
+
+        return NextResponse.json({
+            accepted: count,
+            duplicates: storedIds.length - count,
+            // Every id here is in the table now — freshly inserted, already
+            // there, or written by the request that beat us. The client marks
+            // exactly these synced and never has to infer the complement of
+            // `rejected`.
+            stored: storedIds,
+            rejected,
+        })
+    },
+)

--- a/apps/caramel-app/src/app/api/extension/me/route.ts
+++ b/apps/caramel-app/src/app/api/extension/me/route.ts
@@ -1,4 +1,5 @@
 import { preflight, withRoute } from '@/lib/api/withRoute'
+import prisma from '@/lib/prisma'
 import { NextResponse } from 'next/server'
 
 // Validated-identity probe for the extension popup: it calls this with the
@@ -29,9 +30,23 @@ export const GET = withRoute(
             return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
         }
         const { username, name, email, image } = session.user
+
+        // The savings-sync consent flag, read from the users table rather than
+        // off `session.user`. better-auth only projects the fields it knows
+        // about onto the session, so a custom column arrives as `undefined`
+        // there — falsy, and therefore silently indistinguishable from a real
+        // "off". The popup switch renders from this value, so a silent false
+        // would show every consenting shopper an off switch and quietly stop
+        // their sync. A dedicated read is the cheap price of not guessing.
+        const preference = await prisma.user.findUnique({
+            where: { id: session.user.id },
+            select: { savingsSyncEnabled: true },
+        })
+
         return NextResponse.json({
             username: username || name || email || null,
             image: image || null,
+            savingsSyncEnabled: preference?.savingsSyncEnabled ?? false,
         })
     },
 )

--- a/apps/caramel-app/tests/unit/account-savings-ingest.test.ts
+++ b/apps/caramel-app/tests/unit/account-savings-ingest.test.ts
@@ -1,0 +1,509 @@
+import { POST } from '@/app/api/account/savings/route'
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// POST /api/account/savings — the extension's opt-in savings push.
+//
+// The two properties that actually matter here are idempotency and honest
+// reporting, and they are both properties of REPEATED or PARTIALLY-BAD input,
+// which is exactly the input a hand-run happy path never produces. So the
+// prisma mock below is stateful: it enforces the real UNIQUE(client_event_id)
+// constraint in memory, which is what lets "send the same batch twice" be a
+// test rather than a hope.
+
+interface SavingsRow {
+    userId: string
+    couponId: string | null
+    store: string
+    code: string
+    amountCents: number
+    currency: string
+    occurredAt: Date
+    clientEventId: string
+}
+
+const { prismaMock, db, defaults } = vi.hoisted(() => {
+    const state = {
+        savings: [] as SavingsRow[],
+        /** Catalog coupon ids this deployment has ingested. */
+        coupons: new Set<string>(),
+    }
+
+    // Held separately so beforeEach can mockReset() and re-arm. A test that
+    // overrides one of these with mockResolvedValue would otherwise leak its
+    // override into every test after it — which it did, and the symptom was a
+    // LATER test failing on state the earlier one had changed.
+    const impl = {
+        findSavings: async (args: {
+            where: { clientEventId: { in: string[] } }
+        }) =>
+            state.savings
+                .filter(row =>
+                    args.where.clientEventId.in.includes(row.clientEventId),
+                )
+                .map(row => ({ clientEventId: row.clientEventId })),
+
+        // Models the real ON CONFLICT DO NOTHING: a row whose client_event_id
+        // already exists is skipped, not duplicated and not thrown. Without
+        // skipDuplicates it throws, exactly as Postgres would.
+        createSavings: async (args: {
+            data: SavingsRow[]
+            skipDuplicates?: boolean
+        }) => {
+            let count = 0
+            for (const row of args.data) {
+                const clash = state.savings.some(
+                    existing => existing.clientEventId === row.clientEventId,
+                )
+                if (clash) {
+                    if (args.skipDuplicates) continue
+                    throw new Error(
+                        'Unique constraint failed on the fields: (`client_event_id`)',
+                    )
+                }
+                state.savings.push(row)
+                count++
+            }
+            return { count }
+        },
+
+        findCoupons: async (args: { where: { id: { in: string[] } } }) =>
+            args.where.id.in
+                .filter(id => state.coupons.has(id))
+                .map(id => ({ id })),
+    }
+
+    return {
+        db: state,
+        defaults: impl,
+        prismaMock: {
+            savingsEvent: {
+                findMany: vi.fn(impl.findSavings),
+                createMany: vi.fn(impl.createSavings),
+            },
+            coupon: { findMany: vi.fn(impl.findCoupons) },
+        },
+    }
+})
+vi.mock('@/lib/prisma', () => ({ default: prismaMock }))
+
+const { envMock } = vi.hoisted(() => ({
+    envMock: {
+        CHROME_EXTENSION_ORIGIN: 'chrome-extension://known-id' as
+            | string
+            | undefined,
+        FIREFOX_EXTENSION_ORIGIN: undefined as string | undefined,
+        SAFARI_EXTENSION_ORIGIN: undefined as string | undefined,
+    },
+}))
+vi.mock('@/lib/env', () => ({ env: envMock }))
+
+const { getSessionMock } = vi.hoisted(() => ({
+    getSessionMock: vi.fn(async () => null as unknown),
+}))
+vi.mock('@/lib/auth/auth', () => ({
+    auth: { api: { getSession: getSessionMock } },
+}))
+
+vi.mock('@/lib/rateLimit', async importOriginal => {
+    const actual = await importOriginal<typeof import('@/lib/rateLimit')>()
+    return { ...actual, checkRateLimit: vi.fn(async () => null) }
+})
+
+interface IngestResponse {
+    accepted: number
+    duplicates: number
+    stored: string[]
+    rejected: { index: number; clientEventId: string | null; reason: string }[]
+}
+
+function request(body: unknown): NextRequest {
+    return new NextRequest('http://localhost/api/account/savings', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+    })
+}
+
+/** A valid event; override any field to make it invalid in exactly one way. */
+function event(overrides: Record<string, unknown> = {}) {
+    return {
+        clientEventId: 'evt-1',
+        store: 'shop.com',
+        code: 'SAVE10',
+        amountCents: 1250,
+        currency: 'USD',
+        occurredAt: '2026-08-09T12:00:00.000Z',
+        ...overrides,
+    }
+}
+
+async function post(body: unknown) {
+    const res = await POST(request(body))
+    return { res, json: (await res.json()) as IngestResponse }
+}
+
+function signedIn(id = 'user-1') {
+    getSessionMock.mockResolvedValue({ user: { id }, session: { id: 'sess' } })
+}
+
+beforeEach(() => {
+    db.savings.length = 0
+    db.coupons.clear()
+    prismaMock.savingsEvent.findMany.mockReset()
+    prismaMock.savingsEvent.findMany.mockImplementation(defaults.findSavings)
+    prismaMock.savingsEvent.createMany.mockReset()
+    prismaMock.savingsEvent.createMany.mockImplementation(
+        defaults.createSavings,
+    )
+    prismaMock.coupon.findMany.mockReset()
+    prismaMock.coupon.findMany.mockImplementation(defaults.findCoupons)
+    getSessionMock.mockReset()
+    getSessionMock.mockResolvedValue(null)
+})
+
+describe('a signed-out caller cannot push savings', () => {
+    it('401s with no session, and writes nothing', async () => {
+        const res = await POST(request({ events: [event()] }))
+        expect(res.status).toBe(401)
+        expect(prismaMock.savingsEvent.createMany).not.toHaveBeenCalled()
+        expect(db.savings).toHaveLength(0)
+    })
+})
+
+describe('a well-formed batch is stored once', () => {
+    it('stores every event and reports each id back', async () => {
+        signedIn()
+        const { res, json } = await post({
+            events: [
+                event({ clientEventId: 'a' }),
+                event({ clientEventId: 'b', store: 'other.com' }),
+            ],
+        })
+
+        expect(res.status).toBe(200)
+        expect(json.accepted).toBe(2)
+        expect(json.duplicates).toBe(0)
+        expect(json.stored).toEqual(['a', 'b'])
+        expect(json.rejected).toEqual([])
+        expect(db.savings.map(row => row.clientEventId)).toEqual(['a', 'b'])
+    })
+
+    it('stamps the row with the signed-in user, never a client-supplied one', async () => {
+        signedIn('user-42')
+        await post({
+            events: [event({ clientEventId: 'a', userId: 'somebody-else' })],
+        })
+        expect(db.savings[0]!.userId).toBe('user-42')
+    })
+
+    it('uppercases the currency so usd and USD are one total, not two', async () => {
+        signedIn()
+        await post({ events: [event({ currency: 'usd' })] })
+        expect(db.savings[0]!.currency).toBe('USD')
+    })
+
+    it('accepts an automatic discount, which has no code', async () => {
+        signedIn()
+        const { json } = await post({ events: [event({ code: '' })] })
+        expect(json.accepted).toBe(1)
+        expect(db.savings[0]!.code).toBe('')
+    })
+})
+
+describe('replaying a batch does not duplicate anything', () => {
+    it('stores nothing the second time and still reports the ids stored', async () => {
+        signedIn()
+        const batch = {
+            events: [
+                event({ clientEventId: 'a' }),
+                event({ clientEventId: 'b' }),
+            ],
+        }
+
+        const first = await post(batch)
+        expect(first.json.accepted).toBe(2)
+
+        // The retry a client makes when it never saw the first response.
+        const second = await post(batch)
+        expect(second.res.status).toBe(200)
+        expect(second.json.accepted).toBe(0)
+        expect(second.json.duplicates).toBe(2)
+        // Still reported as stored — they ARE stored, and a client that read
+        // this as "not stored" would retry them forever.
+        expect(second.json.stored).toEqual(['a', 'b'])
+
+        expect(db.savings).toHaveLength(2)
+    })
+
+    it('does not duplicate when a later batch re-sends one earlier id among new ones', async () => {
+        signedIn()
+        await post({ events: [event({ clientEventId: 'a' })] })
+
+        const { json } = await post({
+            events: [
+                event({ clientEventId: 'a' }),
+                event({ clientEventId: 'b' }),
+            ],
+        })
+
+        expect(json.accepted).toBe(1)
+        expect(json.duplicates).toBe(1)
+        expect(db.savings.map(row => row.clientEventId)).toEqual(['a', 'b'])
+    })
+
+    it('collapses an id repeated inside one batch instead of inserting it twice', async () => {
+        signedIn()
+        const { json } = await post({
+            events: [
+                event({ clientEventId: 'a' }),
+                event({ clientEventId: 'a' }),
+            ],
+        })
+
+        expect(db.savings).toHaveLength(1)
+        expect(json.stored).toEqual(['a'])
+        // The repeat is not an error: its id ends up stored either way, so the
+        // "every id lands in stored or rejected" contract still holds.
+        expect(json.rejected).toEqual([])
+    })
+
+    it('survives the pre-check missing a row that already exists', async () => {
+        signedIn()
+        await post({ events: [event({ clientEventId: 'a' })] })
+        expect(db.savings).toHaveLength(1)
+
+        // The state a concurrent flush produces: the row IS in the table, but
+        // the pre-flight SELECT does not see it — the other request had not
+        // committed when this one read. Simulated directly rather than with two
+        // real in-flight requests, because the interleaving that matters is the
+        // read/write ordering, not the parallelism, and this way it happens
+        // every run instead of sometimes.
+        prismaMock.savingsEvent.findMany.mockResolvedValue([])
+
+        const { res, json } = await post({
+            events: [event({ clientEventId: 'a' })],
+        })
+
+        // No 500 on the unique-constraint violation…
+        expect(res.status).toBe(200)
+        // …still exactly one row…
+        expect(db.savings).toHaveLength(1)
+        // …and the id is still reported stored, because it IS stored. A client
+        // told otherwise would retry it forever.
+        expect(json.stored).toEqual(['a'])
+        expect(json.accepted).toBe(0)
+    })
+
+    it('always hands createMany the conflict clause — the last line of defence', async () => {
+        signedIn()
+        await post({ events: [event({ clientEventId: 'a' })] })
+        expect(
+            prismaMock.savingsEvent.createMany.mock.calls[0]![0].skipDuplicates,
+        ).toBe(true)
+    })
+
+    it('never sends a duplicate to createMany at all', async () => {
+        signedIn()
+        await post({ events: [event({ clientEventId: 'a' })] })
+        await post({
+            events: [
+                event({ clientEventId: 'a' }),
+                event({ clientEventId: 'b' }),
+            ],
+        })
+
+        const secondInsert =
+            prismaMock.savingsEvent.createMany.mock.calls[1]![0]
+        expect(secondInsert.data.map(row => row.clientEventId)).toEqual(['b'])
+    })
+})
+
+describe('one bad row does not cost the good rows beside it', () => {
+    it('stores the valid events and reports the invalid one with a reason', async () => {
+        signedIn()
+        const { res, json } = await post({
+            events: [
+                event({ clientEventId: 'good-1' }),
+                event({ clientEventId: 'bad', amountCents: -500 }),
+                event({ clientEventId: 'good-2' }),
+            ],
+        })
+
+        expect(res.status).toBe(200)
+        expect(json.stored).toEqual(['good-1', 'good-2'])
+        expect(json.rejected).toHaveLength(1)
+        expect(json.rejected[0]!.index).toBe(1)
+        expect(json.rejected[0]!.clientEventId).toBe('bad')
+        expect(json.rejected[0]!.reason).toContain('amountCents')
+        expect(db.savings.map(row => row.clientEventId)).toEqual([
+            'good-1',
+            'good-2',
+        ])
+    })
+
+    it('accounts for EVERY submitted id — nothing is silently dropped', async () => {
+        signedIn()
+        const ids = ['a', 'b', 'c', 'd']
+        const { json } = await post({
+            events: [
+                event({ clientEventId: 'a' }),
+                event({ clientEventId: 'b', currency: 'DOLLARS' }),
+                event({ clientEventId: 'c', occurredAt: 'not-a-date' }),
+                event({ clientEventId: 'd' }),
+            ],
+        })
+
+        const accountedFor = [
+            ...json.stored,
+            ...json.rejected.map(row => row.clientEventId),
+        ]
+        expect(new Set(accountedFor)).toEqual(new Set(ids))
+    })
+
+    it('still answers 200 when every row was rejected — the REQUEST was fine', async () => {
+        signedIn()
+        const { res, json } = await post({
+            events: [event({ amountCents: 0 })],
+        })
+        expect(res.status).toBe(200)
+        expect(json.accepted).toBe(0)
+        expect(json.stored).toEqual([])
+        expect(json.rejected).toHaveLength(1)
+        expect(prismaMock.savingsEvent.createMany).not.toHaveBeenCalled()
+    })
+
+    it('names the row by index even when its id is unreadable', async () => {
+        signedIn()
+        const { json } = await post({ events: [{ nonsense: true }] })
+        expect(json.rejected[0]!.index).toBe(0)
+        expect(json.rejected[0]!.clientEventId).toBeNull()
+    })
+})
+
+describe('validation of a single event', () => {
+    const cases: [string, Record<string, unknown>][] = [
+        ['a missing idempotency key', { clientEventId: undefined }],
+        ['an empty idempotency key', { clientEventId: '   ' }],
+        ['a zero amount', { amountCents: 0 }],
+        ['a negative amount', { amountCents: -1 }],
+        ['a fractional amount', { amountCents: 12.5 }],
+        ['an amount above the sanity ceiling', { amountCents: 10_000_001 }],
+        ['a two-letter currency', { currency: 'US' }],
+        ['a four-letter currency', { currency: 'USDD' }],
+        ['a numeric currency', { currency: '840' }],
+        ['an empty store', { store: '' }],
+        ['an unparseable timestamp', { occurredAt: 'yesterday' }],
+    ]
+
+    for (const [label, override] of cases) {
+        it(`rejects ${label}`, async () => {
+            signedIn()
+            const { json } = await post({ events: [event(override)] })
+            expect(json.rejected).toHaveLength(1)
+            expect(db.savings).toHaveLength(0)
+        })
+    }
+
+    it('rejects an event dated beyond the clock-skew allowance', async () => {
+        signedIn()
+        const { json } = await post({
+            events: [
+                event({
+                    occurredAt: new Date(
+                        Date.now() + 60 * 60 * 1000,
+                    ).toISOString(),
+                }),
+            ],
+        })
+        expect(json.rejected[0]!.reason).toContain('future')
+    })
+
+    it('tolerates a device clock that runs a couple of minutes fast', async () => {
+        signedIn()
+        const { json } = await post({
+            events: [
+                event({
+                    occurredAt: new Date(
+                        Date.now() + 2 * 60 * 1000,
+                    ).toISOString(),
+                }),
+            ],
+        })
+        expect(json.rejected).toEqual([])
+        expect(json.accepted).toBe(1)
+    })
+
+    it('rejects an epoch timestamp — a corrupted clock, not history', async () => {
+        signedIn()
+        const { json } = await post({
+            events: [event({ occurredAt: new Date(0).toISOString() })],
+        })
+        expect(json.rejected[0]!.reason).toContain('implausibly old')
+    })
+})
+
+describe('the envelope is all-or-nothing', () => {
+    it('422s a batch over the cap rather than truncating it', async () => {
+        signedIn()
+        const events = Array.from({ length: 101 }, (_, i) =>
+            event({ clientEventId: `e-${i}` }),
+        )
+        const res = await POST(request({ events }))
+        expect(res.status).toBe(422)
+        // Truncating would drop rows the caller believed it handed over.
+        expect(prismaMock.savingsEvent.createMany).not.toHaveBeenCalled()
+    })
+
+    it('accepts a batch exactly at the cap', async () => {
+        signedIn()
+        const events = Array.from({ length: 100 }, (_, i) =>
+            event({ clientEventId: `e-${i}` }),
+        )
+        const { res, json } = await post({ events })
+        expect(res.status).toBe(200)
+        expect(json.accepted).toBe(100)
+    })
+
+    it('422s an empty batch', async () => {
+        signedIn()
+        const res = await POST(request({ events: [] }))
+        expect(res.status).toBe(422)
+    })
+
+    it('422s a body that is not an events array', async () => {
+        signedIn()
+        const res = await POST(request({ events: 'nope' }))
+        expect(res.status).toBe(422)
+    })
+})
+
+describe('an unknown coupon id cannot take the batch down with it', () => {
+    it('nulls the link and still stores the saving', async () => {
+        signedIn()
+        db.coupons.add('coupon-live')
+
+        const { json } = await post({
+            events: [
+                event({ clientEventId: 'a', couponId: 'coupon-live' }),
+                // Expired out of the catalog since the extension cached it. A
+                // real FK violation here would fail the WHOLE createMany.
+                event({ clientEventId: 'b', couponId: 'coupon-gone' }),
+            ],
+        })
+
+        expect(json.accepted).toBe(2)
+        expect(db.savings.find(r => r.clientEventId === 'a')!.couponId).toBe(
+            'coupon-live',
+        )
+        expect(
+            db.savings.find(r => r.clientEventId === 'b')!.couponId,
+        ).toBeNull()
+    })
+
+    it('does not query the catalog when no event names a coupon', async () => {
+        signedIn()
+        await post({ events: [event()] })
+        expect(prismaMock.coupon.findMany).not.toHaveBeenCalled()
+    })
+})

--- a/apps/caramel-app/tests/unit/account-savings-sync-toggle.test.ts
+++ b/apps/caramel-app/tests/unit/account-savings-sync-toggle.test.ts
@@ -1,0 +1,200 @@
+import { PATCH } from '@/app/api/account/savings-sync/route'
+import { GET as EXTENSION_ME } from '@/app/api/extension/me/route'
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The savings-sync consent flag, and the two routes that make it ONE authority:
+// PATCH /api/account/savings-sync writes it, GET /api/extension/me reports it to
+// the popup. Both are pinned here together because the bug they exist to prevent
+// is a disagreement BETWEEN them.
+
+const { prismaMock, db } = vi.hoisted(() => {
+    const state = { savingsSyncEnabled: new Map<string, boolean>() }
+    return {
+        db: state,
+        prismaMock: {
+            user: {
+                update: vi.fn(
+                    async (args: {
+                        where: { id: string }
+                        data: { savingsSyncEnabled: boolean }
+                    }) => {
+                        state.savingsSyncEnabled.set(
+                            args.where.id,
+                            args.data.savingsSyncEnabled,
+                        )
+                        return {
+                            savingsSyncEnabled: args.data.savingsSyncEnabled,
+                        }
+                    },
+                ),
+                findUnique: vi.fn(async (args: { where: { id: string } }) => ({
+                    savingsSyncEnabled:
+                        state.savingsSyncEnabled.get(args.where.id) ?? false,
+                })),
+            },
+        },
+    }
+})
+vi.mock('@/lib/prisma', () => ({ default: prismaMock }))
+
+const { envMock } = vi.hoisted(() => ({
+    envMock: {
+        CHROME_EXTENSION_ORIGIN: 'chrome-extension://known-id' as
+            | string
+            | undefined,
+        FIREFOX_EXTENSION_ORIGIN: undefined as string | undefined,
+        SAFARI_EXTENSION_ORIGIN: undefined as string | undefined,
+    },
+}))
+vi.mock('@/lib/env', () => ({ env: envMock }))
+
+const { getSessionMock } = vi.hoisted(() => ({
+    getSessionMock: vi.fn(async () => null as unknown),
+}))
+vi.mock('@/lib/auth/auth', () => ({
+    auth: { api: { getSession: getSessionMock } },
+}))
+
+vi.mock('@/lib/rateLimit', async importOriginal => {
+    const actual = await importOriginal<typeof import('@/lib/rateLimit')>()
+    return { ...actual, checkRateLimit: vi.fn(async () => null) }
+})
+
+function patchRequest(body: unknown): NextRequest {
+    return new NextRequest('http://localhost/api/account/savings-sync', {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+    })
+}
+
+function signedIn(id = 'user-1') {
+    getSessionMock.mockResolvedValue({
+        user: { id, username: 'ada', image: null },
+        session: { id: 'sess' },
+    })
+}
+
+beforeEach(() => {
+    db.savingsSyncEnabled.clear()
+    prismaMock.user.update.mockClear()
+    prismaMock.user.findUnique.mockClear()
+    getSessionMock.mockReset()
+    getSessionMock.mockResolvedValue(null)
+})
+
+describe('PATCH /api/account/savings-sync', () => {
+    it('401s a signed-out caller and changes nothing', async () => {
+        const res = await PATCH(patchRequest({ enabled: true }))
+        expect(res.status).toBe(401)
+        expect(prismaMock.user.update).not.toHaveBeenCalled()
+    })
+
+    it('turns sync on for the signed-in user', async () => {
+        signedIn('user-7')
+        const res = await PATCH(patchRequest({ enabled: true }))
+
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({ savingsSyncEnabled: true })
+        expect(db.savingsSyncEnabled.get('user-7')).toBe(true)
+    })
+
+    it('turns sync off again — the switch is reversible in one tap', async () => {
+        signedIn('user-7')
+        await PATCH(patchRequest({ enabled: true }))
+        const res = await PATCH(patchRequest({ enabled: false }))
+
+        expect(await res.json()).toEqual({ savingsSyncEnabled: false })
+        expect(db.savingsSyncEnabled.get('user-7')).toBe(false)
+    })
+
+    it('writes only the caller’s own row', async () => {
+        signedIn('user-7')
+        await PATCH(patchRequest({ enabled: true, userId: 'someone-else' }))
+        expect(prismaMock.user.update.mock.calls[0]![0].where).toEqual({
+            id: 'user-7',
+        })
+    })
+
+    it('422s a non-boolean rather than coercing it', async () => {
+        signedIn()
+        // 'false' the string is truthy; coercion here would silently opt a
+        // shopper IN to uploading their shopping record.
+        const res = await PATCH(patchRequest({ enabled: 'false' }))
+        expect(res.status).toBe(422)
+        expect(prismaMock.user.update).not.toHaveBeenCalled()
+    })
+
+    it('422s a missing enabled field', async () => {
+        signedIn()
+        const res = await PATCH(patchRequest({}))
+        expect(res.status).toBe(422)
+    })
+
+    it('answers with the PERSISTED value, not the requested one', async () => {
+        signedIn('user-7')
+        // A store that saved something other than what was asked (a trigger, a
+        // partial write) must be visible to the client, not papered over by
+        // echoing the request back.
+        prismaMock.user.update.mockResolvedValueOnce({
+            savingsSyncEnabled: false,
+        })
+        const res = await PATCH(patchRequest({ enabled: true }))
+        expect(await res.json()).toEqual({ savingsSyncEnabled: false })
+    })
+})
+
+function meRequest(): NextRequest {
+    return new NextRequest('http://localhost/api/extension/me', {
+        headers: { origin: 'chrome-extension://known-id' },
+    })
+}
+
+describe('GET /api/extension/me reports the same flag the popup switch renders', () => {
+    it('defaults to off for an account that never opted in', async () => {
+        signedIn('user-new')
+        const res = await EXTENSION_ME(meRequest())
+        expect(res.status).toBe(200)
+        expect(await res.json()).toMatchObject({ savingsSyncEnabled: false })
+    })
+
+    it('reports on once the account has opted in', async () => {
+        signedIn('user-7')
+        await PATCH(patchRequest({ enabled: true }))
+
+        const res = await EXTENSION_ME(meRequest())
+        expect(await res.json()).toMatchObject({ savingsSyncEnabled: true })
+    })
+
+    it('reads the flag from the users table, never off the session object', async () => {
+        // better-auth projects only the fields it knows onto session.user, so a
+        // custom column arrives there as undefined — falsy, and therefore
+        // indistinguishable from a real "off". A session that CLAIMS the flag
+        // must not be believed.
+        getSessionMock.mockResolvedValue({
+            user: {
+                id: 'user-7',
+                username: 'ada',
+                image: null,
+                savingsSyncEnabled: false,
+            },
+            session: { id: 'sess' },
+        })
+        db.savingsSyncEnabled.set('user-7', true)
+
+        const res = await EXTENSION_ME(meRequest())
+        expect(await res.json()).toMatchObject({ savingsSyncEnabled: true })
+        expect(prismaMock.user.findUnique).toHaveBeenCalledTimes(1)
+    })
+
+    it('still carries the identity fields the popup already depended on', async () => {
+        signedIn('user-7')
+        const res = await EXTENSION_ME(meRequest())
+        expect(await res.json()).toEqual({
+            username: 'ada',
+            image: null,
+            savingsSyncEnabled: false,
+        })
+    })
+})

--- a/apps/caramel-extension/.size-limit.js
+++ b/apps/caramel-extension/.size-limit.js
@@ -156,7 +156,26 @@ module.exports = [
         // nothing true about bundle weight. The standing recommendation above
         // (price MINIFIED bytes) is now five raises overdue and still the
         // owner's call.
-        limit: '258 KB',
+        //
+        // 2026-08-09 — 258 → 268 KB, all of it in caramel-base.js: opt-in cloud
+        // savings sync. A recorded saving now carries a client-generated
+        // idempotency key, the catalog coupon id its two call sites used to
+        // drop, and a sync-eligibility flag; the cap became eviction-aware; and
+        // the batched push itself lives here (one flush at a time, entries
+        // marked synced ONLY from what the server says it stored). ~5.5 kB is
+        // code. The rest records three decisions that would each be re-decided
+        // wrongly by a later edit: eligibility is frozen at RECORD time, so
+        // turning the switch on never retroactively uploads what was earned
+        // while it was off; a saving earned signed OUT is never attributed to
+        // the next account that signs in; and an entry that never reached the
+        // server is never evicted while a synced one — already safe on the
+        // account — could go instead. A trimming pass paid back 0.70 kB.
+        // Measured 266.77 kB — 268 for the same headroom reason as the 249 and
+        // 258 lines above. The standing recommendation (price MINIFIED bytes)
+        // is now six raises overdue; this change did not take it, because the
+        // file's own note puts that call with the owner and not with the change
+        // that re-baselines the numbers.
+        limit: '268 KB',
         brotli: false,
     },
     {
@@ -177,7 +196,19 @@ module.exports = [
         // 59.32 kB — 60 rather than 59.5 for the same reason the 249 line gives:
         // headroom keeps the next comment edit from failing a build for a reason
         // that says nothing true about bundle weight.
-        limit: '60 KB',
+        //
+        // 2026-08-09 — 60 → 64 KB. The "Sync my savings" row in the settings
+        // view (signed-in only, cloning the existing .settings-row markup so it
+        // costs no CSS), its toggle handler, the polite live region, the
+        // /profile#savings deep link, and the popup-open catch-up sweep that
+        // flushes savings queued while the device was offline. ~2.0 kB is code
+        // and markup; the rest states the ordering constraint, which is the
+        // whole defence against a later edit inverting it: the account column
+        // is the authority and the DEVICE flag is what gates every upload, so a
+        // popup that cached "on" before the server confirmed would sync a
+        // shopping record against an account that never agreed. A trimming pass
+        // paid back 0.25 kB. Measured 63.39 kB — 64 for the usual headroom.
+        limit: '64 KB',
         brotli: false,
     },
     {
@@ -204,7 +235,19 @@ module.exports = [
         // an empty list — "you follow nothing" and "we couldn't ask" are
         // different answers and the star must not paint the first when it means
         // the second. Measured 19.02 kB; 20 for the usual headroom.
-        limit: '20 KB',
+        //
+        // 2026-08-09 — 20 → 22 KB. The two actions savings sync rides on:
+        // syncSavings (the batched POST to /api/account/savings) and
+        // setSavingsSync (PATCH /api/account/savings-sync), both through
+        // fetchCaramelApi so the stored bearer is attached in the one place
+        // that ever attaches it. ~0.9 kB is code; the rest records why the
+        // ingest response is handed BACK to the caller instead of being
+        // swallowed the way reportOutcome's is — caramel-base.js marks an entry
+        // synced only from the ids the server says it stored, so a dropped
+        // response has to leave those entries queued for the next sweep rather
+        // than silently losing a shopper's savings. Measured 21.25 kB; 22 for
+        // the usual headroom.
+        limit: '22 KB',
         brotli: false,
     },
 ]

--- a/apps/caramel-extension/background.js
+++ b/apps/caramel-extension/background.js
@@ -379,6 +379,53 @@ currentBrowser.runtime.onMessage.addListener(
                 })
 
             return true
+        } else if (message.action === 'syncSavings') {
+            // Opt-in cloud savings sync. Routed through the worker like all
+            // other API traffic so the bearer token never has to reach a
+            // content script running on a store's page.
+            //
+            // The response is handed BACK to the caller rather than swallowed:
+            // caramel-base.js marks entries synced only from what the server
+            // says it stored, so a dropped response has to leave them queued.
+            fetchCaramelApi(caramelUrl('api/account/savings'), {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    events: Array.isArray(message.events) ? message.events : [],
+                }),
+            })
+                .then(async r => {
+                    if (!r.ok) return { error: `HTTP ${r.status}` }
+                    return r.json()
+                })
+                .then(resp => sendResponse(resp))
+                .catch(err => {
+                    logError('syncSavings', err)
+                    sendResponse({ error: String(err) })
+                })
+
+            return true
+        } else if (message.action === 'setSavingsSync') {
+            // Writes the ACCOUNT-side consent flag. The popup switch also
+            // writes the device setting, but this column is the authority the
+            // website reads, so a toggle that only touched local storage would
+            // leave /profile showing the opposite of the popup.
+            fetchCaramelApi(caramelUrl('api/account/savings-sync'), {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ enabled: !!message.enabled }),
+            })
+                .then(async r => {
+                    if (!r.ok) return { error: `HTTP ${r.status}` }
+                    return r.json()
+                })
+                .then(resp => sendResponse(resp))
+                .catch(err => {
+                    logError('setSavingsSync', err)
+                    sendResponse({ error: String(err) })
+                })
+
+            return true
         } else if (message.action === 'fetchSupportedStores') {
             const url = caramelUrl('api/extension/supported-stores')
             // The bulk payload gets the larger budget, and one retry: the

--- a/apps/caramel-extension/caramel-base.js
+++ b/apps/caramel-extension/caramel-base.js
@@ -301,8 +301,14 @@ function caramelClearSession(done) {
 
 /* --------------------------------------------------  user settings */
 // One storage.sync object so preferences roam with the browser profile.
-// Shape: { autoApply: boolean, disabledSites: string[] } — read through
-// this helper only, so defaults live in exactly one place.
+// Shape: { autoApply: boolean, disabledSites: string[], syncSavings: boolean }
+// — read through this helper only, so defaults live in exactly one place.
+//
+// `syncSavings` DEFAULTS FALSE, and unlike `autoApply` it is written as
+// `=== true` rather than `!== false`: an absent key must read as "has not
+// opted in". This flag is consent to upload a shopping record, so a default
+// that treated silence as yes would be consent nobody gave. The account-side
+// authority is users.savings_sync_enabled; this is the roaming cache of it.
 const CARAMEL_SETTINGS_KEY = 'caramel_settings'
 // Cross-file content-script/popup reads — per-file analysis can't see them.
 // oxlint-disable-next-line no-unused-vars
@@ -316,10 +322,15 @@ function caramelGetSettings() {
                     disabledSites: Array.isArray(s.disabledSites)
                         ? s.disabledSites
                         : [],
+                    syncSavings: s.syncSavings === true,
                 })
             })
         } catch {
-            resolve({ autoApply: true, disabledSites: [] })
+            resolve({
+                autoApply: true,
+                disabledSites: [],
+                syncSavings: false,
+            })
         }
     })
 }
@@ -413,8 +424,88 @@ function caramelGetSavings(options) {
         }
     })
 }
-// entry: { domain, code, amount, currency, t } — amount must be a real
-// measured saving (> 0); applied-but-unmeasured codes are not recorded.
+/* Stable id for one saving, minted once and never regenerated: it is the
+ * idempotency key POST /api/account/savings dedupes on, so a RETRY must carry
+ * the value the first attempt did. Stamped at record time; sync only reads it.
+ *
+ * crypto.randomUUID() is missing in an INSECURE context and a plain http://
+ * checkout is one, so it is feature-detected, falling back to getRandomValues
+ * (which IS available there) and then to Math.random — a weak id still works as
+ * an idempotency key, where a thrown TypeError would lose the saving.
+ */
+function _caramelNewEventId() {
+    try {
+        if (
+            globalThis.crypto &&
+            typeof globalThis.crypto.randomUUID === 'function'
+        ) {
+            return globalThis.crypto.randomUUID()
+        }
+        if (
+            globalThis.crypto &&
+            typeof globalThis.crypto.getRandomValues === 'function'
+        ) {
+            const bytes = globalThis.crypto.getRandomValues(new Uint8Array(16))
+            bytes[6] = (bytes[6] & 0x0f) | 0x40
+            bytes[8] = (bytes[8] & 0x3f) | 0x80
+            const hex = Array.from(bytes, b =>
+                b.toString(16).padStart(2, '0'),
+            ).join('')
+            return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+        }
+    } catch {
+        // fall through to the arithmetic id below
+    }
+    return `caramel-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 12)}`
+}
+
+/* Applies CARAMEL_SAVINGS_MAX, evicting SYNCED entries before unsynced ones.
+ *
+ * A blind newest-50 trim can evict an entry that never reached the server,
+ * deleting the only copy that ever existed. A synced entry is safe on the
+ * account and costs nothing to drop locally, so those go first, oldest first.
+ *
+ * When EVERY entry is unsynced (a long outage, or a shopper who never opted in)
+ * the oldest is dropped. That is a real loss, so it goes through logError
+ * rather than passing in silence: it is the one path in the savings history
+ * where data leaves and does not come back.
+ */
+function _caramelTrimSavings(list) {
+    if (list.length <= CARAMEL_SAVINGS_MAX) return list
+    const keep = list.slice()
+    for (
+        let i = keep.length - 1;
+        i >= 0 && keep.length > CARAMEL_SAVINGS_MAX;
+        i--
+    ) {
+        if (keep[i] && (keep[i].synced || keep[i].syncRejected))
+            keep.splice(i, 1)
+    }
+    if (keep.length > CARAMEL_SAVINGS_MAX) {
+        logError(
+            'savings cap evicted unsynced entries',
+            `dropped ${keep.length - CARAMEL_SAVINGS_MAX} saving(s) that never reached the server`,
+        )
+        return keep.slice(0, CARAMEL_SAVINGS_MAX)
+    }
+    return keep
+}
+
+function _caramelWriteSavings(list) {
+    return new Promise(resolve => {
+        try {
+            currentBrowser.storage.local.set(
+                { [CARAMEL_SAVINGS_KEY]: _caramelTrimSavings(list) },
+                resolve,
+            )
+        } catch {
+            resolve()
+        }
+    })
+}
+
+// entry: { domain, code, amount, currency, t, couponId } — amount must be a
+// real measured saving (> 0); applied-but-unmeasured codes are not recorded.
 // oxlint-disable-next-line no-unused-vars
 async function caramelRecordSaving(entry) {
     if (!entry || !(entry.amount > 0)) return
@@ -423,23 +514,150 @@ async function caramelRecordSaving(entry) {
     const list = await caramelGetSavings({ all: true })
     const session = await caramelGetSession().catch(() => null)
     const owner = session?.user?.username || null
+    const settings = await caramelGetSettings()
+
+    /* Eligibility is decided here, once, and frozen onto the entry rather than
+     * re-derived at sweep time from whatever the settings then say. Two
+     * promises depend on it: "sync starts from here" (turning the switch on
+     * must not retroactively upload savings earned while it was off), and a
+     * saving earned SIGNED OUT belongs to the device, not to the next account
+     * that signs in — no owner, no upload.
+     */
+    const syncPending = !!(settings.syncSavings && session?.token && owner)
+
     list.unshift({
         domain: String(entry.domain || ''),
         code: String(entry.code || ''),
         amount: Math.round(entry.amount * 100) / 100,
         currency: String(entry.currency || 'USD'),
         t: entry.t || Date.now(),
+        // Stamped on EVERY entry, syncable or not: it costs one call, and an
+        // entry that acquires an id only when it becomes eligible could not be
+        // retried idempotently the first time.
+        clientEventId: _caramelNewEventId(),
+        // The catalog coupon this win came from. The call sites hold it (they
+        // already pass it to the trust-loop report) and used to drop it, which
+        // left the account-side event unable to name the code's source.
+        ...(entry.couponId ? { couponId: String(entry.couponId) } : {}),
         // Absent for a signed-out saving — see _caramelSavingsVisibleTo.
         ...(owner ? { u: owner } : {}),
+        ...(syncPending ? { syncPending: true } : {}),
     })
-    return new Promise(resolve => {
-        try {
-            currentBrowser.storage.local.set(
-                { [CARAMEL_SAVINGS_KEY]: list.slice(0, CARAMEL_SAVINGS_MAX) },
-                resolve,
-            )
-        } catch {
-            resolve()
+    await _caramelWriteSavings(list)
+
+    // Deliberately not awaited: the saving is already banked locally and the
+    // money path must not wait on a round-trip to show the shopper their
+    // result. The result IS checked — caramelSyncSavings marks what the server
+    // confirmed and leaves the rest queued — just not here.
+    if (syncPending) caramelSyncSavings()
+}
+
+/* --------------------------------------------------  savings cloud sync */
+// Server-side batch cap is 100; 50 matches the local history cap, so a full
+// catch-up sweep is one request.
+const CARAMEL_SYNC_BATCH_MAX = 50
+
+/* One flush at a time. Two callers race by design — the recording moment fires
+ * one, opening the popup fires a catch-up sweep — and both read the history,
+ * push, then write the marks back, so two in flight can lose the other's mark
+ * (last write wins on the whole array). Duplicate EVENTS stay impossible either
+ * way (clientEventId is unique server-side), but a lost mark means re-pushing
+ * an entry forever. Collapsing onto one promise is cheaper than making the
+ * read-modify-write atomic.
+ */
+let _caramelSyncInFlight = null
+
+/* Pushes queued savings to the account. Never throws and never surfaces
+ * anything to the shopper — a failed background sync is not worth interrupting
+ * checkout for; failures stay queued for the next attempt and go to logError.
+ * Resolves to { pushed, rejected, skipped } so callers and tests can see what
+ * happened instead of inferring it from storage.
+ */
+// oxlint-disable-next-line no-unused-vars
+function caramelSyncSavings() {
+    if (_caramelSyncInFlight) return _caramelSyncInFlight
+    _caramelSyncInFlight = _caramelSyncSavingsOnce().finally(() => {
+        _caramelSyncInFlight = null
+    })
+    return _caramelSyncInFlight
+}
+
+async function _caramelSyncSavingsOnce() {
+    const settings = await caramelGetSettings()
+    if (!settings.syncSavings) return { pushed: 0, skipped: 'sync-off' }
+
+    const session = await caramelGetSession().catch(() => null)
+    const owner = session?.user?.username || null
+    if (!session?.token || !owner) return { pushed: 0, skipped: 'signed-out' }
+
+    const list = await caramelGetSavings({ all: true })
+    const queue = list.filter(
+        e =>
+            e &&
+            e.syncPending &&
+            !e.synced &&
+            !e.syncRejected &&
+            e.clientEventId &&
+            // Only this account's entries. A guest entry has no owner and must
+            // not be attributed to whoever happens to be signed in now.
+            e.u === owner,
+    )
+    if (!queue.length) return { pushed: 0, skipped: 'nothing-queued' }
+
+    const batch = queue.slice(0, CARAMEL_SYNC_BATCH_MAX)
+    let response
+    try {
+        response = await caramelSendMessage({
+            action: 'syncSavings',
+            events: batch.map(e => ({
+                clientEventId: e.clientEventId,
+                store: e.domain,
+                code: e.code || '',
+                couponId: e.couponId || null,
+                // Integer minor units on the wire — the stored `amount` is a
+                // 2-decimal float and floats are not what a total gets summed
+                // from.
+                amountCents: Math.round(e.amount * 100),
+                currency: e.currency || 'USD',
+                occurredAt: new Date(e.t).toISOString(),
+            })),
+        })
+    } catch (err) {
+        logError('syncSavings transport', err)
+        return { pushed: 0, error: String(err) }
+    }
+    if (!response || response.error) {
+        logError('syncSavings', response?.error || 'no response')
+        return { pushed: 0, error: response?.error || 'no response' }
+    }
+
+    const stored = new Set(
+        Array.isArray(response.stored) ? response.stored : [],
+    )
+    const rejected = new Map(
+        (Array.isArray(response.rejected) ? response.rejected : [])
+            .filter(r => r && r.clientEventId)
+            .map(r => [r.clientEventId, String(r.reason || 'rejected')]),
+    )
+
+    // Re-read rather than reusing `list`: the money path may have unshifted a
+    // new saving while this request was in flight, and writing the stale array
+    // back would erase it.
+    const fresh = await caramelGetSavings({ all: true })
+    for (const e of fresh) {
+        if (!e || !e.clientEventId) continue
+        if (stored.has(e.clientEventId)) {
+            e.synced = true
+        } else if (rejected.has(e.clientEventId)) {
+            // The server will refuse this payload every time — validation is
+            // deterministic — so retrying it forever would be a poison pill at
+            // the head of the queue. Mark it, keep it (the shopper's local
+            // history is unchanged), and record why.
+            e.syncRejected = rejected.get(e.clientEventId)
+            logError('syncSavings rejected an event', e.syncRejected)
         }
-    })
+    }
+    await _caramelWriteSavings(fresh)
+
+    return { pushed: stored.size, rejected: rejected.size }
 }

--- a/apps/caramel-extension/coupon-runner.js
+++ b/apps/caramel-extension/coupon-runner.js
@@ -495,6 +495,10 @@ async function startApplyingCoupons(rec, options) {
                     'caramel_applied',
                     JSON.stringify({
                         code: bestCode,
+                        // Carried across the reload so the fresh document can
+                        // record the saving against its catalog coupon — the
+                        // handoff is the only place that id still exists there.
+                        id: bestId,
                         saved,
                         currency: confirmed.currency || bestCurrency,
                         t: Date.now(),
@@ -1059,6 +1063,10 @@ async function startApplyingCoupons(rec, options) {
                 code: bestCode,
                 amount: bestSave,
                 currency: caramelCurrencyCode(),
+                // Same id the trust-loop report just used. The history used to
+                // drop it, which left a synced savings event unable to name the
+                // catalog row the code came from.
+                couponId: bestId,
             })
         }
         /* A code that didn't move a READABLE total is not a code we can call

--- a/apps/caramel-extension/popup.js
+++ b/apps/caramel-extension/popup.js
@@ -128,6 +128,11 @@ async function renderSettingsView(backFn, domain) {
     const container = document.getElementById('auth-container')
     if (!container) return
     const s = await caramelGetSettings()
+    // Savings sync needs an account to sync TO, so the row is signed-in only —
+    // the gate #accountLink already uses. A guest tapping a switch that can only
+    // bounce them into sign-in is a dead end.
+    const session = await caramelGetSession().catch(() => null)
+    const hasAccount = !!session?.token
     // Dot-less "domains" are extension pages (the popup opened as a tab /
     // login window reports its own chrome-extension host) — no site toggle.
     const site =
@@ -162,9 +167,22 @@ async function renderSettingsView(backFn, domain) {
               : ''
       }
 
+      ${
+          hasAccount
+              ? `<label class="settings-row">
+        <span class="settings-copy">
+          <span>Sync my savings</span>
+          <small>Keep your savings on your Caramel account, not just this device</small>
+        </span>
+        <input type="checkbox" id="syncSavingsToggle" class="settings-switch" role="switch" ${s.syncSavings ? 'checked' : ''}/>
+      </label>
+      <span id="syncSavingsStatus" role="status" aria-live="polite" style="position:absolute;width:1px;height:1px;overflow:hidden;clip-path:inset(50%);white-space:nowrap;"></span>`
+              : ''
+      }
+
       <div id="savingsSummary"></div>
 
-      <a id="accountLink" class="account-link" href="${caramelUrl('profile')}" target="_blank" rel="noopener noreferrer" style="display:none;">Manage account →</a>
+      <a id="accountLink" class="account-link" href="${caramelUrl('profile#savings')}" target="_blank" rel="noopener noreferrer" style="display:none;">Manage account →</a>
 
       <button id="backBtn" class="back-btn" type="button">← Back</button>
     </div>`
@@ -185,6 +203,53 @@ async function renderSettingsView(backFn, domain) {
             caramelSetSettings({
                 disabledSites: e.target.checked ? [...rest, site] : rest,
             })
+        })
+
+    /* Savings sync. The ACCOUNT column is the authority, so: server first,
+     * device cache second — writing the local flag up front and reconciling
+     * later would leave a device claiming consent the account never recorded,
+     * and that flag is what gates every upload. On failure the switch goes back
+     * where it was: this one governs whether a shopping record leaves the
+     * device, so it must never overstate what happened. */
+    const syncSavingsToggle = document.getElementById('syncSavingsToggle')
+    if (syncSavingsToggle)
+        syncSavingsToggle.addEventListener('change', async e => {
+            const requested = e.target.checked
+            const status = document.getElementById('syncSavingsStatus')
+            syncSavingsToggle.disabled = true
+            let resp = null
+            try {
+                resp = await caramelSendMessage({
+                    action: 'setSavingsSync',
+                    enabled: requested,
+                })
+            } catch (err) {
+                resp = { error: String(err) }
+            }
+            syncSavingsToggle.disabled = false
+
+            if (
+                !resp ||
+                resp.error ||
+                typeof resp.savingsSyncEnabled !== 'boolean'
+            ) {
+                e.target.checked = !requested
+                const message =
+                    'Couldn’t change that setting. Please try again.'
+                if (status) status.textContent = message
+                showCopyToast(message)
+                return
+            }
+
+            const enabled = resp.savingsSyncEnabled
+            e.target.checked = enabled
+            await caramelSetSettings({ syncSavings: enabled })
+            if (status)
+                status.textContent = enabled
+                    ? 'Savings sync is on'
+                    : 'Savings sync is off'
+            // Turning it on flushes anything already queued on this device.
+            if (enabled) caramelSyncSavings()
         })
 
     caramelGetSession().then(({ token }) => {
@@ -322,6 +387,25 @@ function validateStoredSession(token, storedUser) {
                 // Profile only — the token is untouched, so write it beside
                 // the session in local rather than back into sync.
                 currentBrowser.storage.local.set({ user: fresh }, () => {})
+            }
+
+            /* Savings-sync consent, straight from the account. storage.sync
+             * caches it, and is not a second source of truth: a shopper who
+             * turned sync on from the website would otherwise open the popup to
+             * a switch saying off, and — worse — this device would keep not
+             * uploading, since the local flag gates the push. Reached only on a
+             * 200, so offline leaves the cache alone rather than reading
+             * silence as "off". caramelSetSettings resolves on storage errors
+             * instead of rejecting, so there is no rejection path here. */
+            if (typeof data.savingsSyncEnabled === 'boolean') {
+                caramelSetSettings({
+                    syncSavings: data.savingsSyncEnabled,
+                }).then(() => {
+                    // Catch-up sweep. Savings recorded while this device was
+                    // offline, or whose push failed, are still queued locally
+                    // and nothing else would ever retry them.
+                    if (data.savingsSyncEnabled) caramelSyncSavings()
+                })
             }
         })
         .catch(() => {

--- a/apps/caramel-extension/store-detect.js
+++ b/apps/caramel-extension/store-detect.js
@@ -543,6 +543,7 @@ async function _resumePendingSubmit() {
             code: pending.code,
             amount: saved,
             currency: caramelCurrencyCode(),
+            couponId: pending.id,
         })
         showFinalModal(saved, pending.code)
         return true
@@ -639,6 +640,7 @@ async function startCheckoutDetection() {
                     code: st.code,
                     amount: st.saved || 0,
                     currency: st.currency || 'USD',
+                    couponId: st.id || null,
                 })
                 let amount = st.saved || 0
                 let msg = null

--- a/apps/caramel-extension/tests/popup-savings-sync-row.test.mjs
+++ b/apps/caramel-extension/tests/popup-savings-sync-row.test.mjs
@@ -1,0 +1,217 @@
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { loadExtensionSource, loadExtensionSources } from './_load.mjs'
+
+// The "Sync my savings" row in the popup settings view.
+//
+// The row is a consent control, so the tests below are mostly about what it
+// must NOT do: appear for someone with no account to sync to, arrive already
+// switched on, or claim a change the account never accepted.
+//
+// Harness mirrors popup-settings-view.test.mjs — real load order, one shared
+// chrome stub, only the worker transport and storage stubbed. The service
+// worker's own handler is covered separately in savings-sync.test.mjs; here it
+// is stubbed so a failing PATCH can be produced on demand.
+
+let renderSettingsView
+let syncData
+let localData
+let sentMessages
+/** What the stubbed worker answers `setSavingsSync` with. */
+let patchResponse
+
+beforeAll(() => {
+    document.body.innerHTML =
+        '<div id="loading-container"></div>' +
+        '<button id="settingsIcon" style="display:none"></button>' +
+        '<div id="auth-container"></div>' +
+        '<div id="toastContainer"></div>'
+
+    loadExtensionSource('coupon-constants.generated.js', [])
+    loadExtensionSources(
+        [
+            'caramel-base.js',
+            'dom-utils.js',
+            'store-detect.js',
+            'coupon-apply.js',
+            'coupon-fetch.js',
+            'coupon-runner.js',
+        ],
+        [],
+    )
+
+    globalThis.currentBrowser.runtime.sendMessage = (message, cb) => {
+        sentMessages.push(message)
+        if (message?.action === 'getActiveTabDomainRecord') {
+            cb({ url: 'https://www.example.com/cart' })
+        } else if (message?.action === 'setSavingsSync') {
+            cb(patchResponse)
+        } else if (message?.action === 'syncSavings') {
+            cb({ accepted: 0, duplicates: 0, stored: [], rejected: [] })
+        } else {
+            cb(undefined)
+        }
+    }
+    globalThis.currentBrowser.storage.sync.get = (_keys, cb) =>
+        cb({ ...syncData })
+    globalThis.currentBrowser.storage.sync.set = (items, cb) => {
+        Object.assign(syncData, items)
+        if (cb) cb()
+    }
+    globalThis.currentBrowser.storage.local.get = (_keys, cb) =>
+        cb({ ...localData })
+    globalThis.currentBrowser.storage.local.set = (items, cb) => {
+        Object.assign(localData, items)
+        if (cb) cb()
+    }
+    ;({ renderSettingsView } = loadExtensionSource('popup.js', [
+        'renderSettingsView',
+    ]))
+})
+
+beforeEach(() => {
+    syncData = {}
+    localData = {}
+    sentMessages = []
+    patchResponse = { savingsSyncEnabled: true }
+})
+
+function signIn() {
+    localData.token = 'tok-ada'
+    localData.user = { username: 'ada' }
+}
+
+function settingsHtml() {
+    return document.getElementById('auth-container').innerHTML
+}
+
+/** Lets the toggle's async handler settle. */
+const flush = () => new Promise(resolve => setTimeout(resolve, 0))
+
+describe('the sync row needs an account to sync to', () => {
+    it('is hidden from a guest', async () => {
+        await renderSettingsView(null, 'www.example.com')
+        expect(document.getElementById('syncSavingsToggle')).toBeNull()
+        expect(settingsHtml()).not.toContain('Sync my savings')
+        // The rest of the settings view still serves guests.
+        expect(settingsHtml()).toContain('Checkout prompt')
+    })
+
+    it('appears once the shopper is signed in', async () => {
+        signIn()
+        await renderSettingsView(null, 'www.example.com')
+        expect(settingsHtml()).toContain('Sync my savings')
+        expect(document.getElementById('syncSavingsToggle')).not.toBeNull()
+    })
+})
+
+describe('the row starts off, and reflects the stored preference', () => {
+    it('renders unchecked for an account that never opted in', async () => {
+        signIn()
+        await renderSettingsView(null, 'www.example.com')
+        expect(document.getElementById('syncSavingsToggle').checked).toBe(false)
+    })
+
+    it('renders checked once the preference says so', async () => {
+        signIn()
+        syncData.caramel_settings = { syncSavings: true }
+        await renderSettingsView(null, 'www.example.com')
+        expect(document.getElementById('syncSavingsToggle').checked).toBe(true)
+    })
+
+    it('is a switch, with a live region to announce the change', async () => {
+        signIn()
+        await renderSettingsView(null, 'www.example.com')
+        const toggle = document.getElementById('syncSavingsToggle')
+        // role="switch" makes a screen reader say on/off rather than
+        // checked/unchecked — the right vocabulary for a setting.
+        expect(toggle.getAttribute('role')).toBe('switch')
+        const status = document.getElementById('syncSavingsStatus')
+        expect(status.getAttribute('aria-live')).toBe('polite')
+    })
+
+    it('adds no new stylesheet classes — it reuses the existing settings row', async () => {
+        signIn()
+        await renderSettingsView(null, 'www.example.com')
+        expect(document.getElementById('syncSavingsToggle').className).toBe(
+            'settings-switch',
+        )
+    })
+})
+
+describe('turning the row on writes the account first, the device second', () => {
+    it('PATCHes the account through the worker and then caches the result', async () => {
+        signIn()
+        await renderSettingsView(null, 'www.example.com')
+
+        const toggle = document.getElementById('syncSavingsToggle')
+        toggle.checked = true
+        toggle.dispatchEvent(new Event('change'))
+        await flush()
+
+        expect(sentMessages).toContainEqual({
+            action: 'setSavingsSync',
+            enabled: true,
+        })
+        expect(syncData.caramel_settings.syncSavings).toBe(true)
+        expect(toggle.checked).toBe(true)
+        expect(
+            document.getElementById('syncSavingsStatus').textContent,
+        ).toContain('on')
+    })
+
+    it('turns back off in one tap, with no confirmation to get past', async () => {
+        signIn()
+        syncData.caramel_settings = { syncSavings: true }
+        patchResponse = { savingsSyncEnabled: false }
+        await renderSettingsView(null, 'www.example.com')
+
+        const toggle = document.getElementById('syncSavingsToggle')
+        toggle.checked = false
+        toggle.dispatchEvent(new Event('change'))
+        await flush()
+
+        expect(syncData.caramel_settings.syncSavings).toBe(false)
+        expect(toggle.checked).toBe(false)
+    })
+
+    it('puts the switch back and caches nothing when the account refuses', async () => {
+        signIn()
+        patchResponse = { error: 'HTTP 503' }
+        await renderSettingsView(null, 'www.example.com')
+
+        const toggle = document.getElementById('syncSavingsToggle')
+        toggle.checked = true
+        toggle.dispatchEvent(new Event('change'))
+        await flush()
+
+        // The local flag is what gates every upload, so a device that cached
+        // "on" here would start syncing against an account that never agreed.
+        expect(syncData.caramel_settings?.syncSavings).not.toBe(true)
+        expect(toggle.checked).toBe(false)
+    })
+
+    it('trusts the account’s answer over the tap when the two disagree', async () => {
+        signIn()
+        patchResponse = { savingsSyncEnabled: false }
+        await renderSettingsView(null, 'www.example.com')
+
+        const toggle = document.getElementById('syncSavingsToggle')
+        toggle.checked = true
+        toggle.dispatchEvent(new Event('change'))
+        await flush()
+
+        expect(toggle.checked).toBe(false)
+        expect(syncData.caramel_settings.syncSavings).toBe(false)
+    })
+})
+
+describe('the account link points at the savings section', () => {
+    it('deep-links to /profile#savings, not the top of the page', async () => {
+        signIn()
+        await renderSettingsView(null, 'www.example.com')
+        const link = document.getElementById('accountLink')
+        // Someone tapping this from the sync row is going to the savings
+        // settings; landing at the top of a long account page is a dead drop.
+        expect(link.getAttribute('href')).toContain('/profile#savings')
+    })
+})

--- a/apps/caramel-extension/tests/savings-sync.test.mjs
+++ b/apps/caramel-extension/tests/savings-sync.test.mjs
@@ -1,0 +1,626 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+    backStorageArea,
+    getOnMessageListeners,
+    loadExtensionSources,
+} from './_load.mjs'
+
+// Opt-in cloud savings sync, end to end inside the extension: caramel-base.js
+// records and queues, caramelSendMessage crosses into the REAL background.js
+// onMessage listener, and background.js makes the fetch. Nothing between the
+// money path and the network is stubbed out — only the network itself, by a
+// fake that enforces the same UNIQUE(client_event_id) the table does, so
+// "retrying doesn't duplicate" is something these tests can actually observe.
+//
+// The three behaviours worth stating plainly, because each is a promise made
+// to the shopper in the UI copy:
+//   * OFF by default, and off means NOTHING leaves the device.
+//   * Sync starts from when it was turned on — earlier savings stay local.
+//   * A saving earned signed OUT belongs to the device, not to whoever signs
+//     in next.
+
+let base
+let localData
+let fetchCalls
+/** Stands in for savings_events, unique on client_event_id like the real one. */
+let serverRows
+let accountSyncEnabled
+let serverDown
+
+/* Backs ONE storage area, with ONE data object, on BOTH chrome stubs this
+ * realm ends up holding.
+ *
+ * caramel-base.js pins `window.currentBrowser` on its first load and guards the
+ * assignment with `window.__caramel_shared_utils_loaded` — a window flag that
+ * survives every reload inside a jsdom file. So from the SECOND test onward
+ * caramel-base keeps the stub installed for the first test, while background.js
+ * (`const currentBrowser = chrome`) binds the freshly installed one. They are
+ * two different objects with two different storages.
+ *
+ * Backing only the one _load.mjs's helper targets left the other reading empty
+ * storage, and the symptom was pointed: settings and history worked, while the
+ * worker's getStoredToken() found no token and sent every request unauthorized —
+ * a signed-in fixture producing signed-out traffic, only when the file ran as a
+ * whole. Sharing one data object between both stubs is also what a real browser
+ * has: one storage, many references. */
+function backStorageEverywhere(area, data) {
+    const pinned = globalThis.currentBrowser
+    const fresh = globalThis.chrome
+    backStorageArea(area, data)
+    if (fresh && fresh !== pinned) {
+        globalThis.currentBrowser = fresh
+        backStorageArea(area, data)
+        globalThis.currentBrowser = pinned
+    }
+    return data
+}
+
+function loadRealm() {
+    base = loadExtensionSources(
+        ['caramel-base.js', 'background.js'],
+        [
+            'caramelGetSettings',
+            'caramelSetSettings',
+            'caramelGetSavings',
+            'caramelRecordSaving',
+            'caramelSyncSavings',
+        ],
+    )
+    // Real Chrome leaves this undefined on success; the permissive stub would
+    // auto-create a truthy callable that caramelSendMessage reads as a dead port.
+    globalThis.chrome.runtime.lastError = undefined
+    globalThis.currentBrowser.runtime.lastError = undefined
+
+    localData = backStorageEverywhere('local', {})
+    // Settings live here; the tests drive them through caramelSetSettings
+    // rather than by poking the object, so the handle is not kept.
+    backStorageEverywhere('sync', {})
+
+    // The real transport: content script / popup → service worker.
+    globalThis.currentBrowser.runtime.sendMessage = (message, callback) => {
+        let answered = false
+        for (const listener of getOnMessageListeners()) {
+            listener(message, {}, response => {
+                if (answered) return
+                answered = true
+                callback(response)
+            })
+        }
+    }
+}
+
+function installFakeServer() {
+    fetchCalls = []
+    serverRows = []
+    accountSyncEnabled = false
+    serverDown = false
+
+    globalThis.fetch = async (url, opts = {}) => {
+        const href = String(url)
+        fetchCalls.push({ url: href, opts })
+
+        if (serverDown) {
+            return { ok: false, status: 503, json: async () => ({}) }
+        }
+
+        // Checked BEFORE the ingest path: '/api/account/savings-sync' also
+        // contains '/api/account/savings'.
+        if (href.includes('/api/account/savings-sync')) {
+            accountSyncEnabled = !!JSON.parse(opts.body).enabled
+            return {
+                ok: true,
+                status: 200,
+                json: async () => ({ savingsSyncEnabled: accountSyncEnabled }),
+            }
+        }
+
+        if (href.includes('/api/account/savings')) {
+            const { events } = JSON.parse(opts.body)
+            const storedIds = []
+            const rejected = []
+            let accepted = 0
+            events.forEach((event, index) => {
+                if (!(event.amountCents > 0)) {
+                    rejected.push({
+                        index,
+                        clientEventId: event.clientEventId,
+                        reason: 'amountCents: too small',
+                    })
+                    return
+                }
+                const already = serverRows.some(
+                    row => row.clientEventId === event.clientEventId,
+                )
+                if (!already) {
+                    serverRows.push(event)
+                    accepted++
+                }
+                storedIds.push(event.clientEventId)
+            })
+            return {
+                ok: true,
+                status: 200,
+                json: async () => ({
+                    accepted,
+                    duplicates: storedIds.length - accepted,
+                    stored: storedIds,
+                    rejected,
+                }),
+            }
+        }
+
+        return { ok: true, status: 200, json: async () => ({}) }
+    }
+}
+
+/** Signs in, or out when passed null. */
+function setSession(username) {
+    if (username) {
+        localData.token = 'tok-' + username
+        localData.user = { username }
+    } else {
+        delete localData.token
+        delete localData.user
+    }
+}
+
+function ingestCalls() {
+    return fetchCalls.filter(
+        call =>
+            call.url.includes('/api/account/savings') &&
+            !call.url.includes('savings-sync'),
+    )
+}
+
+/** The events one ingest request carried. */
+function pushedEvents(index = 0) {
+    return JSON.parse(ingestCalls()[index].opts.body).events
+}
+
+async function stored() {
+    return await base.caramelGetSavings({ all: true })
+}
+
+/* Records a saving and settles the push it triggers.
+ *
+ * caramelRecordSaving deliberately does NOT await the upload — the money path
+ * must never wait on a network round-trip to show a shopper their result — so
+ * a test that asserted straight after it would be racing the request. It does
+ * fire the push synchronously before returning, and caramelSyncSavings hands
+ * back the in-flight promise rather than starting a second one, so awaiting it
+ * here settles that same push instead of inventing a new one. */
+async function record(entry) {
+    await base.caramelRecordSaving(entry)
+    await base.caramelSyncSavings()
+}
+
+beforeEach(() => {
+    loadRealm()
+    installFakeServer()
+})
+
+describe('savings sync is off until the shopper turns it on', () => {
+    it('defaults the device setting to off', async () => {
+        expect((await base.caramelGetSettings()).syncSavings).toBe(false)
+    })
+
+    it('uploads nothing while it is off, even for a signed-in shopper', async () => {
+        setSession('ada')
+        await record({
+            domain: 'shop.com',
+            code: 'TEN',
+            amount: 10,
+        })
+
+        expect(ingestCalls()).toHaveLength(0)
+        const list = await stored()
+        expect(list).toHaveLength(1)
+        expect(list[0].syncPending).toBeUndefined()
+        expect(list[0].synced).toBeUndefined()
+    })
+
+    it('an explicit sweep while off still uploads nothing', async () => {
+        setSession('ada')
+        await record({
+            domain: 'shop.com',
+            code: 'TEN',
+            amount: 10,
+        })
+
+        expect(await base.caramelSyncSavings()).toMatchObject({
+            skipped: 'sync-off',
+        })
+        expect(ingestCalls()).toHaveLength(0)
+    })
+})
+
+describe('a signed-out shopper behaves exactly as before', () => {
+    beforeEach(async () => {
+        await base.caramelSetSettings({ syncSavings: true })
+        setSession(null)
+    })
+
+    it('records the saving locally and uploads nothing', async () => {
+        await record({
+            domain: 'shop.com',
+            code: 'GUEST5',
+            amount: 5,
+        })
+
+        expect(ingestCalls()).toHaveLength(0)
+        const list = await stored()
+        expect(list).toHaveLength(1)
+        expect(list[0].u).toBeUndefined()
+        expect(list[0].syncPending).toBeUndefined()
+    })
+
+    it('still shows the guest their own savings', async () => {
+        await record({
+            domain: 'shop.com',
+            code: 'GUEST5',
+            amount: 5,
+        })
+        expect((await base.caramelGetSavings()).map(e => e.code)).toEqual([
+            'GUEST5',
+        ])
+    })
+
+    it('never uploads that guest saving once someone signs in afterwards', async () => {
+        await record({
+            domain: 'shop.com',
+            code: 'GUEST5',
+            amount: 5,
+        })
+        setSession('ada')
+
+        await base.caramelSyncSavings()
+        expect(ingestCalls()).toHaveLength(0)
+        expect(serverRows).toHaveLength(0)
+    })
+})
+
+describe('with sync on and an account, a win is pushed as it happens', () => {
+    beforeEach(async () => {
+        await base.caramelSetSettings({ syncSavings: true })
+        setSession('ada')
+    })
+
+    it('sends one event carrying everything the account record needs', async () => {
+        await record({
+            domain: 'shop.com',
+            code: 'TEN',
+            amount: 12.5,
+            currency: 'GBP',
+            couponId: 'coupon-99',
+            t: Date.parse('2026-08-09T10:30:00.000Z'),
+        })
+
+        expect(ingestCalls()).toHaveLength(1)
+        const events = pushedEvents()
+        expect(events).toHaveLength(1)
+        expect(events[0]).toMatchObject({
+            store: 'shop.com',
+            code: 'TEN',
+            couponId: 'coupon-99',
+            // Integer minor units on the wire — a lifetime total is not summed
+            // from 2-decimal floats.
+            amountCents: 1250,
+            currency: 'GBP',
+            occurredAt: '2026-08-09T10:30:00.000Z',
+        })
+        expect(typeof events[0].clientEventId).toBe('string')
+        expect(events[0].clientEventId.length).toBeGreaterThan(8)
+    })
+
+    it('goes out with the account bearer, through the service worker', async () => {
+        await record({
+            domain: 'shop.com',
+            code: 'TEN',
+            amount: 10,
+        })
+        expect(ingestCalls()[0].opts.headers.Authorization).toBe(
+            'Bearer tok-ada',
+        )
+        expect(ingestCalls()[0].opts.method).toBe('POST')
+    })
+
+    it('marks the entry synced only after the server confirms it', async () => {
+        await record({
+            domain: 'shop.com',
+            code: 'TEN',
+            amount: 10,
+        })
+        const list = await stored()
+        expect(list[0].synced).toBe(true)
+        expect(serverRows).toHaveLength(1)
+    })
+
+    it('sends a code-less automatic discount as an empty code, not a dropped event', async () => {
+        await record({
+            domain: 'shop.com',
+            code: '',
+            amount: 4,
+        })
+        expect(pushedEvents()[0].code).toBe('')
+        expect(serverRows).toHaveLength(1)
+    })
+
+    it('does not upload another account’s queued entries', async () => {
+        await record({
+            domain: 'shop.com',
+            code: 'ADA',
+            amount: 10,
+        })
+        setSession('grace')
+        await record({
+            domain: 'shop.com',
+            code: 'GRACE',
+            amount: 20,
+        })
+
+        const graceBatch = pushedEvents(1)
+        expect(graceBatch.map(e => e.code)).toEqual(['GRACE'])
+    })
+})
+
+describe('a failed push is retried, and the retry cannot duplicate', () => {
+    beforeEach(async () => {
+        await base.caramelSetSettings({ syncSavings: true })
+        setSession('ada')
+    })
+
+    it('leaves the entry queued when the server is unreachable', async () => {
+        serverDown = true
+        await record({
+            domain: 'shop.com',
+            code: 'TEN',
+            amount: 10,
+        })
+
+        const list = await stored()
+        expect(list[0].synced).toBeUndefined()
+        expect(list[0].syncPending).toBe(true)
+        expect(serverRows).toHaveLength(0)
+    })
+
+    it('retries the SAME clientEventId, so the row is written exactly once', async () => {
+        serverDown = true
+        await record({
+            domain: 'shop.com',
+            code: 'TEN',
+            amount: 10,
+        })
+        const idAtFirstAttempt = (await stored())[0].clientEventId
+
+        serverDown = false
+        await base.caramelSyncSavings()
+        // A third attempt, as a popup catch-up sweep would make.
+        await base.caramelSyncSavings()
+
+        const idAfterRetries = (await stored())[0].clientEventId
+        expect(idAfterRetries).toBe(idAtFirstAttempt)
+        // The id is what makes the replay safe — regenerating it per attempt
+        // would write one row per retry.
+        expect(serverRows).toHaveLength(1)
+        expect(serverRows[0].clientEventId).toBe(idAtFirstAttempt)
+        expect((await stored())[0].synced).toBe(true)
+    })
+
+    it('a sweep with nothing queued makes no request at all', async () => {
+        await record({
+            domain: 'shop.com',
+            code: 'TEN',
+            amount: 10,
+        })
+        const before = ingestCalls().length
+
+        expect(await base.caramelSyncSavings()).toMatchObject({
+            skipped: 'nothing-queued',
+        })
+        expect(ingestCalls()).toHaveLength(before)
+    })
+
+    it('pushes a backlog of queued savings in one request when the server returns', async () => {
+        serverDown = true
+        for (const code of ['A', 'B', 'C']) {
+            await record({
+                domain: 'shop.com',
+                code,
+                amount: 5,
+            })
+        }
+        serverDown = false
+
+        await base.caramelSyncSavings()
+        expect(serverRows).toHaveLength(3)
+        expect((await stored()).every(e => e.synced)).toBe(true)
+    })
+})
+
+describe('an event the server permanently refuses is not retried forever', () => {
+    it('marks it rejected, keeps it locally, and stops pushing it', async () => {
+        await base.caramelSetSettings({ syncSavings: true })
+        setSession('ada')
+
+        // caramelRecordSaving refuses a non-positive amount outright, so drive
+        // the poison payload the way a corrupted stored entry would: queue a
+        // good one, then blank its amount before the sweep.
+        serverDown = true
+        await record({
+            domain: 'shop.com',
+            code: 'BAD',
+            amount: 10,
+        })
+        const list = await stored()
+        list[0].amount = 0
+        await new Promise(resolve =>
+            globalThis.currentBrowser.storage.local.set(
+                { caramel_savings: list },
+                resolve,
+            ),
+        )
+
+        serverDown = false
+        await base.caramelSyncSavings()
+
+        const afterFirst = await stored()
+        expect(afterFirst[0].synced).toBeUndefined()
+        expect(afterFirst[0].syncRejected).toContain('amountCents')
+        expect(serverRows).toHaveLength(0)
+
+        const callsSoFar = ingestCalls().length
+        await base.caramelSyncSavings()
+        // A rejection is deterministic: re-sending it would be a poison pill
+        // parked at the head of the queue forever.
+        expect(ingestCalls()).toHaveLength(callsSoFar)
+    })
+})
+
+describe('sync starts from when it was turned on', () => {
+    it('does not retroactively upload savings earned while it was off', async () => {
+        setSession('ada')
+        await record({
+            domain: 'shop.com',
+            code: 'BEFORE',
+            amount: 10,
+        })
+
+        await base.caramelSetSettings({ syncSavings: true })
+        await base.caramelSyncSavings()
+
+        expect(ingestCalls()).toHaveLength(0)
+        expect(serverRows).toHaveLength(0)
+    })
+
+    it('uploads the savings earned after it was turned on', async () => {
+        setSession('ada')
+        await record({
+            domain: 'shop.com',
+            code: 'BEFORE',
+            amount: 10,
+        })
+        await base.caramelSetSettings({ syncSavings: true })
+        await record({
+            domain: 'shop.com',
+            code: 'AFTER',
+            amount: 20,
+        })
+
+        expect(serverRows.map(row => row.code)).toEqual(['AFTER'])
+    })
+
+    it('turning sync back off stops new uploads and keeps what was already sent', async () => {
+        await base.caramelSetSettings({ syncSavings: true })
+        setSession('ada')
+        await record({
+            domain: 'shop.com',
+            code: 'SENT',
+            amount: 10,
+        })
+
+        await base.caramelSetSettings({ syncSavings: false })
+        await record({
+            domain: 'shop.com',
+            code: 'AFTER_OFF',
+            amount: 20,
+        })
+
+        expect(serverRows.map(row => row.code)).toEqual(['SENT'])
+        // Off means stop sending, not erase — the local history is intact and
+        // the server keeps what it already has.
+        expect((await stored()).map(e => e.code)).toEqual(['AFTER_OFF', 'SENT'])
+    })
+})
+
+describe('the 50-entry cap evicts a synced entry before an unsynced one', () => {
+    /** A history one entry short of the cap, newest first. */
+    function seed({ oldestUnsynced }) {
+        const list = []
+        for (let i = 0; i < 50; i++) {
+            list.push({
+                domain: 'shop.com',
+                code: `C${i}`,
+                amount: 1,
+                currency: 'USD',
+                t: Date.now() - i * 1000,
+                clientEventId: `id-${i}`,
+                u: 'ada',
+                syncPending: true,
+                // Index 49 is the oldest. Making it the one that never reached
+                // the server is what the blind newest-50 trim would delete.
+                synced: !(oldestUnsynced && i === 49),
+            })
+        }
+        localData.caramel_savings = list
+    }
+
+    beforeEach(() => {
+        setSession('ada')
+    })
+
+    it('keeps the unsynced straggler and drops a synced entry instead', async () => {
+        seed({ oldestUnsynced: true })
+        await record({
+            domain: 'shop.com',
+            code: 'NEW',
+            amount: 3,
+        })
+
+        const list = await stored()
+        expect(list).toHaveLength(50)
+        expect(list[0].code).toBe('NEW')
+        // The entry that exists ONLY here survived.
+        expect(list.some(e => e.code === 'C49')).toBe(true)
+        // A synced entry — safe on the account — made room for it.
+        expect(list.some(e => e.code === 'C48')).toBe(false)
+    })
+
+    it('falls back to dropping the oldest when every entry is unsynced', async () => {
+        seed({ oldestUnsynced: false })
+        const list = localData.caramel_savings
+        for (const entry of list) entry.synced = false
+
+        await record({
+            domain: 'shop.com',
+            code: 'NEW',
+            amount: 3,
+        })
+
+        const after = await stored()
+        expect(after).toHaveLength(50)
+        expect(after[0].code).toBe('NEW')
+        expect(after.some(e => e.code === 'C49')).toBe(false)
+    })
+})
+
+describe('the popup switch writes the account flag, not just the device', () => {
+    it('PATCHes the account and reports the persisted value back', async () => {
+        setSession('ada')
+        const response = await new Promise(resolve =>
+            globalThis.currentBrowser.runtime.sendMessage(
+                { action: 'setSavingsSync', enabled: true },
+                resolve,
+            ),
+        )
+
+        expect(response).toEqual({ savingsSyncEnabled: true })
+        const patch = fetchCalls.find(call =>
+            call.url.includes('/api/account/savings-sync'),
+        )
+        expect(patch.opts.method).toBe('PATCH')
+        expect(JSON.parse(patch.opts.body)).toEqual({ enabled: true })
+        expect(patch.opts.headers.Authorization).toBe('Bearer tok-ada')
+    })
+
+    it('surfaces a failure instead of reporting success', async () => {
+        setSession('ada')
+        serverDown = true
+        const response = await new Promise(resolve =>
+            globalThis.currentBrowser.runtime.sendMessage(
+                { action: 'setSavingsSync', enabled: true },
+                resolve,
+            ),
+        )
+        expect(response).toEqual({ error: 'HTTP 503' })
+    })
+})

--- a/apps/caramel-extension/tests/settings-savings.test.mjs
+++ b/apps/caramel-extension/tests/settings-savings.test.mjs
@@ -41,10 +41,13 @@ beforeEach(() => {
 })
 
 describe('caramel-base.js settings helpers', () => {
-    it('defaults to auto-apply ON with no disabled sites', async () => {
+    it('defaults to auto-apply ON with no disabled sites, and savings sync OFF', async () => {
+        // syncSavings false is the load-bearing half: it is consent to upload a
+        // shopping record, so an absent key must read as "has not opted in".
         expect(await helpers.caramelGetSettings()).toEqual({
             autoApply: true,
             disabledSites: [],
+            syncSavings: false,
         })
         expect(await helpers.caramelPromptAllowed('shop.example.com')).toBe(
             true,
@@ -77,6 +80,7 @@ describe('caramel-base.js settings helpers', () => {
         expect(await helpers.caramelGetSettings()).toEqual({
             autoApply: false,
             disabledSites: ['a.com'],
+            syncSavings: false,
         })
     })
 })


### PR DESCRIPTION
Savings a shopper earns are kept on one device today. This adds an **opt-in** way to keep them on their account instead — off by default, one tap either way, and nothing leaves the device until both the account and the device say yes.

## API

### `POST /api/account/savings`

`auth: 'session'` · `rateLimit: 'mutation'` · `origin: true` · no CORS/OPTIONS (the MV3 worker fetches with `host_permissions` and never preflights, same as `coupons/[id]/report`).

```jsonc
// request
{ "events": [ {
    "clientEventId": "b1f2…",     // required, ≤64 — the idempotency key
    "store": "shop.com",           // required, ≤255
    "code": "SAVE10",              // may be "" — automatic discounts have no code
    "couponId": "c1",              // optional/null
    "amountCents": 1250,           // positive int, ≤10_000_000
    "currency": "USD",             // exactly 3 letters, uppercased at the boundary
    "occurredAt": "2026-08-09T10:30:00.000Z"
} ] }                              // 1..100 events

// 200
{ "accepted": 3, "duplicates": 1,
  "stored":   ["id1","id2","id3","id4"],
  "rejected": [ { "index": 4, "clientEventId": "id5", "reason": "amountCents: too big" } ] }
```

### `PATCH /api/account/savings-sync`
`{ "enabled": boolean }` → `200 { "savingsSyncEnabled": boolean }` — the **persisted** value, never the requested one.

### `GET /api/extension/me`
Gains `savingsSyncEnabled: boolean` alongside `username` / `image`.

### Schema
`users.savings_sync_enabled BOOLEAN NOT NULL DEFAULT false`. One additive migration.

> Read this column with `prisma.user.findUnique`, **not** off `session.user` — better-auth only projects the fields it knows, so a custom column arrives there as `undefined`, which is falsy and silently indistinguishable from a real "off".

## Decisions

**Batch semantics — envelope all-or-nothing, events per-item.** A body that isn't `{ events: [...] }`, is empty, or exceeds 100 is a broken client → `422`, whole batch refused; truncating would drop rows the caller believed it had handed over. A single malformed *event* must not cost the nine good rows beside it, so events get per-item results. Per-item is not per-item-silent: every submitted `clientEventId` comes back in exactly one of `stored` or `rejected`, with a reason. The status code describes the request, so a well-formed batch is `200` even when every row in it was rejected.

**`stored` is explicit, not inferred.** It lists every id the server now holds — freshly inserted, already there, or written by a request that beat us. The client marks exactly those synced and never computes the complement of `rejected`.

**Rejections are permanent, and the client stops retrying them.** Validation is deterministic, so re-sending a rejected payload is a poison pill at the head of the queue. The entry is kept locally, stamped `syncRejected`, and logged.

**Unknown `couponId` is nulled, not rejected.** `savings_events.coupon_id` is a real FK onto the catalog; the extension reports whatever id the apply flow held, which can name a row since expired or not yet ingested. Inserting it would fail the **entire** `createMany` over a broken link. `store`/`code`/`amount` are denormalized precisely so the saving survives the catalog row not existing, so nothing user-visible is lost.

**Cap ↔ evict — sync-aware eviction, with the loss stated when it's unavoidable.** The local history is capped at 50. A blind newest-50 trim can evict an entry that never reached the server, deleting the only copy that ever existed. Trimming now drops **synced** entries first (oldest first) — they're safe on the account and cost nothing to lose locally. When *every* entry is unsynced (long outage, or a shopper who never opted in) the oldest is dropped and that goes through `logError`, not silence: it's the one path in the savings history where data leaves and doesn't come back.

**Eligibility is frozen at record time, not re-derived at sweep time.** Two promises depend on it: turning the switch on never retroactively uploads savings earned while it was off ("sync starts from here"), and a saving earned signed **out** belongs to the device, not to the next account that signs in.

**Toggle order is server first, device second.** The device flag gates every upload, so a popup that cached "on" before the server confirmed would sync a shopping record against an account that never agreed. On failure the switch goes back where it was.

**Off ≠ delete.** Turning sync off stops new uploads and keeps server history. Deletion is a separate, explicit act on `/profile`.

## Extension

`syncSavings` defaults **false** and is read as `=== true` (not `!== false` like `autoApply`) — absent must mean "has not opted in". Recorded savings now carry a `clientEventId`, the coupon id both call sites used to drop, and their eligibility. Push happens at the recording moment (fire-and-forget from the money path's view — the result is still checked and recorded) plus a catch-up sweep on popup open; one flush at a time. Settings row clones the existing `.settings-row` markup — zero new CSS — and `#accountLink` now deep-links to `/profile#savings`.

## Tests — 100 new, all suites green

App **634** passing (`account-savings-ingest` 35, `account-savings-sync-toggle` 11), extension **709** passing (`savings-sync` 23, `popup-savings-sync-row` 11), guards **57/57**.

Coverage: replay idempotency, cross-batch retry, intra-batch duplicates, the pre-check missing an already-stored row, batch cap + envelope rejects, 11 per-field validation cases, clock-skew tolerance, auth gating, unknown-`couponId` survival, default-off, logged-out-unchanged, guest savings never adopted, sync-starts-from-here, stable id across retries, sync-aware eviction, and the toggle's server-first ordering.

### Red-proofs

| Mutation | Result |
|---|---|
| `skipDuplicates` removed | 2 red — the pre-check-miss test **500s** on the constraint violation |
| `stored` reports only newly-inserted ids | 1 red — a replay is reported "not stored", so a client retries forever |
| `clientEventId` regenerated per push attempt | 5 red — **2 server rows** where there should be 1 |

### Verified beyond unit tests
- **Schema drift proven, not assumed** — migrations deployed into a throwaway Postgres 16, then `prisma migrate diff --from-schema-datamodel … --to-url` → *"No difference detected."* Column confirmed `boolean not null default false`; `client_event_id` confirmed genuinely `UNIQUE`.
- **Real-browser guard run** independently confirms the new entry shape end to end: `{"amount":12,"clientEventId":"ff28f5f1-…","code":"SAVE12","couponId":"c1",…}` — one saving banked, coupon id no longer dropped, order button untouched.

## Notes for reviewers

- **Size budgets raised** (`.size-limit.js`, dated per the file's ratchet convention): content-scripts 258→268 KB, popup 60→64 KB, background 20→22 KB. A trimming pass paid back 0.95 kB first. The file's standing recommendation — price **minified** bytes instead — is now six raises overdue; this PR deliberately didn't take it, because the file puts that call with the owner and not with the change that re-baselines the numbers.
- One harness trap fixed in `tests/savings-sync.test.mjs`: `caramel-base.js` pins `window.currentBrowser` behind a window flag that survives reloads, so from the second test onward it and `background.js` hold **different** chrome stubs. The symptom was sharp — settings and history worked while the worker sent every request unauthorized, only when the file ran as a whole.
