### PR TITLE
test: two vacuous-negative pins now assert the positive precondition first

### DIFF
--- a/apps/caramel-app/tests/unit/account-savings-ingest.test.ts
+++ b/apps/caramel-app/tests/unit/account-savings-ingest.test.ts
@@ -503,7 +503,11 @@ describe('an unknown coupon id cannot take the batch down with it', () => {
 
     it('does not query the catalog when no event names a coupon', async () => {
         signedIn()
-        await post({ events: [event()] })
+        const { json } = await post({ events: [event()] })
+        // The ingest must have actually happened for the negative below to
+        // mean anything — a drifted fixture would otherwise leave nothing
+        // ingested and the "no catalog query" claim would hold vacuously.
+        expect(json.accepted).toBe(1)
         expect(prismaMock.coupon.findMany).not.toHaveBeenCalled()
     })
 })

--- a/apps/caramel-extension/tests/savings-sync.test.mjs
+++ b/apps/caramel-extension/tests/savings-sync.test.mjs
@@ -271,6 +271,10 @@ describe('a signed-out shopper behaves exactly as before', () => {
             code: 'GUEST5',
             amount: 5,
         })
+        // The saving must exist locally for the two negatives below to mean
+        // anything — a broken recording path would otherwise leave nothing to
+        // adopt and this test would go green on the wrong reason.
+        expect((await stored()).map(e => e.code)).toEqual(['GUEST5'])
         setSession('ada')
 
         await base.caramelSyncSavings()


### PR DESCRIPTION
Self-audit follow-up from the savings-sync build (PR #172): two tests carried negative assertions with no positive precondition, so a broken/drifted setup path would leave them trivially green on exactly the scenario they guard.

1. extension savings-sync.test.mjs 'never uploads that guest saving once someone signs in afterwards' — now asserts the guest saving exists locally before asserting it was never uploaded.
2. app account-savings-ingest.test.ts 'does not query the catalog when no event names a coupon' — now asserts the ingest accepted the event before asserting no catalog lookup.

Both regressions were already covered by sibling tests in the same describe blocks, so this is self-sufficiency hardening, not an exposure fix. Extension suite 709/709, app file 35/35.