### PR TITLE
test(e2e): existing-email toast budget was tighter than a cold hydrating /signup page

### DIFF
--- a/apps/caramel-app/e2e/auth-flows.spec.ts
+++ b/apps/caramel-app/e2e/auth-flows.spec.ts
@@ -212,9 +212,15 @@ test.describe('Auth Flows — Signup', () => {
             .getByRole('button', { name: 'Create account', exact: true })
             .click()
 
+        // 15s, not 5s: the response is mocked (fulfilled 422 above), so this
+        // only measures the client rendering the toast — but on the deployed
+        // site a cold /signup load can still be hydrating when the click
+        // lands, and 5s went flaky on 2026-08-09 (failOnFlakyTests turns one
+        // slow retry into a red gate). Same budget rationale as the
+        // signup-success redirect above.
         await expect(
             page.getByText(/unable to create your account/i),
-        ).toBeVisible({ timeout: 5000 })
+        ).toBeVisible({ timeout: 15000 })
     })
 
     test('username too short shows validation error', async ({ page }) => {


### PR DESCRIPTION
The 'signup with existing email shows error toast' assertion carried a 5s visibility budget. The API response is mocked in-test, so the budget only measures client-side toast rendering — but against the deployed site a cold /signup load can still be hydrating when the click lands, and the test went flaky on today's main gate (failOnFlakyTests promotes one slow retry to a red run, costing a manual rerun per deploy). Raised to 15s with the rationale in a comment, matching the signup-success redirect budget fix earlier today (PR #166).