### PR TITLE
test(account): three vacuous negatives now assert the positive precondition first

### DIFF
--- a/apps/caramel-app/tests/unit/account-data-delete.test.ts
+++ b/apps/caramel-app/tests/unit/account-data-delete.test.ts
@@ -23,7 +23,10 @@ const { prismaMock, transactionMock } = vi.hoisted(() => {
             savingsEvent: { deleteMany: vi.fn(() => ({ op: 'savings' })) },
             favoriteStore: { deleteMany: vi.fn(() => ({ op: 'favorites' })) },
             couponReport: { deleteMany: vi.fn(() => ({ op: 'reports' })) },
-            user: { update: vi.fn() },
+            // `delete` is mocked even though the route must never call it: a
+            // "not called" assertion against a method the fixture does not
+            // define is a statement about the fixture, not about the route.
+            user: { update: vi.fn(), delete: vi.fn() },
         },
     }
 })
@@ -128,13 +131,25 @@ describe('POST /api/account/data/delete — scope', () => {
     })
 
     it('does NOT delete the account and does NOT touch the sync preference', async () => {
-        await POST(deleteRequest({ confirm: 'DELETE' }))
+        const res = await POST(deleteRequest({ confirm: 'DELETE' }))
 
-        // Toggling sync off and deleting history are deliberately separate
-        // acts — a delete that also changed a setting the user never touched
-        // would make the danger zone do something it did not say it would.
+        // The POSITIVE half first. Without it both negatives below are
+        // trivially true whenever the request never got as far as deleting
+        // anything — a 401, a 422 from a changed body schema, an early return —
+        // so the test would go green on a route that does nothing at all,
+        // which is the opposite of what it claims to verify.
+        expect(res.status).toBe(200)
+        expect(transactionMock).toHaveBeenCalledTimes(1)
+        expect(prismaMock.savingsEvent.deleteMany).toHaveBeenCalledTimes(1)
+        expect(prismaMock.favoriteStore.deleteMany).toHaveBeenCalledTimes(1)
+        expect(prismaMock.couponReport.deleteMany).toHaveBeenCalledTimes(1)
+
+        // Only now is "and nothing else happened" a real statement. Toggling
+        // sync off and deleting history are deliberately separate acts — a
+        // delete that also changed a setting the user never touched would make
+        // the danger zone do something it did not say it would.
         expect(prismaMock.user.update).not.toHaveBeenCalled()
-        expect(prismaMock).not.toHaveProperty('user.delete')
+        expect(prismaMock.user.delete).not.toHaveBeenCalled()
     })
 })
 

--- a/apps/caramel-app/tests/unit/account-export.test.ts
+++ b/apps/caramel-app/tests/unit/account-export.test.ts
@@ -287,7 +287,16 @@ describe('GET /api/account/export', () => {
     it('selects User columns EXPLICITLY — a bare findUnique would export password + token', async () => {
         await GET(exportRequest())
         const args = prismaMock.user.findUnique.mock.calls[0]![0]
-        expect(args.select).toBeDefined()
+        // Positive first: this must be the ACCOUNT select, populated with the
+        // columns the export is supposed to carry. An `undefined` or empty
+        // select would satisfy every `not.toHaveProperty` below while being
+        // exactly the regression (a bare findUnique returns ALL columns).
+        expect(args.select).toMatchObject({
+            id: true,
+            email: true,
+            createdAt: true,
+            emailVerified: true,
+        })
         expect(args.select).not.toHaveProperty('password')
         expect(args.select).not.toHaveProperty('token')
         expect(args.select).not.toHaveProperty('tokenExpiry')

--- a/apps/caramel-app/tests/unit/account-export.test.ts
+++ b/apps/caramel-app/tests/unit/account-export.test.ts
@@ -252,12 +252,28 @@ describe('GET /api/account/export', () => {
 
     it('the ACTUAL response body carries nothing from the never-include list', async () => {
         const res = await GET(exportRequest())
-        // Assert 200 FIRST. Without this the test passes vacuously when the
-        // route 500s (an error body has no forbidden keys either) — which is
-        // exactly what happens when assertExportIsSafe catches a leak, so the
-        // one test that must go red on a leak would have stayed green.
+
+        // A NEGATIVE assertion is only as good as its proof that it is looking
+        // at the real thing. "No forbidden keys" is trivially satisfied by an
+        // empty body, an error body, a 404, or a typo'd URL — every one of
+        // which is a failure this test exists to catch. So the positive half
+        // comes FIRST and is what gives the negative half meaning: this is not
+        // "no secrets leaked", it is "no secrets leaked, in a response that
+        // definitely contained the data secrets could have leaked from".
         expect(res.status).toBe(200)
         const body = (await res.json()) as AccountExport
+
+        expect(body.account.email).toBe('shopper@example.com')
+        expect(body.account.id).toBe(USER_ID)
+        expect(body.savingsEvents.length).toBeGreaterThan(0)
+        expect(body.favoriteStores.length).toBeGreaterThan(0)
+        expect(body.couponReports.length).toBeGreaterThan(0)
+        // The account row this export is built FROM is the one carrying
+        // password/token, so a populated account block is the specific proof
+        // that the walker below had something dangerous to find.
+        expect(Object.keys(body.account).length).toBeGreaterThan(5)
+
+        // Only now does absence mean anything.
         expect(collectForbiddenKeys(body)).toEqual([])
 
         // Belt and braces against the walker itself being wrong: the three

--- a/apps/caramel-app/tests/unit/profile-report-impact.test.ts
+++ b/apps/caramel-app/tests/unit/profile-report-impact.test.ts
@@ -173,11 +173,21 @@ describe('summarizeReports', () => {
         // reportCount, Coupon.timesUsed or CouponSignal.workCount. All three
         // are anonymous aggregates; a number built from them would be a
         // fabricated public claim about other people's behaviour.
-        expect(summarizeReports([report()]).shoppersHelped).toBeNull()
-        expect(
-            summarizeReports(Array.from({ length: 50 }, () => report()))
-                .shoppersHelped,
-        ).toBeNull()
+        //
+        // reportCount is asserted alongside each null so the null is a claim
+        // about a POPULATED summary. summarizeReports has an early return that
+        // yields all-nulls for an empty input, so a bare `.shoppersHelped` is
+        // null on the path this test is not about — and would stay green if
+        // the populated branch broke, or if `report()` drifted out of shape.
+        const one = summarizeReports([report()])
+        expect(one.reportCount).toBe(1)
+        expect(one.shoppersHelped).toBeNull()
+
+        const many = summarizeReports(
+            Array.from({ length: 50 }, () => report()),
+        )
+        expect(many.reportCount).toBe(50)
+        expect(many.shoppersHelped).toBeNull()
     })
 })
 


### PR DESCRIPTION
Test-only follow-up to #171. Three assertions that shipped in `main` are **vacuous** — each passes on the exact regression it exists to catch. Each commit here is backed by a measured red-proof: the strengthened form goes red on a deliberate regression, and the *pre-existing* form stays **green** on that same regression.

No source files change. `main` behaviour is untouched.

## The shared defect

A negative assertion is only as good as its proof that it is looking at the real thing. "No forbidden keys", "not called", "is null" are all trivially satisfied by an empty body, an error response, or a branch that never ran — every one of which is the failure the assertion exists to catch. The fix in each case is to assert the positive precondition *first*, so absence becomes a claim about a payload that genuinely contained something to find.

This is the same class PR #174 fixed on the savings side; these are the three remaining instances, in the code #171 landed.

## Commit 1 — `test(export): prove the payload is genuine before asserting no secrets leaked`

`collectForbiddenKeys(body)` returning `[]` proves nothing if `body` is empty. Now asserts `account.email`, `account.id`, non-empty `savingsEvents` / `favoriteStores` / `couponReports`, and `Object.keys(account).length > 5` — the account block is the one built from the row carrying `password`/`token`, so a populated account is the specific proof the walker had something dangerous to find.

**Red-proof:** made `buildAccountExport` emit empty `favoriteStores`/`savingsEvents` regardless of input — the query-or-mapping regression that returns a well-formed 200 containing nothing.
- strengthened form → **RED**
- positive block stripped back out, same broken builder → **GREEN**

The pre-existing assertion was passing on an export that returned none of the user's data. It was testing that an empty object has no secrets in it.

## Commit 2 — `test(account): prove the mutation ran before asserting what it did not touch`

Two problems in `does NOT delete the account and does NOT touch the sync preference`:

1. Both negatives are trivially true whenever the request never reached the delete — a 401, a 422 from a changed body schema, any early return.
2. `expect(prismaMock).not.toHaveProperty('user.delete')` asserted against the **fixture**, which never defined `user.delete`. A tautology: it would pass even if the route called `prisma.user.delete`, because the mock would throw and `withRoute` would catch it into a 500 while the assertion stayed green. A "not called" assertion against a method the fixture does not define is a statement about the fixture, not the route.

Now: `delete: vi.fn()` is on the mock so "not called" is a real claim, and the test asserts the mutation actually ran (200 + all three `deleteMany` called once) before asserting what it left alone.

**Red-proof:** flipped the body literal so every request 422s and the route deletes nothing.
- strengthened form → **RED**
- positive block stripped back out, same broken route → **GREEN**

Also tightened the sibling export test: `not.toHaveProperty('password')` was riding on a `toBeDefined()` that an empty select would satisfy, so it now asserts the select actually contains `id`/`email`/`createdAt`/`emailVerified` first — a bare `findUnique` returning all columns is the regression it guards.

## Commit 3 — `test(reports): pin the populated summary so the shoppersHelped null means something`

The single anti-fabrication invariant the reports section rests on: `shoppersHelped` must always be null, because nothing records *who* used a coupon and any number would be a fabricated claim about other people's behaviour.

`summarizeReports` has an early return yielding all-nulls for empty input, so `expect(summarizeReports([report()]).shoppersHelped).toBeNull()` is null for the wrong reason — and stays green — if the populated branch breaks or the `report()` fixture drifts out of shape. Now asserts `reportCount` alongside each null.

**Red-proof:** made the early return swallow every input (`reports.length >= 0`), so the populated branch never runs.
- strengthened form → **RED**
- `reportCount` assertions stripped back out, same broken function → **GREEN**

## Verification

All three red-proofs were re-run on **this branch** against current `main` (`b448e00`), not carried over from the original run. Every mutated source file was restored; `git diff origin/main..HEAD` is three test files and nothing else.

`pnpm --filter caramel-app test` → **71 files, 693 passed**. `type-check`, `lint`, `prettier-check`, `knip` all exit 0.
