### PR TITLE
ci: make the Schema Drift gate able to fail (it never could)

### DIFF
--- a/.github/workflows/checks-app.yml
+++ b/.github/workflows/checks-app.yml
@@ -183,8 +183,14 @@ jobs:
         run: pnpm --filter caramel-app run audit:prod
 
   # ─────────────────────────────────────────────────────────────
-  # Schema Drift Check (only when prisma files change)
+  # Schema Drift Check (every PR — there is no path filter)
   # ─────────────────────────────────────────────────────────────
+  # This job was DECORATIVE until 2026-08-10: every check ended in
+  # `--exit-code || echo "No drift detected"`, so the `||` turned a real failure
+  # into a reassuring log line and the job was green no matter what the checks
+  # found. It was also failing all three checks in a row, invisibly, because the
+  # shadow "database" was a shadow SCHEMA (see the SHADOW_DATABASE_URL note).
+  # Rule: no `|| echo` in this job. A check that cannot go red is not a gate.
   schema-drift:
     name: Schema Drift
     if: github.event_name == 'pull_request'
@@ -192,7 +198,11 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15
+        # Prod-matching: docker-compose.yml pins postgres:18.4, and a *drift*
+        # gate measuring against a different engine version is measuring the
+        # wrong database. (The e2e-pr job's postgres:15 stays a separate
+        # punch-list item.)
+        image: postgres:18.4
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -206,7 +216,17 @@ jobs:
 
     env:
       DATABASE_URL: 'postgresql://postgres:postgres@localhost:5432/caramel_ci'
-      SHADOW_DATABASE_URL: 'postgresql://postgres:postgres@localhost:5432/caramel_ci?schema=__shadow'
+      # A dedicated shadow DATABASE, never a shadow SCHEMA. Under
+      # `?schema=__shadow` the migration history genuinely cannot replay: the
+      # older migrations create unqualified tables (which land in __shadow)
+      # while the newer, newer-Prisma ones emit `"public"."…"`-qualified DDL, so
+      # the first public-qualified FK to an older table dies with
+      # P3006 / P1014 "the underlying table for model `public.users` does not
+      # exist". The partial replay then leaves objects behind in caramel_ci,
+      # which made the following `migrate deploy` fail P3005 ("database schema
+      # is not empty") and left the last check diffing against an empty public
+      # schema. A separate database replays the identical history clean.
+      SHADOW_DATABASE_URL: 'postgresql://postgres:postgres@localhost:5432/caramel_ci_shadow'
 
     steps:
       - uses: actions/checkout@v4
@@ -235,33 +255,45 @@ jobs:
         working-directory: ./apps/caramel-app
         run: npx prisma validate
 
-      - name: Prepare shadow schema
+      # Prisma resets this database itself before each replay, so the two drift
+      # checks below can share it; it only has to exist.
+      - name: Create shadow database
         run: |
+          set -euo pipefail
           sudo apt-get -yqq install postgresql-client
-          psql "postgresql://postgres:postgres@localhost:5432/caramel_ci" \
-            -c "CREATE SCHEMA IF NOT EXISTS __shadow;"
+          psql "postgresql://postgres:postgres@localhost:5432/postgres" \
+            -c "DROP DATABASE IF EXISTS caramel_ci_shadow;"
+          psql "postgresql://postgres:postgres@localhost:5432/postgres" \
+            -c "CREATE DATABASE caramel_ci_shadow;"
 
+      # Replays every migration into the shadow database and diffs the result
+      # against schema.prisma. Exit 2 = a schema.prisma change shipped without
+      # its migration (or a hand-edited migration). It fails the job.
       - name: Drift check (schema ⇄ migrations)
         working-directory: ./apps/caramel-app
         run: |
+          set -euo pipefail
           npx prisma migrate diff \
             --from-migrations prisma/migrations \
             --to-schema-datamodel prisma/schema.prisma \
             --shadow-database-url "$SHADOW_DATABASE_URL" \
-            --exit-code || echo "No drift detected or no migrations yet"
+            --exit-code
 
+      # A migration that does not apply to an empty database is a broken
+      # migration, so this failing must fail the job.
       - name: Apply migrations
         working-directory: ./apps/caramel-app
-        run: npx prisma migrate deploy --preview-feature || echo "No migrations to apply"
+        run: npx prisma migrate deploy
 
       - name: Drift check (migrations ⇄ Postgres)
         working-directory: ./apps/caramel-app
         run: |
+          set -euo pipefail
           npx prisma migrate diff \
             --from-migrations prisma/migrations \
             --to-url "$DATABASE_URL" \
             --shadow-database-url "$SHADOW_DATABASE_URL" \
-            --exit-code || echo "No drift detected"
+            --exit-code
 
   # ─────────────────────────────────────────────────────────────
   # E2E & Visual Regression (PR – local dev server)

--- a/apps/caramel-app/prisma/schema.prisma
+++ b/apps/caramel-app/prisma/schema.prisma
@@ -264,10 +264,6 @@ model CouponReport {
   outcome   String
   createdAt DateTime @default(now()) @map("created_at")
 
-  // SCRATCH: deliberate drift, no migration written for it. Exists only to
-  // prove the repaired Schema Drift gate goes RED. Reverted in the next commit.
-  redProofOnly String? @map("red_proof_only")
-
   @@index([couponId, userId, createdAt])
   @@map("coupon_reports")
 }

--- a/apps/caramel-app/prisma/schema.prisma
+++ b/apps/caramel-app/prisma/schema.prisma
@@ -264,6 +264,10 @@ model CouponReport {
   outcome   String
   createdAt DateTime @default(now()) @map("created_at")
 
+  // SCRATCH: deliberate drift, no migration written for it. Exists only to
+  // prove the repaired Schema Drift gate goes RED. Reverted in the next commit.
+  redProofOnly String? @map("red_proof_only")
+
   @@index([couponId, userId, createdAt])
   @@map("coupon_reports")
 }


### PR DESCRIPTION
## The defect

The **Schema Drift** job in `.github/workflows/checks-app.yml` has been green on every PR
regardless of what it found. Two independent bugs, both verified concretely:

**1. It could not fail.** All three checks ended in `--exit-code || echo "No drift detected…"`.
`--exit-code` is what makes `prisma migrate diff` exit 2 on drift — and the `||` turned that
(and any other non-zero exit) into a reassuring log line. `migrate deploy` carried the same
swallow.

**2. Its shadow "database" was a shadow SCHEMA.** `SHADOW_DATABASE_URL` was
`…/caramel_ci?schema=__shadow`. Under a non-`public` shadow schema the migration history
genuinely cannot replay: the older migrations create unqualified tables (which land in
`__shadow`) while the newer, newer-Prisma ones emit `"public"."…"`-qualified DDL, so the first
public-qualified FK to an older table dies. Reproduced verbatim against a disposable Postgres:

```
Error: P3006
Migration `20260809204144_login_features_foundation` failed to apply cleanly to the shadow database.
Error code: P1014
Error: The underlying table for model `public.users` does not exist.
```

**Third failing check, found while reproducing (a knock-on of #2, equally invisible):** the
partial replay leaves objects behind in `caramel_ci`, so the next step's `prisma migrate deploy`
died with `P3005 "The database schema is not empty"` — and the final `migrations ⇄ Postgres`
check then diffed the migration history against an *empty* public schema, i.e. reported maximal
drift. **All three checks were failing on every PR, and all three were swallowed.**

## The fix

- Removed every `|| echo` swallow; the three `run` blocks carry `set -euo pipefail`.
- `SHADOW_DATABASE_URL` now points at a dedicated **database** (`caramel_ci_shadow`), created by
  a `Create shadow database` step (`DROP DATABASE IF EXISTS` + `CREATE DATABASE` via `psql`,
  replacing the old `CREATE SCHEMA __shadow`). Prisma resets that database itself before each
  replay, so both drift checks share it.
- Dropped `--preview-feature` from `migrate deploy` — dead legacy flag (Prisma 6.14 accepts and
  ignores it).
- Bumped the job's postgres service `15 → 18.4`, matching `docker-compose.yml` and the
  `Integration (DB)` job. A *drift* gate measuring against a different engine version is
  measuring the wrong database. (`e2e-pr`'s `postgres:15` stays a separate punch-list item.)
- Corrected the job comment: it claimed "only when prisma files change", but there is no path
  filter — it runs on every PR.

## Local proof (disposable Postgres, before pushing)

Replayed the repaired job logic 1:1 against a throwaway container, on **both** `postgres:15` and
`postgres:18.4`:

```
== 1. prisma validate              The schema at prisma/schema.prisma is valid
== 2. drift (schema ⇄ migrations)  No difference detected.
== 3. migrate deploy               8 migrations applied
== 4. drift (migrations ⇄ PG)      No difference detected.
ALL GREEN
```

The same script pointed at the old `?schema=__shadow` URL fails at step 2 with the P3006/P1014
above — the exact failure the `|| echo` was hiding.

## Red-proof

A check that has never gone red is not yet a gate, so it was proven red **and** green here:

| # | Head | Schema Drift | Run |
| - | ---- | ------------ | --- |
| 1 | `b7e4b28` — fix only | ✅ GREEN | https://github.com/DevinoSolutions/caramel/actions/runs/31342257879/job/93317859470 |
| 2 | `5175012` — scratch commit adds a field to `schema.prisma` with no migration | ❌ **RED** | https://github.com/DevinoSolutions/caramel/actions/runs/31342346436/job/93318114406 |
| 3 | `ec0036b` — scratch commit reverted | ✅ GREEN | https://github.com/DevinoSolutions/caramel/actions/runs/31342445365/job/93318370372 |

Run 2 failed on the drift itself, not on setup — the shadow database was created fine and the
diff found the real change:

```
NOTICE:  database "caramel_ci_shadow" does not exist, skipping
DROP DATABASE
CREATE DATABASE
##[group]Run set -euo pipefail
npx prisma migrate diff \
  --from-migrations prisma/migrations \
  --to-schema-datamodel prisma/schema.prisma \
  --shadow-database-url "$SHADOW_DATABASE_URL" \
  --exit-code
##[endgroup]

[*] Changed the `coupon_reports` table
  [+] Added column `red_proof_only`
##[error]Process completed with exit code 2.
```

Before this PR that identical output was followed by `No drift detected or no migrations yet`
and an exit code of 0.

## Findings beyond the two known bugs

- The `P3005` + maximal-drift knock-on above — a **third** check that was failing silently.
- `--preview-feature` on `migrate deploy` is dead legacy syntax, kept alive by the swallow.
- The job comment described a path filter that does not exist.
- Nothing stops a future `|| echo` from re-neutering a check. The other `|| true` / `|| echo`
  occurrences under `.github/` were reviewed and are legitimate (poll loops, tolerant
  `git fetch`), so no repo-wide grep gate was added here — raising it as a punch-list item
  rather than growing this PR.
- Unrelated to CI: the husky pre-commit hook's `prisma validate` needs `DATABASE_URL` present
  (`.env` or exported) or it fails `P1012` locally. Left alone.
