### PR TITLE
fix(savings): enforce account savings-sync consent server-side on ingest

### DIFF
--- a/apps/caramel-app/src/app/api/account/savings/route.ts
+++ b/apps/caramel-app/src/app/api/account/savings/route.ts
@@ -6,13 +6,36 @@ import { z } from 'zod'
 // POST /api/account/savings — the extension's opt-in cloud savings sync.
 //
 // The extension records every measured win to device storage first and pushes
-// here afterwards, in batches, only when BOTH the device's `syncSavings`
-// setting and the account's `savings_sync_enabled` column are on. `auth:
-// 'session'` rather than 'optional': a savings event with no owner is not a
-// degraded record, it is a meaningless one — there is nowhere to put it and
-// nobody to show it to. Rate-limited + origin-gated like every other mutation;
-// no CORS/OPTIONS export for the same reason coupons/[id]/report has none —
-// the MV3 service worker fetches with host_permissions and never preflights.
+// here afterwards, in batches, when its device `syncSavings` setting is on.
+// `auth: 'session'` rather than 'optional': a savings event with no owner is
+// not a degraded record, it is a meaningless one — there is nowhere to put it
+// and nobody to show it to. Rate-limited + origin-gated like every other
+// mutation; no CORS/OPTIONS export for the same reason coupons/[id]/report has
+// none — the MV3 service worker fetches with host_permissions and never
+// preflights.
+//
+// ── CONSENT IS ENFORCED HERE, NOT ASSUMED ────────────────────────────────────
+// The device setting is a CLIENT cache of the account's consent, and a client
+// cache is not a gate. A stale extension build, a device that never saw the
+// user turn sync off elsewhere, or anything else holding a bearer token can
+// POST this route directly. So `users.savings_sync_enabled` is read per
+// request and a false value refuses the whole batch — the account column is
+// the authority, the device setting only decides whether we bother asking.
+//
+// Read via prisma.user.findUnique, never off `session.user`: better-auth
+// projects only the fields it knows onto the session object, so a custom
+// column arrives `undefined` there — indistinguishable from a real `false`,
+// which is exactly how a consent check silently degrades into a coin flip.
+//
+// The refusal is 403 with a MACHINE-READABLE body, `{ error:
+// 'savings_sync_disabled' }`, because the extension has to tell this apart
+// from a transport failure. Its sweep leaves an event queued on any error and
+// retries on the next popup open, so a bare 403 (or any opaque status) would
+// mean a permanent retry loop against a wall. On this code the extension
+// instead reconciles its cached setting to off and un-queues the batch: the
+// events stay on the device, nothing is marked synced, and the sweep stops.
+// Not 401 — the caller IS authenticated; not a silent 200, which would tell
+// the client the events were stored and let it drop them.
 //
 // ── BATCH SEMANTICS (decided, do not re-litigate) ────────────────────────────
 // TWO layers, because they answer two different questions.
@@ -149,6 +172,19 @@ export const POST = withRoute(
             return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
         }
         const userId = session.user.id
+
+        // Consent gate — see the header note. Fails CLOSED: a user row that
+        // cannot be read at all is not permission to bank someone's data.
+        const account = await prisma.user.findUnique({
+            where: { id: userId },
+            select: { savingsSyncEnabled: true },
+        })
+        if (!account?.savingsSyncEnabled) {
+            return NextResponse.json(
+                { error: 'savings_sync_disabled' },
+                { status: 403 },
+            )
+        }
 
         const candidates: PreparedEvent[] = []
         const rejected: RejectedEvent[] = []

--- a/apps/caramel-app/src/app/profile/sections/SavingsSection.tsx
+++ b/apps/caramel-app/src/app/profile/sections/SavingsSection.tsx
@@ -267,18 +267,23 @@ export default function SavingsSection({
  */
 function SyncOffBody({ savings }: { savings: ProfileOverview['savings'] }) {
     if (savings.eventCount > 0) {
+        // Verb and pronoun agree with the count too, not just the noun — a
+        // half-pluralized sentence ("The 1 event ... are still here ... delete
+        // them") reads as a bug in the page that is telling you your data is
+        // safe, which is the worst place to look careless.
+        const one = savings.eventCount === 1
         return (
             <div className={noticeClasses} role="status">
                 <p className={noticeTitleClasses}>Sync is off.</p>
                 <p className={noticeBodyClasses}>
                     New savings stay on your device. The {savings.eventCount}{' '}
-                    {savings.eventCount === 1 ? 'event' : 'events'} already in
-                    your account are still here —{' '}
+                    {one ? 'event' : 'events'} already in your account{' '}
+                    {one ? 'is' : 'are'} still here —{' '}
                     <Link
                         href="#data"
                         className="font-semibold underline underline-offset-2"
                     >
-                        delete them from Data &amp; privacy
+                        delete {one ? 'it' : 'them'} from Data &amp; privacy
                     </Link>
                     .
                 </p>

--- a/apps/caramel-app/tests/unit/account-savings-ingest.test.ts
+++ b/apps/caramel-app/tests/unit/account-savings-ingest.test.ts
@@ -27,6 +27,9 @@ const { prismaMock, db, defaults } = vi.hoisted(() => {
         savings: [] as SavingsRow[],
         /** Catalog coupon ids this deployment has ingested. */
         coupons: new Set<string>(),
+        /** users rows, keyed by id. Absent = no such user, which the route
+         * must treat as "no consent" rather than as permission. */
+        users: new Map<string, { savingsSyncEnabled: boolean }>(),
     }
 
     // Held separately so beforeEach can mockReset() and re-arm. A test that
@@ -71,6 +74,9 @@ const { prismaMock, db, defaults } = vi.hoisted(() => {
             args.where.id.in
                 .filter(id => state.coupons.has(id))
                 .map(id => ({ id })),
+
+        findUser: async (args: { where: { id: string } }) =>
+            state.users.get(args.where.id) ?? null,
     }
 
     return {
@@ -82,6 +88,7 @@ const { prismaMock, db, defaults } = vi.hoisted(() => {
                 createMany: vi.fn(impl.createSavings),
             },
             coupon: { findMany: vi.fn(impl.findCoupons) },
+            user: { findUnique: vi.fn(impl.findUser) },
         },
     }
 })
@@ -143,13 +150,19 @@ async function post(body: unknown) {
     return { res, json: (await res.json()) as IngestResponse }
 }
 
+/** Signed in AND consented — the only state in which an ingest can succeed, so
+ * it is the default for every test that is about something else. */
 function signedIn(id = 'user-1') {
     getSessionMock.mockResolvedValue({ user: { id }, session: { id: 'sess' } })
+    db.users.set(id, { savingsSyncEnabled: true })
 }
 
 beforeEach(() => {
     db.savings.length = 0
     db.coupons.clear()
+    db.users.clear()
+    prismaMock.user.findUnique.mockReset()
+    prismaMock.user.findUnique.mockImplementation(defaults.findUser)
     prismaMock.savingsEvent.findMany.mockReset()
     prismaMock.savingsEvent.findMany.mockImplementation(defaults.findSavings)
     prismaMock.savingsEvent.createMany.mockReset()
@@ -505,5 +518,91 @@ describe('an unknown coupon id cannot take the batch down with it', () => {
         signedIn()
         await post({ events: [event()] })
         expect(prismaMock.coupon.findMany).not.toHaveBeenCalled()
+    })
+})
+
+// The device setting is a CACHE of consent, not the gate. Anything holding a
+// bearer token can POST this route — a stale extension build that never saw
+// the user turn sync off, most of all — so the account column decides, per
+// request. Proven live before it was fixed: a user with sync off had an event
+// stored and displayed back to them.
+describe('the account consent flag gates the ingest, not the device setting', () => {
+    // Positive first, deliberately: the negatives below all assert "nothing was
+    // written", which is also what a route broken in any OTHER way produces.
+    // This pins that the exact same batch DOES store when consent is on, so a
+    // green negative means the gate worked rather than that nothing works.
+    it('stores the batch when the account has savings sync ON', async () => {
+        signedIn('user-consents')
+        const { res, json } = await post({
+            events: [event({ clientEventId: 'consented' })],
+        })
+
+        expect(res.status).toBe(200)
+        expect(json.accepted).toBe(1)
+        expect(db.savings.map(row => row.clientEventId)).toEqual(['consented'])
+    })
+
+    it('refuses that same batch with 403 savings_sync_disabled when consent is OFF', async () => {
+        signedIn('user-declines')
+        db.users.set('user-declines', { savingsSyncEnabled: false })
+
+        const res = await POST(request({ events: [event()] }))
+        const body = (await res.json()) as { error?: string }
+
+        expect(res.status).toBe(403)
+        // A machine-readable code, not prose: the extension branches on this
+        // exact string to stop sweeping instead of retrying forever.
+        expect(body.error).toBe('savings_sync_disabled')
+        expect(db.savings).toHaveLength(0)
+        expect(prismaMock.savingsEvent.createMany).not.toHaveBeenCalled()
+    })
+
+    it('refuses before touching the events at all — a valid batch is not half-processed', async () => {
+        signedIn('user-declines')
+        db.users.set('user-declines', { savingsSyncEnabled: false })
+
+        await POST(request({ events: [event()] }))
+
+        expect(prismaMock.savingsEvent.findMany).not.toHaveBeenCalled()
+    })
+
+    it('reads the flag from the users table, never off the session object', async () => {
+        // better-auth projects only the fields it knows onto session.user, so
+        // a custom column arrives there as undefined — indistinguishable from
+        // a real false. A gate reading the session would refuse EVERY user.
+        getSessionMock.mockResolvedValue({
+            user: { id: 'user-1', savingsSyncEnabled: false },
+            session: { id: 'sess' },
+        })
+        db.users.set('user-1', { savingsSyncEnabled: true })
+
+        const { res, json } = await post({ events: [event()] })
+
+        expect(res.status).toBe(200)
+        expect(json.accepted).toBe(1)
+        expect(prismaMock.user.findUnique).toHaveBeenCalledWith({
+            where: { id: 'user-1' },
+            select: { savingsSyncEnabled: true },
+        })
+    })
+
+    it('fails closed when the user row cannot be read', async () => {
+        // The session names user-ghost; the users table has no such row.
+        // Absence of a recorded consent is not consent.
+        getSessionMock.mockResolvedValue({
+            user: { id: 'user-ghost' },
+            session: { id: 'sess' },
+        })
+
+        const res = await POST(request({ events: [event()] }))
+
+        expect(res.status).toBe(403)
+        expect(db.savings).toHaveLength(0)
+    })
+
+    it('still 401s a signed-out caller rather than 403 — the gate did not replace auth', async () => {
+        const res = await POST(request({ events: [event()] }))
+        expect(res.status).toBe(401)
+        expect(prismaMock.user.findUnique).not.toHaveBeenCalled()
     })
 })

--- a/apps/caramel-extension/.size-limit.js
+++ b/apps/caramel-extension/.size-limit.js
@@ -175,7 +175,17 @@ module.exports = [
         // is now six raises overdue; this change did not take it, because the
         // file's own note puts that call with the owner and not with the change
         // that re-baselines the numbers.
-        limit: '268 KB',
+        //
+        // 2026-08-10 — 268 → 270 KB. The consent-refusal branch in
+        // caramel-base.js's sweep: the ingest route now enforces the ACCOUNT's
+        // savings_sync_enabled column (a device setting is a cache, not a
+        // gate — proven live, a user with sync off had an event stored), and
+        // answers 403 savings_sync_disabled. ~0.4 kB is code; the rest records
+        // why that one error string is not retried like every other error,
+        // which is the whole defence against a later edit folding it back into
+        // the generic failure path and shipping an infinite retry loop. A
+        // trimming pass paid back 0.14 kB. Measured 268.33 kB.
+        limit: '270 KB',
         brotli: false,
     },
     {
@@ -247,7 +257,17 @@ module.exports = [
         // response has to leave those entries queued for the next sweep rather
         // than silently losing a shopper's savings. Measured 21.25 kB; 22 for
         // the usual headroom.
-        limit: '22 KB',
+        //
+        // 2026-08-10 — 22 → 23 KB while GREEN, which needs saying out loud.
+        // The syncSavings handler now reads the error BODY on a failed status
+        // instead of collapsing it to `HTTP <status>`, so the sweep can tell
+        // the route's 403 savings_sync_disabled apart from a transient failure.
+        // Measured 21.96 kB — it fits, with 40 bytes to spare, and 40 bytes is
+        // not a budget, it is a tripwire that turns the next comment edit into
+        // a red build saying nothing true about bundle weight. Same headroom
+        // reasoning as the 249 and 258 KB lines above, applied before the fact
+        // rather than after.
+        limit: '23 KB',
         brotli: false,
     },
 ]

--- a/apps/caramel-extension/background.js
+++ b/apps/caramel-extension/background.js
@@ -387,6 +387,13 @@ currentBrowser.runtime.onMessage.addListener(
             // The response is handed BACK to the caller rather than swallowed:
             // caramel-base.js marks entries synced only from what the server
             // says it stored, so a dropped response has to leave them queued.
+            //
+            // The error BODY is read on a failed status, not just the number:
+            // the route answers 403 { error: 'savings_sync_disabled' } when the
+            // account has sync off, and the sweep has to tell that permanent
+            // "stop asking" apart from a transient failure it should retry.
+            // Collapsing every non-ok response to `HTTP <status>` made the two
+            // identical, which is an infinite retry on every popup open.
             fetchCaramelApi(caramelUrl('api/account/savings'), {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
@@ -395,7 +402,13 @@ currentBrowser.runtime.onMessage.addListener(
                 }),
             })
                 .then(async r => {
-                    if (!r.ok) return { error: `HTTP ${r.status}` }
+                    if (!r.ok) {
+                        const body = await r.json().catch(() => null)
+                        return {
+                            error: body?.error || `HTTP ${r.status}`,
+                            status: r.status,
+                        }
+                    }
                     return r.json()
                 })
                 .then(resp => sendResponse(resp))

--- a/apps/caramel-extension/caramel-base.js
+++ b/apps/caramel-extension/caramel-base.js
@@ -626,6 +626,34 @@ async function _caramelSyncSavingsOnce() {
         logError('syncSavings transport', err)
         return { pushed: 0, error: String(err) }
     }
+    // The ACCOUNT says sync is off and this device's setting was stale. The
+    // server owns consent, so this is an answer, not a failure — retrying it
+    // would ask the same question on every popup open forever, and the answer
+    // can only change through caramelSetSettings, which re-arms the sweep.
+    //
+    // Two writes, neither a sync: reconcile the cached setting (the next sweep
+    // then short-circuits at 'sync-off' before building a batch), and clear
+    // syncPending on everything queued for this account so it stays device-
+    // local. That keeps the "sync starts from here" promise — consenting later
+    // uploads what follows, never a backlog recorded while consent was off.
+    // Nothing is marked `synced` (nothing was stored) and nothing is marked
+    // `syncRejected` (the events are fine; the permission was missing).
+    if (response && response.error === 'savings_sync_disabled') {
+        await caramelSetSettings({ syncSavings: false })
+        const pendingIds = new Set(queue.map(e => e.clientEventId))
+        const current = await caramelGetSavings({ all: true })
+        for (const e of current) {
+            if (e && e.clientEventId && pendingIds.has(e.clientEventId)) {
+                delete e.syncPending
+            }
+        }
+        await _caramelWriteSavings(current)
+        logError(
+            'syncSavings',
+            `account has savings sync off — un-queued ${pendingIds.size} device-local entries`,
+        )
+        return { pushed: 0, skipped: 'sync-disabled-by-account' }
+    }
     if (!response || response.error) {
         logError('syncSavings', response?.error || 'no response')
         return { pushed: 0, error: response?.error || 'no response' }

--- a/apps/caramel-extension/tests/savings-sync.test.mjs
+++ b/apps/caramel-extension/tests/savings-sync.test.mjs
@@ -92,7 +92,13 @@ function loadRealm() {
 function installFakeServer() {
     fetchCalls = []
     serverRows = []
-    accountSyncEnabled = false
+    // The ACCOUNT-side consent column, and the ingest route enforces it (a
+    // device setting is a cache, not a gate). Defaults to consented because
+    // that is the state every other test in this file is implicitly in: the
+    // real popup switch PATCHes the account before it writes the device
+    // setting, so "device on, account off" is a stale-device anomaly, not the
+    // normal path. The describe that cares flips it deliberately.
+    accountSyncEnabled = true
     serverDown = false
 
     globalThis.fetch = async (url, opts = {}) => {
@@ -115,6 +121,15 @@ function installFakeServer() {
         }
 
         if (href.includes('/api/account/savings')) {
+            // Consent is checked server-side, per request, before a single
+            // event is looked at — same as the real route.
+            if (!accountSyncEnabled) {
+                return {
+                    ok: false,
+                    status: 403,
+                    json: async () => ({ error: 'savings_sync_disabled' }),
+                }
+            }
             const { events } = JSON.parse(opts.body)
             const storedIds = []
             const rejected = []
@@ -622,5 +637,107 @@ describe('the popup switch writes the account flag, not just the device', () => 
             ),
         )
         expect(response).toEqual({ error: 'HTTP 503' })
+    })
+})
+
+// A device can hold syncSavings=true while the ACCOUNT says no: the user turned
+// sync off on another device or in /profile, and this extension never heard.
+// The server refuses those pushes (403 savings_sync_disabled). What matters
+// here is what the sweep does NEXT — because the sweep's rule for every other
+// failure is "leave it queued and try again on the next popup open", and
+// applying that rule to a permanent refusal is an infinite retry loop.
+describe('a refusal from the account is an answer, not a failure to retry', () => {
+    beforeEach(async () => {
+        await base.caramelSetSettings({ syncSavings: true })
+        setSession('ada')
+        accountSyncEnabled = false
+    })
+
+    // Positive control: the same fixture WITH consent stores the event, so the
+    // absence-shaped assertions below mean "the refusal was handled" and not
+    // "this fixture never syncs anything".
+    it('stores the very same event once the account consents', async () => {
+        accountSyncEnabled = true
+        await record({ domain: 'shop.com', code: 'TEN', amount: 10 })
+
+        expect(serverRows).toHaveLength(1)
+        expect((await stored())[0].synced).toBe(true)
+    })
+
+    it('stops sweeping instead of retrying the refusal forever', async () => {
+        await record({ domain: 'shop.com', code: 'TEN', amount: 10 })
+        expect(ingestCalls()).toHaveLength(1)
+
+        // Three more sweeps, as three popup opens would make.
+        await base.caramelSyncSavings()
+        await base.caramelSyncSavings()
+        await base.caramelSyncSavings()
+
+        expect(ingestCalls()).toHaveLength(1)
+    })
+
+    it('marks nothing synced — the server stored nothing', async () => {
+        await record({ domain: 'shop.com', code: 'TEN', amount: 10 })
+
+        const list = await stored()
+        expect(list).toHaveLength(1)
+        expect(list[0].synced).toBeUndefined()
+        expect(serverRows).toHaveLength(0)
+    })
+
+    it('does not mark the event rejected — the event was fine, the permission was missing', async () => {
+        await record({ domain: 'shop.com', code: 'TEN', amount: 10 })
+        expect((await stored())[0].syncRejected).toBeUndefined()
+    })
+
+    it('un-queues the batch so it stays device-local', async () => {
+        await record({ domain: 'shop.com', code: 'TEN', amount: 10 })
+        expect((await stored())[0].syncPending).toBeUndefined()
+    })
+
+    it('reconciles the device setting to the account, so the next sweep short-circuits', async () => {
+        await record({ domain: 'shop.com', code: 'TEN', amount: 10 })
+
+        expect((await base.caramelGetSettings()).syncSavings).toBe(false)
+        expect(await base.caramelSyncSavings()).toEqual({
+            pushed: 0,
+            skipped: 'sync-off',
+        })
+    })
+
+    it('keeps the saving visible in the shopper local history', async () => {
+        await record({ domain: 'shop.com', code: 'TEN', amount: 10 })
+
+        const list = await stored()
+        expect(list[0].domain).toBe('shop.com')
+        expect(list[0].amount).toBe(10)
+    })
+
+    it('does not upload a backlog if the shopper later turns sync back on', async () => {
+        await record({ domain: 'shop.com', code: 'TEN', amount: 10 })
+
+        // Consent granted afterwards. "Sync starts from here" — the refused
+        // event was recorded while the account said no and stays local.
+        accountSyncEnabled = true
+        await base.caramelSetSettings({ syncSavings: true })
+        await base.caramelSyncSavings()
+
+        expect(serverRows).toHaveLength(0)
+
+        // ...and a saving earned AFTER does upload, so the sweep is alive.
+        await record({ domain: 'shop.com', code: 'LATER', amount: 4 })
+        expect(serverRows.map(row => row.code)).toEqual(['LATER'])
+    })
+
+    it('a transport failure is still retried — only the refusal stops the sweep', async () => {
+        accountSyncEnabled = true
+        serverDown = true
+        await record({ domain: 'shop.com', code: 'TEN', amount: 10 })
+        expect(ingestCalls()).toHaveLength(1)
+
+        await base.caramelSyncSavings()
+        expect(ingestCalls()).toHaveLength(2)
+        expect((await stored())[0].syncPending).toBe(true)
+        expect((await base.caramelGetSettings()).syncSavings).toBe(true)
     })
 })


### PR DESCRIPTION
`POST /api/account/savings` never checked `users.savings_sync_enabled`. Proven live: a user with sync off had an event stored and displayed back to them. The route's own header comment claimed both the device setting and the account column gated the push — it enforced neither.

A device setting is a cache of consent, not a gate. Anything holding a bearer token can POST the route directly, and a stale extension build that never saw the user turn sync off is exactly that.

## The refusal shape

`403 { error: 'savings_sync_disabled' }` — a machine-readable code, chosen against the extension's own retry semantics:

- **Not a bare 403.** The worker collapsed every non-ok response to `HTTP <status>` and the sweep leaves an event queued on any error, retrying on the next popup open. An opaque refusal is a permanent retry loop against a wall. The worker now reads the error body on a failed status so the two are distinguishable.
- **Not a per-item rejection.** `syncRejected` means "the server will refuse this payload every time" and poisons the entry permanently. The events are fine; only the permission was missing.
- **Not a silent 200.** That tells the client the events were stored and invites it to drop them.
- **Not 401.** The caller is authenticated. It is the consent that is absent.

On that code the sweep reconciles its cached setting to off (so the next sweep short-circuits before building a batch) and clears `syncPending` on the queued batch, making those events permanently device-local. Nothing is marked synced. That also keeps the "sync starts from here" promise: consenting later uploads what follows, never a backlog recorded while consent was off.

The preference is read with `prisma.user.findUnique`, never off `session.user` — better-auth projects only fields it knows, so a custom column arrives `undefined` there, indistinguishable from a real `false`. A gate reading the session would refuse every user. Fails closed on an unreadable user row.

## Tests

`apps/caramel-app/tests/unit/account-savings-ingest.test.ts` — 41 (was 35), new describe *"the account consent flag gates the ingest, not the device setting"*:
- stores the batch when the account has savings sync ON (positive precondition, first — every other assertion in the describe is absence-shaped and would also pass against a route broken in some other way)
- refuses that same batch with 403 savings_sync_disabled when consent is OFF
- refuses before touching the events at all — a valid batch is not half-processed
- reads the flag from the users table, never off the session object
- fails closed when the user row cannot be read
- still 401s a signed-out caller rather than 403 — the gate did not replace auth

`apps/caramel-extension/tests/savings-sync.test.mjs` — 32 (was 23), new describe *"a refusal from the account is an answer, not a failure to retry"*. The fake server now enforces consent on the ingest path, so this runs through the real background worker:
- stores the very same event once the account consents (positive control)
- stops sweeping instead of retrying the refusal forever
- marks nothing synced — the server stored nothing
- does not mark the event rejected — the event was fine, the permission was missing
- un-queues the batch so it stays device-local
- reconciles the device setting to the account, so the next sweep short-circuits
- keeps the saving visible in the shopper local history
- does not upload a backlog if the shopper later turns sync back on
- a transport failure is still retried — only the refusal stops the sweep

## Red-proofs (each restored)

**A — route gate disabled.** 3 failures, all named, and the positive control plus the session-trap test stayed green, so the negatives failed for the right reason:

```
PASS (38) FAIL (3)
1. ... refuses that same batch with 403 savings_sync_disabled when consent is OFF
2. ... refuses before touching the events at all — a valid batch is not half-processed
3. ... fails closed when the user row cannot be read
```

**B — worker reverted to collapsing non-ok into `HTTP <status>`.** The sweep can no longer see the code and retries. 4 failures:

```
PASS (28) FAIL (4)
1. ... stops sweeping instead of retrying the refusal forever
2. ... un-queues the batch so it stays device-local
3. ... reconciles the device setting to the account, so the next sweep short-circuits
4. ... does not upload a backlog if the shopper later turns sync back on
```

**C — sweep's refusal branch removed, body-read intact.** Same 4 failures, which is the point: the enforcement needs both halves, and either one alone leaves the loop.

## Rider

`SavingsSection.tsx` pluralized the noun but hardcoded the verb and pronoun, so at exactly one event it read *"The 1 event already in your account **are** still here — delete **them**"*. Verb and pronoun now agree with the count in both cases.

## Gates

`tsc --noEmit` clean · `eslint .` 0 errors both workspaces · oxlint exit 0 · prettier clean · knip ok both · `test:guards` 57/57 · app suite 699 · extension suite 718 · size-limit green.

`.size-limit.js` raises, both dated per the file's ratchet convention: content-scripts 268 → 270 KB (measured 268.33, after a 0.14 kB trimming pass), and background.js 22 → 23 KB **while green** at 21.96 — 40 bytes of headroom is a tripwire, not a budget, and the file's 249/258 KB notes set that precedent.
