### PR TITLE
build(extension): size budgets measure minified bytes instead of raw source

### DIFF
--- a/apps/caramel-extension/.gitignore
+++ b/apps/caramel-extension/.gitignore
@@ -14,6 +14,9 @@
 # production
 /build
 
+# minified copies the size gate weighs — rebuilt by `pnpm size`, never shipped
+/.size-cache
+
 # misc
 .DS_Store
 *.pem

--- a/apps/caramel-extension/.size-limit.js
+++ b/apps/caramel-extension/.size-limit.js
@@ -1,273 +1,58 @@
-/* Bundle-size budgets — RE-BASELINED 2026-08-06.
+/* Bundle-size budgets — measured over MINIFIED bytes (re-baselined 2026-08-10).
  *
- * These are RAW SOURCE BYTES (@size-limit/file — no bundler, no minifier), so
- * every line of the explanatory comment this codebase's house style requires is
- * counted as if it were executable weight. It isn't: the parser discards
- * comments, and the cost this gate exists to bound is CODE running on every
- * store page load.
+ * `pnpm size` runs scripts/measure-size.mjs first, which minifies every shipped
+ * script into .size-cache/ and is where the file lists live. These paths point
+ * at that output, so what gets weighed here is roughly the CODE: comments and
+ * formatting are gone before the ruler touches anything. Explaining a fix costs
+ * nothing; adding logic costs bytes. That is the whole point of the change.
  *
- * The consequence was predictable, and had already happened. The gate went red
- * on 2026-08-04 — roughly 54 KB over on content-scripts — and stayed red through
- * every commit since, which also meant the `Build the store package` step that
- * runs after it never executed on any of them. A budget that is permanently red
- * is not a budget. And it was not the codebase that was wrong: "a rule that
- * lives only in a file will be forgotten" cuts both ways, because a check nobody
- * can satisfy gets ignored exactly like a rule with no check.
+ * It replaces a raw-source budget that priced prose, and it is worth one line
+ * on why: that gate took seven documented raises in four days, several of them
+ * buying room for sentences rather than behaviour, and it sent at least one
+ * session shaving comments to fit a ceiling whose stated purpose was bounding
+ * code that runs on every store page. It also spent a period permanently red,
+ * which silently skipped the packaging step that ran after it. A budget nobody
+ * can satisfy is not a budget.
  *
- * So these are the sizes measured TODAY, and they are a RATCHET — the same shape
- * as scripts/ty_baseline.json and except_silent_baseline.json in the sibling
- * repo. Growth from here fails the build, so it has to be a decision rather than
- * a drift. Raising a number is allowed; raising it silently is not. Date the
- * reason beside it.
+ * These are still a RATCHET, same shape as ty_baseline.json in the sibling
+ * repo. Growth from here fails the build, so it has to be a decision rather
+ * than a drift — and now a raise means real code arrived. Raising a number is
+ * allowed; raising it silently is not. Date the reason beside it.
  *
- * TODO: the honest long-term fix is to measure MINIFIED bytes, which would price
- * code and stop pricing prose, and would put the real figure far below these. It
- * needs a measurement-only bundler (@size-limit/esbuild) — a deliberate call
- * about a repo that ships unbundled by design, so it belongs to the owner and
- * not to the same change that re-baselines the numbers.
+ * The headroom over each measurement is deliberate but small (~10%): a budget
+ * sitting a few bytes above the measurement turns the next honest edit into a
+ * red build, and one sitting far above it stops being a gate at all.
  *
- * JS rather than JSON purely so the paragraph above can sit next to the numbers
- * it explains; size-limit rejects unknown keys in a JSON config.
+ * NOTE — this does not bound the DOWNLOAD. scripts/build-dist.mjs copies these
+ * files verbatim, so the shipped package is unminified and a store download
+ * really does carry the comments. That is a once-per-install cost; this gate
+ * exists for the per-page-load one. A ceiling on the shipped artifact would be
+ * a separate budget over dist/.
+ *
+ * JS rather than JSON purely so this paragraph can sit next to the numbers it
+ * explains; size-limit rejects unknown keys in a JSON config.
  */
 module.exports = [
     {
-        name: 'content-scripts (injected)',
-        path: [
-            'caramel-env.js',
-            'coupon-constants.generated.js',
-            'cart-signals.js',
-            'caramel-base.js',
-            'dom-utils.js',
-            'store-detect.js',
-            'coupon-apply.js',
-            'coupon-fetch.js',
-            'coupon-runner.js',
-            'UI-helpers.js',
-            'inject.js',
-        ],
-        // 2026-08-06 — 219 → 223 KB. Two behaviour changes plus the reasoning
-        // they carry: the capability gate now opens for a store with codes and
-        // no config row (store-detect.js), and the no-record branch asks the
-        // catalogue before telling a shopper we hold nothing for their store
-        // (coupon-runner.js).
-        //
-        // 2026-08-06 — 223 → 227 KB. Both live-QA fixes land in coupon-runner:
-        // reading a discount the platform records in
-        // `cart_level_discount_applications` rather than on the code entry (the
-        // shape every real cart measured that day actually uses, and whose
-        // absence silently deleted a shopper's live -$9.00), and crediting the
-        // code the cart is honouring when it is one we probed. Measured
-        // 226.71 kB.
-        //
-        // 2026-08-06 — 227 → 230 KB. The top-bar probe in UI-helpers.js became
-        // a bounded DOM sweep after eight live carts showed the old hit test
-        // could not see past a cookie scrim or into a `pointer-events:none`
-        // nav. Measured 229.68 kB.
-        //
-        // That is the THIRD raise in one day, all three for behaviour plus the
-        // measurements recorded beside it, and it is the signal the TODO above
-        // predicted: at ~1 KB of prose per fix this gate now tracks how much
-        // was explained, not how much runs. It is still doing its job — every
-        // raise here was a deliberate line in a diff — but the next person to
-        // hit it should price minified bytes instead of raising it a fourth
-        // time. That call is the owner's, per the note above.
-        //
-        // 2026-08-06 — 230 → 232 KB, and yes, that is the fourth raise, by the
-        // same session that wrote the paragraph above telling itself not to.
-        // The unpinned-header case (100percentpure) and the overlap rule that
-        // stopped the pill dodging a bar it never touched (cultbeauty) landed
-        // in UI-helpers.js. 1.2 KB of the 2.6 KB it cost was paid back by
-        // cutting prose first; deleting the rest would have meant deleting the
-        // store-by-store numbers that stop a future edit undoing the fix, which
-        // is a worse trade than a 2 KB line. Measured 231.44 kB.
-        //
-        // The standing recommendation is unchanged and now overdue: price
-        // MINIFIED bytes. Until an owner takes that call, a raise here is the
-        // honest move and a silent one still is not.
-        //
-        // 2026-08-06 — 232 → 233 KB. `_caramelUsableTitle` now drops a claim
-        // whose amount fell out of the scrape (100percentpure ships LASHES as
-        // "Get off with code"). The fix plus its comment ran 174 B over after
-        // four rounds of trimming prose elsewhere in the file, which is the
-        // clearest statement yet that this gate is measuring the wrong bytes:
-        // an afternoon can be spent shaving sentences to fit a budget whose
-        // stated purpose is bounding CODE that runs on every store page.
-        // Measured 232.17 kB.
-        //
-        // 2026-08-06 — 233 → 239 KB, two behaviour changes in one evening
-        // pass. Console silence: the dev-gated logError in caramel-base.js,
-        // because three raw console.error calls were printing into STORES'
-        // consoles on shoppers' machines (pinned by
-        // tests/console-silence.test.mjs). Cart-intent signal: store-detect's
-        // gate now opens on the URL SHAPES that drawer-cart stores actually
-        // write — measured live: allbirds 302s /cart to /?openCartDrawer=true
-        // and toms navigates it to /?open_cart=true then rewrites to bare / —
-        // where the old path-only rule saw an ordinary home page and the
-        // shopper got silence on a store we hold codes for. Measured
-        // 238.97 kB.
-        //
-        // 2026-08-06 — 239 → 249 KB. The restore step was destroying the
-        // discount it existed to protect: measured live on harney.com, the
-        // shopper's own HARNEY10 survived all eight probes, the re-apply killed
-        // it (the /discount endpoint appends, and re-sending an attached code
-        // demotes it), and `restored: true` was asserted from the REQUEST
-        // succeeding while the same log line carried the undiscounted total.
-        // The fix is three helpers in coupon-runner.js — ask whether a NAMED
-        // code is still live, clear-then-send when a restore is genuinely
-        // needed, and gate the "already applied and saving you" sentence on the
-        // money being back — plus a third modal branch for the outcome that
-        // previously had no honest wording at all (their code gone, unrecovered).
-        // ~3.5 kB of that is code; the rest is the harney measurement, stated
-        // once in coupon-apply.js and cross-referenced. A first trimming pass
-        // bought 0.7 kB; going further would delete the store-by-store numbers,
-        // which the 232→233 KB note above already ruled the worse trade.
-        // Measured 247.99 kB — the extra kB over that is deliberate headroom,
-        // not slack: 248 left ten bytes, which turns the next comment edit into
-        // a build failure that says nothing true about bundle weight.
-        // 2026-08-07 — 249 → 256 KB. The fleet-silence root-cause fix:
-        // caramelSendMessage in caramel-base.js (bounded worker waits +
-        // runtime.lastError read — the raw sendMessage form could hang the
-        // apply flow forever on an evicted worker), and store-detect's
-        // boundary now distinguishes "the API answered" from "we could not
-        // ask" (retry once, expired-cache fallback, STORE_LIST_FETCH_FAILED
-        // recorded) instead of rendering both as "unsupported store".
-        // Measured live: the worker's cold fetch of the 1.14 MB store list
-        // ran 6.7 s→>60 s against an 8 s abort, and the abort became an
-        // empty list — silence on every fresh install. ~2.5 kB is code; the
-        // rest is the measurement prose that stops the next edit undoing it.
-        // Measured 254.83 kB.
-        //
-        // 2026-08-08 — 256 → 258 KB. Two residuals in the already-applied
-        // discount handling, both in coupon-runner.js. The no-win path reported
-        // 'failed' to the trust loop with no preExistingDiscount gate, so a
-        // store refusing to stack ("cannot be combined with the discount
-        // already applied" — text that reaches lastStoreReason WITHOUT
-        // rejection vocabulary) spent a permanent verdict on a valid code; the
-        // report is now withheld, because the endpoint's vocabulary is exactly
-        // {worked, failed} and has no neutral value to send. And the
-        // zero-effect branch, which had the same snapshot in scope, hedged at
-        // shoppers whose live discount we could see and dropped the
-        // replace-warning its sibling treats as mandatory. ~0.6 kB is code and
-        // message copy; the rest states the constraint, which is the whole
-        // defence against the next edit reinstating a false 'failed'. A first
-        // pass paid back 0.7 kB by cutting prose. Measured 256.71 kB — 258
-        // rather than 257 for the same reason the 249 line gives: ~290 B of
-        // headroom makes the next comment edit a build failure that says
-        // nothing true about bundle weight. The standing recommendation above
-        // (price MINIFIED bytes) is now five raises overdue and still the
-        // owner's call.
-        //
-        // 2026-08-09 — 258 → 268 KB, all of it in caramel-base.js: opt-in cloud
-        // savings sync. A recorded saving now carries a client-generated
-        // idempotency key, the catalog coupon id its two call sites used to
-        // drop, and a sync-eligibility flag; the cap became eviction-aware; and
-        // the batched push itself lives here (one flush at a time, entries
-        // marked synced ONLY from what the server says it stored). ~5.5 kB is
-        // code. The rest records three decisions that would each be re-decided
-        // wrongly by a later edit: eligibility is frozen at RECORD time, so
-        // turning the switch on never retroactively uploads what was earned
-        // while it was off; a saving earned signed OUT is never attributed to
-        // the next account that signs in; and an entry that never reached the
-        // server is never evicted while a synced one — already safe on the
-        // account — could go instead. A trimming pass paid back 0.70 kB.
-        // Measured 266.77 kB — 268 for the same headroom reason as the 249 and
-        // 258 lines above. The standing recommendation (price MINIFIED bytes)
-        // is now six raises overdue; this change did not take it, because the
-        // file's own note puts that call with the owner and not with the change
-        // that re-baselines the numbers.
-        //
-        // 2026-08-10 — 268 → 270 KB. The consent-refusal branch in
-        // caramel-base.js's sweep: the ingest route now enforces the ACCOUNT's
-        // savings_sync_enabled column (a device setting is a cache, not a
-        // gate — proven live, a user with sync off had an event stored), and
-        // answers 403 savings_sync_disabled. ~0.4 kB is code; the rest records
-        // why that one error string is not retried like every other error,
-        // which is the whole defence against a later edit folding it back into
-        // the generic failure path and shipping an infinite retry loop. A
-        // trimming pass paid back 0.14 kB. Measured 268.33 kB.
-        limit: '270 KB',
+        name: 'content-scripts (injected, minified)',
+        path: '.size-cache/content-scripts.min.js',
+        // 2026-08-10 — measured 70.68 kB minified, from 268.33 kB of source
+        // (73.7% of the old budget was formatting and prose).
+        limit: '76 KB',
         brotli: false,
     },
     {
-        name: 'popup.js',
-        path: 'popup.js',
-        // 2026-08-09 — 54 → 60 KB, first raise for this budget. The
-        // follow-this-store star in the coupons-view header: the button markup,
-        // the star SVG in both states, and wireFavoriteStoreButton() (asks the
-        // account what it follows, paints the true state, toggles through the
-        // service worker, reverts a rejected write). ~3.5 kB is code and markup;
-        // the rest states the two constraints that would otherwise be re-decided
-        // wrongly — the star is signed-in-only, and it must live INSIDE the
-        // existing header row, because popup-sizing.test.mjs's 320px coupon-list
-        // cap is measured against everything stacked above it and a header that
-        // grew by a row would slice the last coupon card. A trimming pass paid
-        // back 0.35 kB; going further meant deleting those two, which the
-        // 232 → 233 KB note above already ruled the worse trade. Measured
-        // 59.32 kB — 60 rather than 59.5 for the same reason the 249 line gives:
-        // headroom keeps the next comment edit from failing a build for a reason
-        // that says nothing true about bundle weight.
-        //
-        // 2026-08-09 — 60 → 64 KB. The "Sync my savings" row in the settings
-        // view (signed-in only, cloning the existing .settings-row markup so it
-        // costs no CSS), its toggle handler, the polite live region, the
-        // /profile#savings deep link, and the popup-open catch-up sweep that
-        // flushes savings queued while the device was offline. ~2.0 kB is code
-        // and markup; the rest states the ordering constraint, which is the
-        // whole defence against a later edit inverting it: the account column
-        // is the authority and the DEVICE flag is what gates every upload, so a
-        // popup that cached "on" before the server confirmed would sync a
-        // shopping record against an account that never agreed. A trimming pass
-        // paid back 0.25 kB. Measured 63.39 kB — 64 for the usual headroom.
-        limit: '64 KB',
+        name: 'popup.js (minified)',
+        path: '.size-cache/popup.min.js',
+        // 2026-08-10 — measured 28.29 kB minified, from 63.39 kB of source.
+        limit: '30 KB',
         brotli: false,
     },
     {
-        name: 'background.js (sw)',
-        path: 'background.js',
-        // 2026-08-06 — 15 → 17 KB, first raise for this budget: the worker
-        // gained its own storage-recording logError (it cannot share
-        // caramel-base.js — separate context) and the tabs.onUpdated body
-        // became a named, tested function that re-arms detection when an SPA
-        // rewrites the URL. Measured 16.17 kB. Same standing note as above:
-        // the honest fix is pricing minified bytes, and that call is the
-        // owner's.
-        // 2026-08-07 — 17 → 18 KB. Part of the fleet-silence fix: the bulk
-        // supported-stores fetch gets its own 30 s budget (fetchWithTimeout
-        // grew a per-call override; 8 s stays the default for small calls)
-        // plus one retry — the measured cold fetch is the slow one and the
-        // warm retry lands in seconds. Measured 17.55 kB.
-        //
-        // 2026-08-09 — 18 → 20 KB. The two favorites actions the popup star
-        // rides on (getFavoriteStores / setFavoriteStore → the session-gated
-        // /api/account/favorites routes, via fetchCaramelApi so the stored
-        // bearer is attached in the one place that ever attaches it). ~0.9 kB is
-        // code; the rest records why a 401 is answered as an error rather than
-        // an empty list — "you follow nothing" and "we couldn't ask" are
-        // different answers and the star must not paint the first when it means
-        // the second. Measured 19.02 kB; 20 for the usual headroom.
-        //
-        // 2026-08-09 — 20 → 22 KB. The two actions savings sync rides on:
-        // syncSavings (the batched POST to /api/account/savings) and
-        // setSavingsSync (PATCH /api/account/savings-sync), both through
-        // fetchCaramelApi so the stored bearer is attached in the one place
-        // that ever attaches it. ~0.9 kB is code; the rest records why the
-        // ingest response is handed BACK to the caller instead of being
-        // swallowed the way reportOutcome's is — caramel-base.js marks an entry
-        // synced only from the ids the server says it stored, so a dropped
-        // response has to leave those entries queued for the next sweep rather
-        // than silently losing a shopper's savings. Measured 21.25 kB; 22 for
-        // the usual headroom.
-        //
-        // 2026-08-10 — 22 → 23 KB while GREEN, which needs saying out loud.
-        // The syncSavings handler now reads the error BODY on a failed status
-        // instead of collapsing it to `HTTP <status>`, so the sweep can tell
-        // the route's 403 savings_sync_disabled apart from a transient failure.
-        // Measured 21.96 kB — it fits, with 40 bytes to spare, and 40 bytes is
-        // not a budget, it is a tripwire that turns the next comment edit into
-        // a red build saying nothing true about bundle weight. Same headroom
-        // reasoning as the 249 and 258 KB lines above, applied before the fact
-        // rather than after.
-        limit: '23 KB',
+        name: 'background.js (sw, minified)',
+        path: '.size-cache/background.min.js',
+        // 2026-08-10 — measured 7.04 kB minified, from 21.96 kB of source.
+        limit: '7.5 KB',
         brotli: false,
     },
 ]

--- a/apps/caramel-extension/package.json
+++ b/apps/caramel-extension/package.json
@@ -15,11 +15,12 @@
         "test:e2e": "node scripts/test-extension.mjs",
         "test:guards": "node scripts/test-guards.mjs",
         "test:smoke": "node scripts/smoke-package.mjs ./dist production",
-        "size": "size-limit",
+        "size": "node scripts/measure-size.mjs && size-limit",
         "knip": "knip"
     },
     "devDependencies": {
         "@size-limit/file": "12.1.0",
+        "esbuild": "0.25.12",
         "eslint-config-prettier": "10.1.5",
         "eslint-plugin-html": "8.1.3",
         "eslint-plugin-import": "2.32.0",

--- a/apps/caramel-extension/scripts/measure-size.mjs
+++ b/apps/caramel-extension/scripts/measure-size.mjs
@@ -1,0 +1,92 @@
+/* Prepares what `size-limit` weighs: each shipped script, MINIFIED.
+ *
+ * The budgets used to be measured over raw source, which meant they priced
+ * prose. Every explanatory comment this codebase's house style requires was
+ * counted as if it were executable weight, and the consequence is written out
+ * across .size-limit.js: seven raises in four days, most of them paying for
+ * sentences, one of them an afternoon spent shaving comments to fit a budget
+ * whose stated purpose is bounding CODE. A gate that makes documenting a fix
+ * more expensive than shipping it is pushing in the wrong direction.
+ *
+ * So the numbers now come from minified output: comments and formatting are
+ * gone before anything is weighed, and what remains is roughly the code. Add
+ * fifty lines of explanation and the measurement does not move; add fifty
+ * lines of logic and it does.
+ *
+ * ── minify, do NOT bundle ────────────────────────────────────────────────────
+ * esbuild's transform API, one file at a time, never `build`. Bundling would
+ * tree-shake, and tree-shaking a set of files whose entry points are the
+ * BROWSER (a content script is injected, nothing imports it) would drop every
+ * top-level function as unreachable and report a fraction of the real size —
+ * a gate that reads green because it deleted the code it was supposed to
+ * weigh. Per-file transform has no cross-file view and therefore no way to
+ * decide anything is unused.
+ *
+ * ── what this does and does not bound ────────────────────────────────────────
+ * Honest caveat: the shipped package is NOT minified. scripts/build-dist.mjs
+ * copies these files verbatim, so a store download really does carry the
+ * comments. This gate deliberately does not measure that, because transfer
+ * size is a once-per-install cost while the thing worth bounding is the code
+ * that parses and runs on every store page a shopper visits. If the shipped
+ * artifact ever needs a byte ceiling too, that is a second budget over
+ * dist/ — not a reason to go back to pricing sentences.
+ */
+import { transform } from 'esbuild'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+export const CACHE_DIR = '.size-cache'
+
+/* The one place the measured file sets live. .size-limit.js points at this
+ * script's OUTPUT, so it cannot drift from this list: a file added to a group
+ * here is weighed there without touching the budgets file. Content scripts are
+ * in load order, matching manifest.json. */
+export const GROUPS = {
+    'content-scripts': [
+        'caramel-env.js',
+        'coupon-constants.generated.js',
+        'cart-signals.js',
+        'caramel-base.js',
+        'dom-utils.js',
+        'store-detect.js',
+        'coupon-apply.js',
+        'coupon-fetch.js',
+        'coupon-runner.js',
+        'UI-helpers.js',
+        'inject.js',
+    ],
+    popup: ['popup.js'],
+    background: ['background.js'],
+}
+
+/** Minified bytes of one group, written as a single file for size-limit. */
+async function buildGroup(name, files) {
+    const minified = []
+    for (const file of files) {
+        const source = await readFile(join(ROOT, file), 'utf8')
+        // A syntax error here must stop the build rather than silently
+        // measure a smaller file: esbuild throws, and nothing catches it.
+        const { code } = await transform(source, {
+            loader: 'js',
+            minify: true,
+            // Match the floor the extension already ships against (MV3 is
+            // evergreen Chrome/Firefox/Safari). A lower target would transpile
+            // modern syntax down and inflate the count with polyfilled output
+            // no browser we support would ever receive.
+            target: 'es2022',
+        })
+        minified.push(code)
+    }
+    const out = join(ROOT, CACHE_DIR, `${name}.min.js`)
+    await writeFile(out, minified.join('\n'))
+    return out
+}
+
+const cache = join(ROOT, CACHE_DIR)
+await rm(cache, { recursive: true, force: true })
+await mkdir(cache, { recursive: true })
+for (const [name, files] of Object.entries(GROUPS)) {
+    await buildGroup(name, files)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,7 +76,7 @@ importers:
         version: 9.3.0(@types/react@19.1.11)(immer@10.1.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.185.1)
       '@sentry/nextjs':
         specifier: 10.65.0
-        version: 10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(@types/node@24.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(react@19.2.3)(webpack@5.104.1(esbuild@0.25.12)(postcss@8.5.23))
+        version: 10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(@types/node@24.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(react@19.2.3)(webpack@5.104.1(postcss@8.5.23))
       '@use-gesture/react':
         specifier: 10.3.1
         version: 10.3.1(react@19.2.3)
@@ -85,7 +85,7 @@ importers:
         version: 3.0.2
       better-auth:
         specifier: 1.6.23
-        version: 1.6.23(@opentelemetry/api@1.9.1)(@prisma/client@6.14.0(prisma@6.14.0(typescript@5.9.2))(typescript@5.9.2))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(@types/node@24.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(prisma@6.14.0(typescript@5.9.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)))
+        version: 1.6.23(@opentelemetry/api@1.9.1)(@prisma/client@6.14.0(prisma@6.14.0(typescript@5.9.2))(typescript@5.9.2))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(@types/node@24.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(prisma@6.14.0(typescript@5.9.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)))
       formik:
         specifier: 2.4.9
         version: 2.4.9(@types/react@19.1.11)(react@19.2.3)
@@ -109,7 +109,7 @@ importers:
         version: 1.405.3
       posthog-node:
         specifier: 5.46.0
-        version: 5.46.0(rxjs@6.6.7)
+        version: 5.46.0
       prisma:
         specifier: 6.14.0
         version: 6.14.0(typescript@5.9.2)
@@ -242,16 +242,19 @@ importers:
         version: 5.9.2
       vite-tsconfig-paths:
         specifier: 5.1.4
-        version: 5.1.4(typescript@5.9.2)(vite@8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))
+        version: 5.1.4(typescript@5.9.2)(vite@8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))
 
   apps/caramel-extension:
     devDependencies:
       '@size-limit/file':
         specifier: 12.1.0
         version: 12.1.0(size-limit@12.1.0(jiti@2.6.1))
+      esbuild:
+        specifier: 0.25.12
+        version: 0.25.12
       eslint-config-prettier:
         specifier: 10.1.5
         version: 10.1.5(eslint@8.57.1)
@@ -287,7 +290,7 @@ importers:
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))
       web-ext:
         specifier: 8.10.0
-        version: 8.10.0(body-parser@1.20.6)(express@4.22.2)(node-fetch@2.7.0)
+        version: 8.10.0
 
 packages:
 
@@ -8794,7 +8797,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@sentry/bundler-plugins@10.65.0(rollup@4.62.2)(webpack@5.104.1(esbuild@0.25.12)(postcss@8.5.23))':
+  '@sentry/bundler-plugins@10.65.0(rollup@4.62.2)(webpack@5.104.1(postcss@8.5.23))':
     dependencies:
       '@babel/core': 7.29.7
       '@sentry/cli': 2.58.6
@@ -8805,7 +8808,7 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       rollup: 4.62.2
-      webpack: 5.104.1(esbuild@0.25.12)(postcss@8.5.23)
+      webpack: 5.104.1(postcss@8.5.23)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -8876,7 +8879,7 @@ snapshots:
       '@sentry/utils': 7.120.4
       localforage: 1.10.0
 
-  '@sentry/nextjs@10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(@types/node@24.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(react@19.2.3)(webpack@5.104.1(esbuild@0.25.12)(postcss@8.5.23))':
+  '@sentry/nextjs@10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(@types/node@24.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(react@19.2.3)(webpack@5.104.1(postcss@8.5.23))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@rollup/plugin-commonjs': 28.0.1(rollup@4.62.2)
@@ -8888,7 +8891,7 @@ snapshots:
       '@sentry/opentelemetry': 10.65.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
       '@sentry/react': 10.65.0(react@19.2.3)
       '@sentry/vercel-edge': 10.65.0
-      '@sentry/webpack-plugin': 5.4.0(rollup@4.62.2)(webpack@5.104.1(esbuild@0.25.12)(postcss@8.5.23))
+      '@sentry/webpack-plugin': 5.4.0(rollup@4.62.2)(webpack@5.104.1(postcss@8.5.23))
       next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(@types/node@24.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0)
       rollup: 4.62.2
       stacktrace-parser: 0.1.11
@@ -8984,10 +8987,10 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@sentry/core': 10.65.0
 
-  '@sentry/webpack-plugin@5.4.0(rollup@4.62.2)(webpack@5.104.1(esbuild@0.25.12)(postcss@8.5.23))':
+  '@sentry/webpack-plugin@5.4.0(rollup@4.62.2)(webpack@5.104.1(postcss@8.5.23))':
     dependencies:
-      '@sentry/bundler-plugins': 10.65.0(rollup@4.62.2)(webpack@5.104.1(esbuild@0.25.12)(postcss@8.5.23))
-      webpack: 5.104.1(esbuild@0.25.12)(postcss@8.5.23)
+      '@sentry/bundler-plugins': 10.65.0(rollup@4.62.2)(webpack@5.104.1(postcss@8.5.23))
+      webpack: 5.104.1(postcss@8.5.23)
     transitivePeerDependencies:
       - encoding
       - rollup
@@ -9440,13 +9443,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.10(vite@8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.10(vite@8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))':
     dependencies:
@@ -9575,13 +9578,13 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  addons-linter@7.20.0(body-parser@1.20.6)(express@4.22.2)(node-fetch@2.7.0):
+  addons-linter@7.20.0:
     dependencies:
       '@fluent/syntax': 0.19.0
       '@fregante/relaxed-json': 2.0.0
       '@mdn/browser-compat-data': 7.1.5
       addons-moz-compare: 1.3.0
-      addons-scanner-utils: 9.13.0(body-parser@1.20.6)(express@4.22.2)(node-fetch@2.7.0)
+      addons-scanner-utils: 9.13.0
       ajv: 8.17.1
       chalk: 4.1.2
       cheerio: 1.0.0-rc.12
@@ -9611,7 +9614,7 @@ snapshots:
 
   addons-moz-compare@1.3.0: {}
 
-  addons-scanner-utils@9.13.0(body-parser@1.20.6)(express@4.22.2)(node-fetch@2.7.0):
+  addons-scanner-utils@9.13.0:
     dependencies:
       '@types/yauzl': 2.10.3
       common-tags: 1.8.2
@@ -9619,10 +9622,6 @@ snapshots:
       strip-bom-stream: 4.0.0
       upath: 2.0.1
       yauzl: 2.10.0
-    optionalDependencies:
-      body-parser: 1.20.6
-      express: 4.22.2
-      node-fetch: 2.7.0
 
   adm-zip@0.5.18: {}
 
@@ -9878,7 +9877,7 @@ snapshots:
 
   bcryptjs@3.0.2: {}
 
-  better-auth@1.6.23(@opentelemetry/api@1.9.1)(@prisma/client@6.14.0(prisma@6.14.0(typescript@5.9.2))(typescript@5.9.2))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(@types/node@24.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(prisma@6.14.0(typescript@5.9.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))):
+  better-auth@1.6.23(@opentelemetry/api@1.9.1)(@prisma/client@6.14.0(prisma@6.14.0(typescript@5.9.2))(typescript@5.9.2))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(@types/node@24.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(prisma@6.14.0(typescript@5.9.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))):
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
@@ -9903,7 +9902,7 @@ snapshots:
       prisma: 6.14.0(typescript@5.9.2)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -10756,8 +10755,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.3
       eslint: 9.34.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.34.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.40.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.31.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.40.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.34.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.34.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.34.0(jiti@2.6.1))
@@ -10776,8 +10775,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.3
       eslint: 9.31.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.31.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.31.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.31.0(jiti@2.6.1)))(eslint@9.31.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.31.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.31.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.31.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.31.0(jiti@2.6.1))
@@ -10807,22 +10806,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.31.0(jiti@2.6.1)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.31.0(jiti@2.6.1)
-      get-tsconfig: 4.10.1
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.14
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.31.0(jiti@2.6.1))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.34.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.31.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -10833,28 +10817,44 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.40.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.31.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.40.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@9.34.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.31.0(jiti@2.6.1)))(eslint@9.31.0(jiti@2.6.1)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.31.0(jiti@2.6.1)
+      get-tsconfig: 4.10.1
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.14
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.31.0(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.40.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.31.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.40.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2)
       eslint: 9.34.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.31.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.31.0(jiti@2.6.1)))(eslint@9.31.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.31.0(jiti@2.6.1)))(eslint@9.31.0(jiti@2.6.1)))(eslint@9.31.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2)
       eslint: 9.31.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.31.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.31.0(jiti@2.6.1)))(eslint@9.31.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -10872,7 +10872,7 @@ snapshots:
     dependencies:
       htmlparser2: 10.0.0
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.40.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.40.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10883,7 +10883,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.34.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.40.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@9.34.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.40.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.31.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -10901,7 +10901,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.31.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10910,9 +10910,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 8.57.1
+      eslint: 9.31.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.31.0(jiti@2.6.1)))(eslint@9.31.0(jiti@2.6.1)))(eslint@9.31.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -10930,7 +10930,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.31.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10939,9 +10939,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.31.0(jiti@2.6.1)
+      eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.31.0(jiti@2.6.1)))(eslint@9.31.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13034,11 +13034,9 @@ snapshots:
     transitivePeerDependencies:
       - preact-render-to-string
 
-  posthog-node@5.46.0(rxjs@6.6.7):
+  posthog-node@5.46.0:
     dependencies:
       '@posthog/core': 1.46.9
-    optionalDependencies:
-      rxjs: 6.6.7
 
   potpack@1.0.2: {}
 
@@ -14042,15 +14040,14 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  terser-webpack-plugin@5.6.1(esbuild@0.25.12)(postcss@8.5.23)(webpack@5.104.1(esbuild@0.25.12)(postcss@8.5.23)):
+  terser-webpack-plugin@5.6.1(postcss@8.5.23)(webpack@5.104.1(postcss@8.5.23)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.49.0
-      webpack: 5.104.1(esbuild@0.25.12)(postcss@8.5.23)
+      webpack: 5.104.1(postcss@8.5.23)
     optionalDependencies:
-      esbuild: 0.25.12
       postcss: 8.5.23
 
   terser@5.49.0:
@@ -14449,18 +14446,18 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-tsconfig-paths@5.1.4(typescript@5.9.2)(vite@8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)):
+  vite-tsconfig-paths@5.1.4(typescript@5.9.2)(vite@8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.2)
     optionalDependencies:
-      vite: 8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3):
+  vite@8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
@@ -14469,7 +14466,6 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.3.0
-      esbuild: 0.25.12
       fsevents: 2.3.3
       jiti: 2.6.1
       sass: 1.101.0
@@ -14494,10 +14490,10 @@ snapshots:
       tsx: 4.20.6
       yaml: 2.8.3
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -14514,7 +14510,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -14571,11 +14567,11 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
-  web-ext@8.10.0(body-parser@1.20.6)(express@4.22.2)(node-fetch@2.7.0):
+  web-ext@8.10.0:
     dependencies:
       '@babel/runtime': 7.28.4
       '@devicefarmer/adbkit': 3.3.8
-      addons-linter: 7.20.0(body-parser@1.20.6)(express@4.22.2)(node-fetch@2.7.0)
+      addons-linter: 7.20.0
       camelcase: 8.0.0
       chrome-launcher: 1.2.0
       debounce: 1.2.1
@@ -14621,7 +14617,7 @@ snapshots:
 
   webpack-sources@3.5.1: {}
 
-  webpack@5.104.1(esbuild@0.25.12)(postcss@8.5.23):
+  webpack@5.104.1(postcss@8.5.23):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -14645,7 +14641,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(esbuild@0.25.12)(postcss@8.5.23)(webpack@5.104.1(esbuild@0.25.12)(postcss@8.5.23))
+      terser-webpack-plugin: 5.6.1(postcss@8.5.23)(webpack@5.104.1(postcss@8.5.23))
       watchpack: 2.5.2
       webpack-sources: 3.5.1
     transitivePeerDependencies:


### PR DESCRIPTION
The extension size budgets were measured over raw source, so they priced prose. Every explanatory comment the house style requires counted as executable weight. The record is in the file's own history: seven dated raises in four days, several buying room for sentences rather than behaviour, one session spent shaving comments to fit a ceiling whose stated purpose was bounding code that runs on every store page, and a period where the gate sat permanently red — which silently skipped the packaging step that ran after it. The file carried a standing TODO assigning the real fix to the owner. This is that fix.

`pnpm size` now runs `scripts/measure-size.mjs` first, which minifies each shipped script into a gitignored `.size-cache/`, and the budgets point at that output.

## Before / after

| Group | Raw source | Minified | Formatting + prose | Old limit | New limit |
|---|---|---|---|---|---|
| content-scripts | 268.33 kB | **70.68 kB** | 73.7% | 270 KB | **76 KB** |
| popup.js | 63.39 kB | **28.29 kB** | 55.4% | 64 KB | **30 KB** |
| background.js (sw) | 21.96 kB | **7.04 kB** | 68.0% | 23 KB | **7.5 KB** |

Roughly three-quarters of the old content-script budget was never code. Headroom is now ~7% rather than the ad-hoc padding the old notes kept arguing for — a minified measurement only moves when logic moves, so the budget can afford to be tight, which is the point of having one.

## Minify, do not bundle

`esbuild.transform`, one file at a time, never `build`. Bundling would tree-shake, and tree-shaking files whose entry point is the *browser* (a content script is injected; nothing imports it) would drop every top-level function as unreachable and report a fraction of the real size — a gate reading green because it deleted the code it was supposed to weigh. Per-file transform has no cross-file view and so no way to decide anything is unused.

Verified rather than assumed: all **116** top-level function declarations in the content-script set survive into the minified output, none missing. The growth red-proof below is the same property observed from the other side.

`esbuild` is pinned exactly at `0.25.12` — the version vite/vitest already installs in this workspace, so the gate adds no second platform binary to the store. Not `0.28.2` (current latest) purely to avoid the duplicate download; if vitest moves, matching it is a one-line change.

## Red-proofs

**1 — a large COMMENT no longer moves the measurement (the whole point).** Prepended 1,200 comment lines (**111,690 bytes**) to `caramel-base.js`:

```
content-scripts:  Size: 70.68 kB   (limit 76 kB)  — unchanged, to the byte
```

Under the old raw-source gate that same edit would have blown the budget by ~111 kB. Reverted.

**2 — real growth still fails the build.** Appended 300 reachable top-level functions doing arithmetic and string work (84,045 source bytes) to the same file:

```
Package size limit has exceeded by 40.02 kB
Size limit: 76 kB
Size:       116.02 kB
ELIFECYCLE  Command failed with exit code 1
```

70.68 → 116.02 kB, non-zero exit. Note those 300 functions are never *called* — every one was still counted, which is the no-tree-shaking guarantee measured directly. Reverted; back to 70.68 / 28.29 / 7.04 kB, green.

## Caveat, stated in the config

This does not bound the DOWNLOAD. `scripts/build-dist.mjs` copies files verbatim, so the shipped package is unminified and a store download really does carry the comments. That is a once-per-install cost; this gate exists for the per-page-load one. A ceiling on the shipped artifact would be a separate budget over `dist/`, not a reason to go back to pricing sentences. The old file's 200 lines of dated raises and its TODO are gone, replaced by a short note on what is measured and why.

The measured file lists now live in one place (`measure-size.mjs`), and `.size-limit.js` points at its output — a file added to a group is weighed without touching the budgets file.

## Gates

extension suite 718 · `test:guards` 57/57 · build + package smoke pass (`.size-cache` cannot leak into `dist/` — the build ships an explicit allowlist) · eslint exit 0 · oxlint exit 0 · prettier clean · knip ok · `tsc --noEmit` clean.
