### PR TITLE
feat(extension): popup coupon list scrolls through every code a store has, not just the first 20

### DIFF
--- a/apps/caramel-app/src/lib/couponsRepo.ts
+++ b/apps/caramel-app/src/lib/couponsRepo.ts
@@ -73,8 +73,21 @@ import { randomUUID } from 'node:crypto'
 const visibleCouponsWhere = () =>
     Prisma.sql`status IN (${Prisma.join([...VISIBLE_COUPON_STATUSES])}) AND expired = FALSE`
 
-/** Shared ranking order — the list query and the marketing store page both sort by this identical order. */
-const rankingOrderSql = () => Prisma.sql`rating DESC, created_at DESC`
+/**
+ * Shared ranking order — the list query and the marketing store page both sort
+ * by this identical order.
+ *
+ * `id` is a TIEBREAKER, not a ranking signal, and it is load-bearing for
+ * OFFSET pagination. `rating DESC, created_at DESC` alone is not a total order:
+ * a store's coupons routinely share a rating (0 is the default) and can share a
+ * created_at down to the ingest batch, and Postgres is free to return tied rows
+ * in a different physical order per query. Two requests that differ only by
+ * OFFSET are two separate queries, so a tied row could be returned by both
+ * (a duplicate) or by neither (a row the shopper can never reach — the failure
+ * mode a client-side dedupe cannot see). Appending the primary key makes the
+ * sort total, so page N+1 resumes exactly where page N stopped.
+ */
+const rankingOrderSql = () => Prisma.sql`rating DESC, created_at DESC, id DESC`
 
 /**
  * coupons/stats/route.ts's census predicate. Deliberately NOT

--- a/apps/caramel-app/tests/unit/coupons-pagination.test.ts
+++ b/apps/caramel-app/tests/unit/coupons-pagination.test.ts
@@ -1,0 +1,247 @@
+import { GET as couponsGET } from '@/app/api/coupons/route'
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The paging contract of /api/coupons, written when the extension popup started
+// consuming it (2026-08-10). The popup previously asked for 20 codes and showed
+// whatever came back — eBay held 96 — so the popup now walks pages, and this
+// route is what it walks.
+//
+// The route already accepted `page`/`limit` and already answered with a
+// `page/limit/total/hasMore` envelope. That is precisely why the FIRST thing
+// here is a characterization of the un-paginated call: a shipped extension, the
+// SSR site and the toolbar badge all call this route without paging params, and
+// none of them may notice that a new consumer arrived. Everything after that
+// pins the paging behavior the popup now depends on.
+//
+// `@/lib/prisma` is mocked as a recording resolver keyed on the composed `.sql`
+// (the coupons-read-boundary.test.ts pattern), with the bound VALUES captured
+// too — LIMIT/OFFSET are parameters, so the values array is where the offset
+// arithmetic is actually visible.
+
+type Captured = { sql: string; values: unknown[] }
+let capturedQueries: Captured[] = []
+let catalogRows: unknown[] = []
+let totalRows: unknown[] = []
+
+vi.mock('@/lib/prisma', () => ({
+    default: {
+        $queryRaw: (arg: { sql: string; values: unknown[] }) => {
+            capturedQueries.push({ sql: arg.sql, values: arg.values })
+            const isCount =
+                arg.sql.includes('COUNT(*)') && !arg.sql.includes('LIMIT')
+            return Promise.resolve(isCount ? totalRows : catalogRows)
+        },
+        couponSignal: { findMany: vi.fn(async () => []) },
+    },
+}))
+
+vi.mock('@/lib/rateLimit', () => ({
+    checkRateLimit: async () => null,
+    isTrustedServer: () => false,
+    isOriginAllowed: () => true,
+    forbiddenOrigin: () =>
+        new Response(JSON.stringify({ error: 'Forbidden origin' }), {
+            status: 403,
+        }),
+}))
+
+/** One production-shaped catalog row (numeric columns arrive as strings). */
+function row(n: number) {
+    return {
+        id: String(n),
+        code: `SAVE${n}`,
+        site: 'ebay.com',
+        title: `Deal ${n}`,
+        description: `Description ${n}`,
+        rating: '4.5',
+        discount_type: 'PERCENTAGE',
+        discount_amount: '10',
+        expiry: null,
+        expired: false,
+        timesUsed: 3,
+        status: 'valid',
+        verificationMessage: null,
+    }
+}
+
+const CATALOG_TOTAL = 96
+
+function serve(rows: number[], total = CATALOG_TOTAL) {
+    catalogRows = rows.map(row)
+    totalRows = [{ total }]
+}
+
+async function call(query: string) {
+    const res = await couponsGET(
+        new NextRequest(`http://localhost/api/coupons${query}`),
+    )
+    return { res, body: await res.json() }
+}
+
+/** The list query (the one carrying LIMIT/OFFSET), not the count query. */
+function listQuery() {
+    const q = capturedQueries.find(
+        c => c.sql.includes('FROM coupons') && c.sql.includes('LIMIT'),
+    )
+    expect(q, 'the route issued a list query').toBeDefined()
+    return q!
+}
+
+/** LIMIT and OFFSET are the last two bound parameters of the list query. */
+function limitAndOffset() {
+    const { values } = listQuery()
+    return {
+        limit: values[values.length - 2],
+        offset: values[values.length - 1],
+    }
+}
+
+beforeEach(() => {
+    capturedQueries = []
+    serve([1, 2, 3])
+})
+
+describe('/api/coupons — the un-paginated call is UNCHANGED (characterization)', () => {
+    it('a bare GET still answers the exact same envelope: page 1, limit 10, total, hasMore, coupons', async () => {
+        serve([1, 2, 3], 3)
+        const { res, body } = await call('')
+
+        expect(res.status).toBe(200)
+        // Byte-for-byte: the key set, the values, and nothing new.
+        expect(Object.keys(body).sort()).toEqual([
+            'coupons',
+            'hasMore',
+            'limit',
+            'page',
+            'total',
+        ])
+        expect(body.page).toBe(1)
+        expect(body.limit).toBe(10)
+        expect(body.total).toBe(3)
+        expect(body.hasMore).toBe(false)
+        expect(body.coupons).toHaveLength(3)
+        expect(body.coupons[0]).toMatchObject({
+            id: '1',
+            code: 'SAVE1',
+            site: 'ebay.com',
+            rating: 4.5,
+            lastWorkedAt: null,
+        })
+    })
+
+    it('still defaults to LIMIT 10 OFFSET 0 and the 60s edge cache', async () => {
+        const { res } = await call('')
+
+        expect(limitAndOffset()).toEqual({ limit: 10, offset: 0 })
+        expect(res.headers.get('Cache-Control')).toBe(
+            'public, s-maxage=60, stale-while-revalidate=60',
+        )
+    })
+
+    it("the extension's own un-paginated call (site + key_words + limit=20) is untouched", async () => {
+        // This is the request every SHIPPED extension makes, verbatim.
+        const { res, body } = await call('?site=ebay.com&key_words=&limit=20')
+
+        expect(res.status).toBe(200)
+        expect(limitAndOffset()).toEqual({ limit: 20, offset: 0 })
+        expect(body.page).toBe(1)
+        expect(body.limit).toBe(20)
+    })
+})
+
+describe('/api/coupons — paging', () => {
+    it('page N asks the catalog for the right window and reports it back', async () => {
+        serve([21, 22, 23])
+        const { body } = await call('?site=ebay.com&limit=20&page=2')
+
+        expect(limitAndOffset()).toEqual({ limit: 20, offset: 20 })
+        expect(body.page).toBe(2)
+        expect(body.limit).toBe(20)
+        expect(body.coupons.map((c: { code: string }) => c.code)).toEqual([
+            'SAVE21',
+            'SAVE22',
+            'SAVE23',
+        ])
+    })
+
+    it('hasMore is true while the window ends before the total, and false on the last page', async () => {
+        // Positive precondition first: a middle page really does report more.
+        serve(
+            Array.from({ length: 20 }, (_, i) => i + 21),
+            96,
+        )
+        const middle = await call('?site=ebay.com&limit=20&page=2')
+        expect(middle.body.hasMore).toBe(true)
+        expect(middle.body.total).toBe(96)
+
+        capturedQueries = []
+        // Last page: offset 80 + 16 rows = 96, exactly the total.
+        serve(
+            Array.from({ length: 16 }, (_, i) => i + 81),
+            96,
+        )
+        const last = await call('?site=ebay.com&limit=20&page=5')
+        expect(last.body.coupons).toHaveLength(16)
+        expect(last.body.hasMore).toBe(false)
+    })
+
+    it('an offset past the end is an empty last page, not an error', async () => {
+        serve([], 96)
+        const { res, body } = await call('?site=ebay.com&limit=20&page=99')
+
+        expect(res.status).toBe(200)
+        expect(body.coupons).toEqual([])
+        expect(body.total).toBe(96)
+        expect(body.hasMore).toBe(false)
+        expect(limitAndOffset()).toEqual({ limit: 20, offset: 20 * 98 })
+    })
+})
+
+describe('/api/coupons — the caps a client cannot talk past', () => {
+    it('limit is capped at 50 however large the caller asks', async () => {
+        await call('?limit=5000')
+        expect(limitAndOffset().limit).toBe(50)
+    })
+
+    it.each([
+        ['?limit=0', 10],
+        ['?limit=-5', 10],
+        ['?limit=abc', 10],
+        ['?limit=', 10],
+        ['?limit=25', 25],
+    ])('limit %s resolves to %i', async (query, expected) => {
+        await call(query)
+        expect(limitAndOffset().limit).toBe(expected)
+    })
+
+    it('page is capped at 500, so the catalog cannot be walked indefinitely', async () => {
+        await call('?limit=50&page=999999')
+        expect(limitAndOffset().offset).toBe(50 * 499)
+    })
+
+    it.each([
+        ['?page=0', 0],
+        ['?page=-3', 0],
+        ['?page=abc', 0],
+        ['?page=3', 20],
+    ])('page %s resolves to offset %i at limit 10', async (query, offset) => {
+        await call(`${query}&limit=10`)
+        expect(limitAndOffset().offset).toBe(offset)
+    })
+})
+
+describe('/api/coupons — the sort that makes paging sound', () => {
+    it('orders by a TOTAL order: the ranking, then the primary key as tiebreaker', async () => {
+        await call('?site=ebay.com&limit=20&page=2')
+
+        // Without the id tiebreaker, `rating DESC, created_at DESC` leaves tied
+        // rows in an order Postgres may choose differently per query — and two
+        // pages are two queries, so a tied row can be served twice or never.
+        // The second case is the dangerous one: no client-side dedupe can see a
+        // row that was never sent.
+        expect(listQuery().sql).toContain(
+            'ORDER BY rating DESC, created_at DESC, id DESC',
+        )
+    })
+})

--- a/apps/caramel-app/tests/unit/no-raw-coupon-status.test.ts
+++ b/apps/caramel-app/tests/unit/no-raw-coupon-status.test.ts
@@ -76,6 +76,13 @@ const SKIP_DIR_NAMES = new Set([
     'dist',
     '.git',
     'coverage',
+    // Minified copies of the shipped extension files, written by
+    // `pnpm --filter caramel-extension size` and gitignored. They are the SAME
+    // sources this gate already walks, so scanning them adds nothing — but
+    // minification inlines the generated constants, so every run of the size
+    // gate left this suite red for anyone who then ran the app tests locally.
+    // A gate that fires on its own build output is noise, not a finding.
+    '.size-cache',
 ])
 
 function walk(dir: string, extensions: string[]): string[] {

--- a/apps/caramel-extension/.size-limit.js
+++ b/apps/caramel-extension/.size-limit.js
@@ -45,14 +45,26 @@ module.exports = [
         name: 'popup.js (minified)',
         path: '.size-cache/popup.min.js',
         // 2026-08-10 — measured 28.29 kB minified, from 63.39 kB of source.
-        limit: '30 KB',
+        // 2026-08-10, raised 30 -> 33 kB: the coupon list paginates. A store
+        // can hold far more codes than one request returns (eBay: 96 against a
+        // page of 20) and the popup showed the first page as if it were the
+        // whole store. The 2.7 kB buys an IntersectionObserver sentinel, the
+        // fetch-append-dedupe loop, the four footer states (loading / end /
+        // retry / no-observer button) and delegated copy handlers so appended
+        // rows work — real behaviour, measured 30.97 kB.
+        limit: '33 KB',
         brotli: false,
     },
     {
         name: 'background.js (sw, minified)',
         path: '.size-cache/background.min.js',
         // 2026-08-10 — measured 7.04 kB minified, from 21.96 kB of source.
-        limit: '7.5 KB',
+        // 2026-08-10, raised 7.5 -> 7.8 kB: the fetchCoupons branch forwards a
+        // page number and passes the route's page/total/hasMore envelope back
+        // to the popup (measured 7.3 kB). Raised rather than left at 2.7%
+        // headroom, which is close enough to the ceiling to red the next
+        // honest edit — see the headroom note above.
+        limit: '7.8 KB',
         brotli: false,
     },
 ]

--- a/apps/caramel-extension/assets/styles.css
+++ b/apps/caramel-extension/assets/styles.css
@@ -489,6 +489,21 @@ body {
     scrollbar-width: thin;
     scrollbar-color: var(--cm-scrollbar) transparent;
 }
+/* Bottom of the list: the IntersectionObserver's target while more pages
+   exist, and afterwards the "that's all of them" line. It holds a
+   .skeleton.skeleton-ticket ghost while loading — the same shimmer the popup
+   opens with, so a page arriving looks like the popup already does, and the
+   ghost's real height is what makes the observer's boundary crossing reliable.
+   Only the box needs describing here; the states reuse existing classes. */
+.coupon-list-footer {
+    margin-bottom: 12px; /* matches .coupon-item's rhythm */
+}
+.coupon-list-note {
+    margin: 4px 0 2px;
+    text-align: center;
+    font-size: var(--cm-text-xs);
+    color: var(--cm-text-secondary);
+}
 .coupon-list::-webkit-scrollbar {
     width: 8px;
 }

--- a/apps/caramel-extension/background.js
+++ b/apps/caramel-extension/background.js
@@ -45,6 +45,13 @@ const logError = (where, err) => {
     if (globalThis.CARAMEL_ENV.verbose) console.error('Caramel:', where, err)
 }
 
+/* How many coupons one fetchCoupons request asks for. The number the popup
+ * paginates in, and the number the apply flow works from on its first (usually
+ * only) page. 20 has always been this value; it lives in a named constant now
+ * because a second caller — the popup's next-page request — has to agree with
+ * it, and the route's own ceiling is 50. */
+const COUPON_PAGE_SIZE = 20
+
 const FETCH_TIMEOUT_MS = 8000
 // One budget does not fit both shapes of call we make. The store list is a
 // bulk payload (~1.14 MB, 2670 stores) and the small JSON calls are a few KB.
@@ -294,12 +301,19 @@ currentBrowser.runtime.onMessage.addListener(
 
             return true
         } else if (message.action === 'fetchCoupons') {
-            const { site, kw, category } = message
+            const { site, kw, category, page } = message
             const url = new URL(caramelUrl('api/coupons'))
             url.searchParams.set('site', site)
             url.searchParams.set('key_words', kw || '')
-            url.searchParams.set('limit', '20')
+            url.searchParams.set('limit', String(COUPON_PAGE_SIZE))
             if (category) url.searchParams.set('category', category)
+            // `page` is omitted entirely for page 1 so a caller that doesn't
+            // paginate produces the exact URL this handler has always produced
+            // (the route defaults to page=1). Bounded to the route's own cap of
+            // 500 rather than forwarded raw.
+            const wanted = Number(page)
+            if (Number.isFinite(wanted) && wanted > 1)
+                url.searchParams.set('page', String(Math.min(wanted, 500)))
             if (globalThis.CARAMEL_ENV.verbose)
                 console.log('BACKGROUND: fetchCoupons', {
                     site,
@@ -311,10 +325,26 @@ currentBrowser.runtime.onMessage.addListener(
                 .then(async r => {
                     if (!r.ok) return { error: `HTTP ${r.status}` }
                     const json = await r.json()
+                    const coupons = Array.isArray(json)
+                        ? json
+                        : json.coupons || []
+                    // The page envelope rides along so the popup can page
+                    // through a catalog deeper than one request (eBay had 96
+                    // codes while the popup only ever showed 20). A bare-array
+                    // response — or any older shape without the envelope —
+                    // degrades to "this is all there is", which is what every
+                    // caller assumed before this existed.
                     return {
-                        coupons: Array.isArray(json)
-                            ? json
-                            : json.coupons || [],
+                        coupons,
+                        page:
+                            typeof json.page === 'number' && json.page > 0
+                                ? json.page
+                                : 1,
+                        total:
+                            typeof json.total === 'number'
+                                ? json.total
+                                : coupons.length,
+                        hasMore: json.hasMore === true,
                     }
                 })
                 .then(resp => sendResponse(resp))

--- a/apps/caramel-extension/coupon-fetch.js
+++ b/apps/caramel-extension/coupon-fetch.js
@@ -1,13 +1,25 @@
-// owns: coupon list fetch + classify (fetchCoupons, RESTRICTED_STATUSES, classifyCartCategory, getCoupons)
+// owns: coupon list fetch + classify (fetchCouponsPage, fetchCoupons, RESTRICTED_STATUSES, classifyCartCategory, getCoupons)
 // load after: caramel-base.js, dom-utils.js, store-detect.js, coupon-apply.js, and coupon-constants.generated.js (window.CaramelCoupons — loaded first in every manifest/index.html)
 
 /* --------------------------------------------------  coupon list */
-// Called from other split content-script files (cross-file content-script
-// call — oxlint's per-file analysis can't see it).
+/* ONE page of the store's codes, envelope included.
+ *
+ * fetchCoupons() below is this function with the envelope thrown away, and is
+ * still what the apply flow calls — it only ever wants the best codes it can
+ * try, and page 1 is ranked. The popup calls THIS one, because a shopper
+ * scrolling the list needs to know whether the list ends where it stops: eBay
+ * had 96 live codes on the day the popup was showing 20, with nothing in the
+ * UI to suggest the other 76 existed.
+ *
+ * Resolves `{ coupons, page, total, hasMore }`. A backend that answers without
+ * the envelope (older deploy, bare array) degrades to hasMore:false — "this is
+ * all there is" — which is exactly the behavior that shipped before paging. */
+// Called from popup.js and from fetchCoupons below (cross-file call — oxlint's
+// per-file analysis can't see the popup one).
 // oxlint-disable-next-line no-unused-vars
-async function fetchCoupons(site, kw, category) {
+async function fetchCouponsPage(site, kw, category, page) {
     // Delegate network fetch to background/service worker to avoid CORS failures
-    const meta = { site, kw, category }
+    const meta = { site, kw, category, page }
     try {
         log(
             'AUTO_INSERT_FETCHCOUPONS_START',
@@ -24,6 +36,7 @@ async function fetchCoupons(site, kw, category) {
             site,
             kw,
             category,
+            page,
         })
         if (resp?.error) {
             log('fetchCoupons background error', resp.error)
@@ -40,7 +53,12 @@ async function fetchCoupons(site, kw, category) {
         })
         recordTiming('AUTO_INSERT_FETCHCOUPONS_END', { count: d.length })
         log('Fetched', d.length, 'coupons')
-        return d
+        return {
+            coupons: d,
+            page: typeof resp?.page === 'number' ? resp.page : 1,
+            total: typeof resp?.total === 'number' ? resp.total : d.length,
+            hasMore: resp?.hasMore === true,
+        }
     } catch (e) {
         log('fetchCoupons error', e)
         recordTiming('AUTO_INSERT_FETCHCOUPONS_END', {
@@ -49,6 +67,18 @@ async function fetchCoupons(site, kw, category) {
         })
         throw e
     }
+}
+
+/* The codes themselves, page 1, nothing else — the shape every caller outside
+ * the popup wants and the shape this name has always had. Kept as a wrapper
+ * rather than a second request path so there is exactly one place that talks to
+ * the service worker about coupons. */
+// Called from other split content-script files (cross-file content-script
+// call — oxlint's per-file analysis can't see it).
+// oxlint-disable-next-line no-unused-vars
+async function fetchCoupons(site, kw, category) {
+    const { coupons } = await fetchCouponsPage(site, kw, category, 1)
+    return coupons
 }
 // Statuses that signal a coupon has restrictions the user might trip over.
 // When ANY returned coupon carries one of these, we classify the cart so the

--- a/apps/caramel-extension/popup.js
+++ b/apps/caramel-extension/popup.js
@@ -1,4 +1,4 @@
-/* global currentBrowser, fetchCoupons */
+/* global currentBrowser, fetchCouponsPage */
 
 // Base URL from the build-time environment stamp (caramel-env.js, the first
 // script index.html loads). This used to call a shared `_isDevInstall()` that
@@ -332,16 +332,22 @@ async function initPopup() {
                     // regex-stripping, or the path/query would ride along into
                     // the coupons API's site parameter.
                     const domain = new URL(url).hostname.replace(/^www\./, '')
-                    let coupons = []
+                    // The ENVELOPE, not just the codes: a store can hold far
+                    // more coupons than one request returns (eBay: 96 against a
+                    // page of 20), and `total`/`hasMore` are what let the list
+                    // keep going as the shopper scrolls instead of ending
+                    // silently at the first page.
+                    let page = { coupons: [] }
                     try {
-                        coupons = await fetchCoupons(domain, '')
+                        page = await fetchCouponsPage(domain, '', '', 1)
                     } catch {
                         renderLoadError()
                         return
                     }
+                    const coupons = page.coupons
 
                     if (coupons?.length) {
-                        await renderCouponsView(coupons, user, domain)
+                        await renderCouponsView(coupons, user, domain, page)
                     } else {
                         renderUnsupportedSite(user, domain)
                     }
@@ -1203,8 +1209,260 @@ function wireFavoriteStoreButton(domain) {
 /* ------------------------------------------------------------ */
 /*  Coupons view                                                */
 /* ------------------------------------------------------------ */
-function renderCouponsView(coupons, user, domain) {
+
+/* One coupon card. Extracted from renderCouponsView's template so the FIRST
+ * page and every appended page are built by the same code — a second copy of
+ * this markup is how an appended row quietly loses a badge or a warning. */
+function couponItemHtml(c) {
+    // Sourced from window.CaramelCoupons
+    // (coupon-constants.generated.js, loaded before
+    // this file — F-006) instead of a hard-coded
+    // literal, so this can't re-drift from the app's
+    // src/lib/coupons.ts.
+    const restrictedSet = new Set(window.CaramelCoupons.RESTRICTED_STATUSES)
+    const isRestricted = restrictedSet.has(c.status)
+    const isDead = c.status === 'invalid' || c.status === 'expired'
+    let warning = ''
+    if (isRestricted) {
+        const baseMsg =
+            c.status === 'category_restricted'
+                ? 'Limited to specific categories'
+                : c.status === 'seller_specific'
+                  ? 'Only for items from a specific seller'
+                  : c.status === 'valid_with_warning'
+                    ? 'May have restrictions'
+                    : 'Limited to specific items'
+        const cartHint = c.cartCategory
+            ? ` — your cart looks like <b>${escHtml(c.cartCategory)}</b>${c.cartCategorySecondary ? ` / ${escHtml(c.cartCategorySecondary)}` : ''}`
+            : ''
+        const verifierMsg = c.verificationMessage
+            ? `<div class="coupon-restriction-detail">${escHtml(c.verificationMessage)}</div>`
+            : ''
+        warning = `
+              <div class="coupon-restriction" title="${escHtml(c.verificationMessage || baseMsg)}">
+                <span class="coupon-restriction-icon" aria-hidden="true">
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+                    <path d="M12 9v4"/>
+                    <path d="M12 17h.01"/>
+                  </svg>
+                </span>
+                <span class="coupon-restriction-text">${baseMsg}${cartHint}</span>
+                ${verifierMsg}
+              </div>`
+    }
+    // Verification badge: green=verified, amber=restricted,
+    // grey=not yet verified (grace), red=known not valid.
+    // Labels + which status maps to which tier come from
+    // window.CaramelCoupons.STATUS_META
+    // (coupon-constants.generated.js, F-006); the tier
+    // palette lives in styles.css as
+    // .coupon-badge--<tier> classes on tokens (with dark
+    // values — the app's coupon-card.tsx keeps its own
+    // Tailwind equivalent; the 4-tier axis can't drift
+    // the way the 9-status axis did).
+    const meta = window.CaramelCoupons.STATUS_META[c.status]
+    const badge = meta
+        ? `<span class="coupon-badge coupon-badge--${meta.tier}" title="${escHtml(c.verificationMessage || '')}">${meta.label}</span>`
+        : ''
+    // App-owned trust signal (W1): "worked Xh ago" when
+    // the extension last reported this coupon working
+    // (<7 days). '' (unshown) until W2 wires the report.
+    const workedAgo = formatWorkedAgo(c.lastWorkedAt)
+    return `
+            <div data-code="${escHtml(c.code)}" role="button" tabindex="0" aria-label="${escHtml((c.title || 'Coupon') + ' — copy code ' + c.code)}" class="coupon-item${isRestricted ? ' coupon-item-restricted' : ''}${isDead ? ' coupon-item-dead' : ''}">
+              <div class="coupon-head">
+                <div class="coupon-title">${escHtml(c.title || 'Untitled Coupon')}</div>
+                ${badge}
+                ${workedAgo ? `<span class="coupon-worked-ago">${escHtml(workedAgo)}</span>` : ''}
+              </div>
+              ${c.description ? `<div class="coupon-desc">${escHtml(c.description)}</div>` : ''}
+              ${warning}
+              <div class="coupon-code-row">
+                <span class="coupon-code">${escHtml(c.code)}</span>
+                <span class="coupon-copy">
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <rect x="9" y="9" width="11" height="11" rx="2.5" stroke="currentColor" stroke-width="2"/>
+                    <path d="M5 15V5.5A2.5 2.5 0 0 1 7.5 3H15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                  </svg>
+                  Copy
+                </span>
+              </div>
+            </div>`
+}
+
+/* Identity of a coupon ACROSS requests, for the append dedupe.
+ *
+ * Offset paging over a live catalog is not a snapshot: an ingest between page 1
+ * and page 2 can shift a row across the boundary and hand it to us twice. The
+ * catalog id is the real identity; a code is the fallback for the rare row that
+ * arrives without one, and is unique per store in practice. */
+function couponIdentity(c) {
+    return c?.id != null ? `id:${c.id}` : `code:${c?.code}`
+}
+
+/* How many consecutive all-duplicate pages to chase before handing the shopper
+ * a button instead. Small on purpose: the point is to get past one shifted
+ * page, not to walk a catalog the backend keeps re-serving. */
+const COUPON_PAGE_EMPTY_LIMIT = 3
+
+/* Wording for the bottom of the list. "N codes" counts what the CATALOG holds
+ * for this store, which is the number the shopper is really asking about when
+ * they scroll to the end. */
+function couponListEndHtml(total) {
+    return `<p class="coupon-list-note">${
+        total === 1
+            ? "That's the only code we have"
+            : `You've seen all ${total} codes`
+    }</p>`
+}
+
+/* Repaints the footer of the list for one of four states. It is also the
+ * IntersectionObserver's target: giving it real height while more pages exist
+ * (a ghost card, the same shimmer the popup opens with) is what makes crossing
+ * into view a reliable signal, and it doubles as the "more is coming" cue. */
+function paintCouponListFooter(footer, state, paging) {
+    if (!footer) return
+    footer.dataset.state = state
+    if (state === 'loading' || state === 'idle') {
+        footer.innerHTML =
+            '<div class="skeleton skeleton-ticket" aria-hidden="true"></div>'
+        footer.setAttribute('aria-busy', 'true')
+    } else if (state === 'error') {
+        // Quiet, not an error banner: the codes already on screen are still
+        // good, and one tap retries. Spamming a failure over a working list
+        // would be a worse trade than a button that says what it does.
+        footer.removeAttribute('aria-busy')
+        footer.innerHTML =
+            '<button type="button" id="couponLoadMoreBtn" class="supported-sites-btn">Load more codes</button>'
+    } else {
+        footer.removeAttribute('aria-busy')
+        footer.innerHTML = couponListEndHtml(paging.total)
+    }
+}
+
+/* Fetches the next page and appends it. Every exit leaves the footer in a state
+ * the shopper can act on — never a spinner that spins forever. */
+async function loadMoreCoupons(paging) {
+    if (paging.loading || !paging.hasMore) return
+    const list = document.getElementById('couponList')
+    const footer = document.getElementById('couponListFooter')
+    if (!list || !footer) return
+    paging.loading = true
+    paintCouponListFooter(footer, 'loading', paging)
+    try {
+        const next = await fetchCouponsPage(
+            paging.domain,
+            '',
+            '',
+            paging.page + 1,
+        )
+        // Trust the server's own page number when it sends one — an offset it
+        // clamped is the offset the rows actually came from, and resuming from
+        // our optimistic guess instead would silently re-request the same page.
+        paging.page =
+            typeof next.page === 'number' ? next.page : paging.page + 1
+        if (typeof next.total === 'number') paging.total = next.total
+        paging.hasMore = next.hasMore === true
+
+        const fresh = (next.coupons || []).filter(c => {
+            const key = couponIdentity(c)
+            if (paging.seen.has(key)) return false
+            paging.seen.add(key)
+            return true
+        })
+        if (fresh.length) {
+            paging.empty = 0
+            footer.insertAdjacentHTML(
+                'beforebegin',
+                fresh.map(couponItemHtml).join(''),
+            )
+        } else {
+            paging.empty += 1
+        }
+
+        if (!paging.hasMore) {
+            paintCouponListFooter(footer, 'end', paging)
+            stopCouponPaging(paging)
+            return
+        }
+        // A page that was entirely duplicates leaves the footer exactly where
+        // it was, so the observer has no boundary left to cross and would wait
+        // forever. Pull the next page ourselves — but only a few times, so a
+        // backend insisting there is more while returning nothing new ends at a
+        // button the shopper can press rather than in a loop.
+        if (fresh.length) {
+            paintCouponListFooter(footer, 'idle', paging)
+        } else if (paging.empty >= COUPON_PAGE_EMPTY_LIMIT) {
+            paintCouponListFooter(footer, 'error', paging)
+        } else {
+            paintCouponListFooter(footer, 'idle', paging)
+            paging.loading = false
+            await loadMoreCoupons(paging)
+        }
+    } catch (err) {
+        log('COUPON_PAGE_FAILED', err?.message)
+        paintCouponListFooter(footer, 'error', paging)
+    } finally {
+        paging.loading = false
+    }
+}
+
+function stopCouponPaging(paging) {
+    if (paging.observer) {
+        paging.observer.disconnect()
+        paging.observer = null
+    }
+}
+
+/* Wires the footer up. The observer is the intended path — it works in an
+ * extension popup, with the scrolling .coupon-list itself as the root — and the
+ * button is what a realm without IntersectionObserver gets instead. Both end up
+ * calling the same loader, and the button is ALSO what a failed page falls back
+ * to, so the retry affordance is never a second implementation. */
+function wireCouponPaging(paging) {
+    const list = document.getElementById('couponList')
+    const footer = document.getElementById('couponListFooter')
+    if (!list || !footer || !paging.hasMore) return
+
+    // One delegated listener for the footer, so the retry button keeps working
+    // no matter how many times the footer is repainted.
+    footer.addEventListener('click', e => {
+        if (e.target.closest('#couponLoadMoreBtn')) loadMoreCoupons(paging)
+    })
+
+    if (typeof IntersectionObserver !== 'function') {
+        paintCouponListFooter(footer, 'error', paging)
+        return
+    }
+    paging.observer = new IntersectionObserver(
+        entries => {
+            if (entries.some(entry => entry.isIntersecting))
+                loadMoreCoupons(paging)
+        },
+        // rootMargin pulls the trigger a card's height early so the next page
+        // is usually already there when the shopper reaches the bottom.
+        { root: list, rootMargin: '120px' },
+    )
+    paging.observer.observe(footer)
+}
+
+function renderCouponsView(coupons, user, domain, meta) {
     const container = document.getElementById('auth-container')
+
+    /* Paging state for THIS render. `meta` is the envelope initPopup got with
+     * page 1; without it (every caller that just wants a list painted) the view
+     * behaves exactly as it did before paging existed — one page, no footer. */
+    const paging = {
+        domain,
+        page: typeof meta?.page === 'number' ? meta.page : 1,
+        total: typeof meta?.total === 'number' ? meta.total : coupons.length,
+        hasMore: meta?.hasMore === true && coupons.length > 0,
+        loading: false,
+        empty: 0,
+        seen: new Set(coupons.map(couponIdentity)),
+        observer: null,
+    }
 
     const headerLeft = user
         ? `
@@ -1252,90 +1510,9 @@ function renderCouponsView(coupons, user, domain) {
         ${
             coupons.length === 0
                 ? '<p>No coupons available for this store right now.</p>'
-                : coupons
-                      .map(c => {
-                          // Sourced from window.CaramelCoupons
-                          // (coupon-constants.generated.js, loaded before
-                          // this file — F-006) instead of a hard-coded
-                          // literal, so this can't re-drift from the app's
-                          // src/lib/coupons.ts.
-                          const restrictedSet = new Set(
-                              window.CaramelCoupons.RESTRICTED_STATUSES,
-                          )
-                          const isRestricted = restrictedSet.has(c.status)
-                          const isDead =
-                              c.status === 'invalid' || c.status === 'expired'
-                          let warning = ''
-                          if (isRestricted) {
-                              const baseMsg =
-                                  c.status === 'category_restricted'
-                                      ? 'Limited to specific categories'
-                                      : c.status === 'seller_specific'
-                                        ? 'Only for items from a specific seller'
-                                        : c.status === 'valid_with_warning'
-                                          ? 'May have restrictions'
-                                          : 'Limited to specific items'
-                              const cartHint = c.cartCategory
-                                  ? ` — your cart looks like <b>${escHtml(c.cartCategory)}</b>${c.cartCategorySecondary ? ` / ${escHtml(c.cartCategorySecondary)}` : ''}`
-                                  : ''
-                              const verifierMsg = c.verificationMessage
-                                  ? `<div class="coupon-restriction-detail">${escHtml(c.verificationMessage)}</div>`
-                                  : ''
-                              warning = `
-              <div class="coupon-restriction" title="${escHtml(c.verificationMessage || baseMsg)}">
-                <span class="coupon-restriction-icon" aria-hidden="true">
-                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
-                    <path d="M12 9v4"/>
-                    <path d="M12 17h.01"/>
-                  </svg>
-                </span>
-                <span class="coupon-restriction-text">${baseMsg}${cartHint}</span>
-                ${verifierMsg}
-              </div>`
-                          }
-                          // Verification badge: green=verified, amber=restricted,
-                          // grey=not yet verified (grace), red=known not valid.
-                          // Labels + which status maps to which tier come from
-                          // window.CaramelCoupons.STATUS_META
-                          // (coupon-constants.generated.js, F-006); the tier
-                          // palette lives in styles.css as
-                          // .coupon-badge--<tier> classes on tokens (with dark
-                          // values — the app's coupon-card.tsx keeps its own
-                          // Tailwind equivalent; the 4-tier axis can't drift
-                          // the way the 9-status axis did).
-                          const meta =
-                              window.CaramelCoupons.STATUS_META[c.status]
-                          const badge = meta
-                              ? `<span class="coupon-badge coupon-badge--${meta.tier}" title="${escHtml(c.verificationMessage || '')}">${meta.label}</span>`
-                              : ''
-                          // App-owned trust signal (W1): "worked Xh ago" when
-                          // the extension last reported this coupon working
-                          // (<7 days). '' (unshown) until W2 wires the report.
-                          const workedAgo = formatWorkedAgo(c.lastWorkedAt)
-                          return `
-            <div data-code="${escHtml(c.code)}" role="button" tabindex="0" aria-label="${escHtml((c.title || 'Coupon') + ' — copy code ' + c.code)}" class="coupon-item${isRestricted ? ' coupon-item-restricted' : ''}${isDead ? ' coupon-item-dead' : ''}">
-              <div class="coupon-head">
-                <div class="coupon-title">${escHtml(c.title || 'Untitled Coupon')}</div>
-                ${badge}
-                ${workedAgo ? `<span class="coupon-worked-ago">${escHtml(workedAgo)}</span>` : ''}
-              </div>
-              ${c.description ? `<div class="coupon-desc">${escHtml(c.description)}</div>` : ''}
-              ${warning}
-              <div class="coupon-code-row">
-                <span class="coupon-code">${escHtml(c.code)}</span>
-                <span class="coupon-copy">
-                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                    <rect x="9" y="9" width="11" height="11" rx="2.5" stroke="currentColor" stroke-width="2"/>
-                    <path d="M5 15V5.5A2.5 2.5 0 0 1 7.5 3H15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                  </svg>
-                  Copy
-                </span>
-              </div>
-            </div>`
-                      })
-                      .join('')
+                : coupons.map(couponItemHtml).join('')
         }
+        ${paging.hasMore ? '<div id="couponListFooter" class="coupon-list-footer"></div>' : ''}
       </div>
     </div>
 
@@ -1343,7 +1520,7 @@ function renderCouponsView(coupons, user, domain) {
   `
 
     /* save callback for login back-button */
-    const selfCallback = () => renderCouponsView(coupons, user, domain)
+    const selfCallback = () => renderCouponsView(coupons, user, domain, meta)
 
     /* Settings gear (header): in-popup settings, guests included. */
     wireSettingsGear(selfCallback, domain)
@@ -1373,7 +1550,12 @@ function renderCouponsView(coupons, user, domain) {
        with an execCommand fallback (shared caramelCopyText from UI-helpers.js).
        The bare navigator.clipboard path silently did nothing when the API was
        blocked — now the user always gets either the code on the clipboard or
-       honest feedback instead of a dead click. */
+       honest feedback instead of a dead click.
+
+       Bound ONCE on the list, not per card: rows arriving from page 2 onward
+       are appended straight into this container and would otherwise be
+       decorative — a coupon you can see, click, and not copy. Delegation means
+       a row is wired the moment it exists, with no re-bind step to forget. */
     const copyFromItem = async item => {
         const code = item.getAttribute('data-code')
         const ok = await caramelCopyText(code)
@@ -1383,17 +1565,26 @@ function renderCouponsView(coupons, user, domain) {
                 : `Couldn't copy — code is ${code}`,
         )
     }
-    container.querySelectorAll('.coupon-item').forEach(item => {
-        item.addEventListener('click', () => copyFromItem(item))
+    const list = document.getElementById('couponList')
+    if (list) {
+        list.addEventListener('click', e => {
+            const item = e.target.closest?.('.coupon-item')
+            if (item) copyFromItem(item)
+        })
         // Keyboard users / screen readers: the card is role="button", so
         // Enter and Space must activate it like a real button.
-        item.addEventListener('keydown', e => {
-            if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
-                e.preventDefault()
-                copyFromItem(item)
-            }
+        list.addEventListener('keydown', e => {
+            if (e.key !== 'Enter' && e.key !== ' ' && e.key !== 'Spacebar')
+                return
+            const item = e.target.closest?.('.coupon-item')
+            if (!item) return
+            e.preventDefault()
+            copyFromItem(item)
         })
-    })
+    }
+
+    /* Depth: keep loading pages as the shopper scrolls (see wireCouponPaging). */
+    wireCouponPaging(paging)
 }
 
 /* ------------------------------------------------------------ */

--- a/apps/caramel-extension/tests/popup-coupon-paging.test.mjs
+++ b/apps/caramel-extension/tests/popup-coupon-paging.test.mjs
@@ -1,0 +1,426 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+    getOnMessageListeners,
+    loadExtensionSource,
+    loadExtensionSources,
+} from './_load.mjs'
+
+// Depth of the popup's coupon list (2026-08-10). The popup asked for 20 codes
+// and rendered whatever came back, with nothing on screen to say a store held
+// more — on the day this was written eBay had 96 live codes in the catalog and
+// a shopper could see 20 of them. The owner's ask was blunt: "at least they
+// should see the coupons".
+//
+// The suite runs the REAL producer against the REAL popup, the
+// popup-tab-url-contract.test.mjs pattern: background.js's own onMessage
+// handler builds the request URL and shapes the response, and the popup realm's
+// sendMessage is BRIDGED into that captured handler rather than answered with a
+// hand-written payload. A fixture that describes the contract instead of
+// exercising it is exactly how the eBay bug stayed invisible, so the only thing
+// hand-written here is the catalog the HTTP layer serves.
+//
+// jsdom has no IntersectionObserver and no layout, so the observer is stubbed
+// with one that records what it was asked to watch and lets a test say "this
+// crossed into view". That is the boundary being tested: everything downstream
+// of the callback — request, dedupe, append, end state, failure — is real.
+
+const SITE = 'ebay.com'
+const CATALOG_SIZE = 46
+const PAGE_SIZE = 20
+
+/** A coupon shaped like the /api/coupons rows the popup actually renders. */
+function catalogRow(n) {
+    return {
+        id: String(n),
+        code: `SAVE${String(n).padStart(2, '0')}`,
+        title: `Deal number ${n}`,
+        description: `Description ${n}`,
+        status: n % 7 === 0 ? 'product_restriction' : 'valid',
+    }
+}
+
+const CATALOG = Array.from({ length: CATALOG_SIZE }, (_, i) =>
+    catalogRow(i + 1),
+)
+
+/* ------------------------------------------------------------------ */
+/*  HTTP layer — /api/coupons' documented envelope                     */
+/* ------------------------------------------------------------------ */
+
+/** Every URL background.js fetched, in order. */
+let requestedUrls = []
+/** Pages the HTTP layer should fail on (page number -> times remaining). */
+let failPages = new Map()
+/** Optional override: page number -> rows to serve, or
+ * `{ coupons, hasMore }` when the page must also lie about there being more
+ * (both shapes a real catalog under concurrent ingest can produce). */
+let servedRows = new Map()
+
+function installCatalogFetch(storeSize = CATALOG_SIZE) {
+    requestedUrls = []
+    failPages = new Map()
+    servedRows = new Map()
+    globalThis.fetch = async url => {
+        const parsed = new URL(String(url))
+        requestedUrls.push(parsed)
+        const page = Number(parsed.searchParams.get('page') || '1')
+        const limit = Number(parsed.searchParams.get('limit') || '10')
+
+        const remaining = failPages.get(page) || 0
+        if (remaining > 0) {
+            failPages.set(page, remaining - 1)
+            return { ok: false, status: 503 }
+        }
+
+        const skip = (page - 1) * limit
+        const override = servedRows.get(page)
+        const coupons = !override
+            ? CATALOG.slice(skip, Math.min(skip + limit, storeSize))
+            : Array.isArray(override)
+              ? override
+              : override.coupons
+        const forcedHasMore =
+            override && !Array.isArray(override) ? override.hasMore : undefined
+        return {
+            ok: true,
+            status: 200,
+            // Byte-for-byte the envelope apps/caramel-app/src/app/api/coupons
+            // returns (page/limit/total/hasMore alongside coupons); the app
+            // suite pins that route's own shape.
+            json: async () => ({
+                coupons,
+                page,
+                limit,
+                total: storeSize,
+                hasMore:
+                    forcedHasMore === undefined
+                        ? skip + coupons.length < storeSize
+                        : forcedHasMore,
+            }),
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Realms                                                             */
+/* ------------------------------------------------------------------ */
+
+/** Stub IntersectionObserver: records observed targets and exposes a way to
+ * say "the target scrolled into view". */
+function installObserverStub() {
+    const observed = []
+    class StubIntersectionObserver {
+        constructor(callback, options) {
+            this.callback = callback
+            this.options = options
+            observed.push(this)
+        }
+        observe(target) {
+            this.target = target
+        }
+        disconnect() {
+            this.disconnected = true
+        }
+    }
+    globalThis.IntersectionObserver = StubIntersectionObserver
+    return {
+        instances: observed,
+        /** Fires the newest live observer as if its target came into view. */
+        scrollIntoView() {
+            const live = observed.filter(o => !o.disconnected)
+            const observer = live[live.length - 1]
+            if (!observer) throw new Error('no live IntersectionObserver')
+            observer.callback(
+                [{ isIntersecting: true, target: observer.target }],
+                observer,
+            )
+        },
+    }
+}
+
+/** Boots the popup against the real background handler and renders page 1.
+ * Returns the observer control plus what the popup rendered. */
+async function bootPopup({ withObserver = true, storeSize } = {}) {
+    installCatalogFetch(storeSize)
+
+    // Realm A — the REAL service worker. Its handler stays callable after the
+    // popup realm is built: it closed over its own chrome stub and its own
+    // caramelUrl, and reaches the network through the fetch stub above.
+    loadExtensionSource('background.js', [])
+    const [backgroundHandler] = getOnMessageListeners()
+
+    // Realm B — the REAL popup, same file order as index.html.
+    document.body.innerHTML =
+        '<div id="loading-container"></div><div id="auth-container"></div>'
+    loadExtensionSource('coupon-constants.generated.js', [])
+    loadExtensionSources(
+        [
+            'caramel-base.js',
+            'dom-utils.js',
+            'store-detect.js',
+            'coupon-apply.js',
+            'coupon-fetch.js',
+            'coupon-runner.js',
+            'UI-helpers.js',
+        ],
+        [],
+    )
+
+    /** Every fetchCoupons message the popup sent to the worker. */
+    const sentMessages = []
+    globalThis.currentBrowser.runtime.sendMessage = (message, cb) => {
+        if (message?.action === 'getActiveTabDomainRecord') {
+            cb({ url: `https://www.${SITE}/cart` })
+            return
+        }
+        if (message?.action === 'fetchCoupons') {
+            sentMessages.push(message)
+            // BRIDGE: the real worker handler answers, over the real URL it
+            // builds itself.
+            backgroundHandler(message, {}, cb)
+            return
+        }
+        cb(undefined)
+    }
+    globalThis.currentBrowser.storage.sync.get = (_keys, cb) => cb({})
+
+    const observer = withObserver ? installObserverStub() : null
+    if (!withObserver) delete globalThis.IntersectionObserver
+
+    const copied = []
+    globalThis.caramelCopyText = async text => {
+        copied.push(text)
+        return true
+    }
+
+    const { initPopup } = loadExtensionSource('popup.js', ['initPopup'])
+    const painted = new Promise(resolve => {
+        const original = globalThis.renderCouponsView
+        globalThis.renderCouponsView = (...args) => {
+            const result = original(...args)
+            resolve()
+            return result
+        }
+    })
+    await initPopup()
+    await painted
+
+    return { observer, sentMessages, copied }
+}
+
+const codesOnScreen = () =>
+    [...document.querySelectorAll('#couponList .coupon-item')].map(el =>
+        el.getAttribute('data-code'),
+    )
+
+const footer = () => document.getElementById('couponListFooter')
+
+/** Lets the fetch → sendMessage → append chain settle. */
+const settle = () => new Promise(resolve => setTimeout(resolve, 0))
+
+beforeEach(() => {
+    document.body.innerHTML = ''
+})
+
+describe('popup coupon list — first page', () => {
+    it('renders the first page of codes and, because the store holds more, a footer to load the rest', async () => {
+        await bootPopup()
+
+        const codes = codesOnScreen()
+        expect(codes).toHaveLength(PAGE_SIZE)
+        expect(codes[0]).toBe('SAVE01')
+        expect(codes[PAGE_SIZE - 1]).toBe('SAVE20')
+        expect(footer()).not.toBeNull()
+    })
+
+    it('asks for page 1 with NO page parameter, so the shipped request shape is unchanged', async () => {
+        await bootPopup()
+
+        expect(requestedUrls).toHaveLength(1)
+        const url = requestedUrls[0]
+        expect(url.pathname).toBe('/api/coupons')
+        expect(url.searchParams.get('site')).toBe(SITE)
+        expect(url.searchParams.get('limit')).toBe(String(PAGE_SIZE))
+        expect(url.searchParams.has('page')).toBe(false)
+    })
+
+    it('shows no footer at all when the first page already is the whole store', async () => {
+        // Positive precondition: the SAME popup, same code path, DOES paint a
+        // footer when the store is deep (the two assertions above) — so its
+        // absence here is a store with nothing more to show, not a footer that
+        // never renders.
+        await bootPopup({ storeSize: 3 })
+
+        expect(codesOnScreen()).toEqual(['SAVE01', 'SAVE02', 'SAVE03'])
+        expect(footer()).toBeNull()
+        expect(requestedUrls).toHaveLength(1)
+    })
+})
+
+describe('popup coupon list — scrolling into the next page', () => {
+    it('fetches page 2 with the right parameters, through the real worker, and appends it', async () => {
+        const { observer, sentMessages } = await bootPopup()
+        expect(codesOnScreen()).toHaveLength(PAGE_SIZE)
+
+        observer.scrollIntoView()
+        await settle()
+
+        // The popup asked the worker for page 2...
+        expect(sentMessages.map(m => m.page)).toEqual([1, 2])
+        // ...and the worker turned that into the right request.
+        expect(requestedUrls).toHaveLength(2)
+        expect(requestedUrls[1].searchParams.get('page')).toBe('2')
+        expect(requestedUrls[1].searchParams.get('limit')).toBe(
+            String(PAGE_SIZE),
+        )
+        expect(requestedUrls[1].searchParams.get('site')).toBe(SITE)
+
+        const codes = codesOnScreen()
+        expect(codes).toHaveLength(PAGE_SIZE * 2)
+        expect(codes[PAGE_SIZE]).toBe('SAVE21')
+        expect(codes[codes.length - 1]).toBe('SAVE40')
+        // Appended rows are real cards, not text: the badge markup came from
+        // the same builder the first page used.
+        expect(
+            document.querySelectorAll('#couponList .coupon-badge'),
+        ).toHaveLength(PAGE_SIZE * 2)
+    })
+
+    it('a code that shifts between pages is appended ONCE (no duplicates)', async () => {
+        const { observer } = await bootPopup()
+        const before = codesOnScreen()
+        expect(before).toHaveLength(PAGE_SIZE)
+        expect(new Set(before).size).toBe(PAGE_SIZE)
+
+        // An ingest between the two requests pushes three page-1 rows down: the
+        // live catalog is not a snapshot, and offset paging hands them back.
+        servedRows.set(2, [
+            CATALOG[17],
+            CATALOG[18],
+            CATALOG[19],
+            ...CATALOG.slice(20, 37),
+        ])
+
+        observer.scrollIntoView()
+        await settle()
+
+        const after = codesOnScreen()
+        expect(after).toEqual([...new Set(after)])
+        // The three repeats were dropped; the 17 genuinely new rows landed.
+        expect(after).toHaveLength(PAGE_SIZE + 17)
+        expect(after.slice(0, PAGE_SIZE)).toEqual(before)
+        expect(after[PAGE_SIZE]).toBe('SAVE21')
+    })
+
+    it('copy still works on a row that arrived with page 2', async () => {
+        const { observer, copied } = await bootPopup()
+        observer.scrollIntoView()
+        await settle()
+
+        const appended = [
+            ...document.querySelectorAll('#couponList .coupon-item'),
+        ].find(el => el.getAttribute('data-code') === 'SAVE30')
+        expect(appended, 'a page-2 row is on screen').toBeTruthy()
+
+        appended.dispatchEvent(new window.Event('click', { bubbles: true }))
+        await settle()
+        expect(copied).toEqual(['SAVE30'])
+    })
+})
+
+describe('popup coupon list — the end of the catalog', () => {
+    it('stops cleanly on the last page, says how many there were, and stops observing', async () => {
+        const { observer } = await bootPopup()
+
+        // 46 codes at 20 a page: two more pulls reach the end.
+        observer.scrollIntoView()
+        await settle()
+        expect(codesOnScreen()).toHaveLength(40)
+        expect(footer()).not.toBeNull()
+
+        observer.scrollIntoView()
+        await settle()
+
+        expect(codesOnScreen()).toHaveLength(CATALOG_SIZE)
+        expect(footer().textContent).toContain(
+            `You've seen all ${CATALOG_SIZE} codes`,
+        )
+        expect(footer().hasAttribute('aria-busy')).toBe(false)
+        expect(observer.instances.every(o => o.disconnected)).toBe(true)
+
+        // And it does not keep asking: 3 requests for 3 pages, nothing more.
+        expect(requestedUrls).toHaveLength(3)
+    })
+})
+
+describe('popup coupon list — when a page fails', () => {
+    it('leaves a quiet retry button instead of a spinner that never resolves, and the codes already on screen survive', async () => {
+        const { observer } = await bootPopup()
+        // Precondition: the happy path really does produce rows for this store.
+        expect(codesOnScreen()).toHaveLength(PAGE_SIZE)
+
+        failPages.set(2, 1)
+        observer.scrollIntoView()
+        await settle()
+
+        expect(codesOnScreen()).toHaveLength(PAGE_SIZE)
+        expect(footer().hasAttribute('aria-busy')).toBe(false)
+        expect(footer().querySelector('.skeleton')).toBeNull()
+        const retry = document.getElementById('couponLoadMoreBtn')
+        expect(retry).not.toBeNull()
+        expect(retry.textContent).toContain('Load more')
+        // No error banner painted over a list that is still perfectly usable.
+        expect(document.body.textContent).not.toContain("Couldn't load coupons")
+    })
+
+    it('the retry button actually loads the page that failed', async () => {
+        const { observer } = await bootPopup()
+        failPages.set(2, 1)
+        observer.scrollIntoView()
+        await settle()
+        expect(codesOnScreen()).toHaveLength(PAGE_SIZE)
+
+        document
+            .getElementById('couponLoadMoreBtn')
+            .dispatchEvent(new window.Event('click', { bubbles: true }))
+        await settle()
+
+        expect(codesOnScreen()).toHaveLength(PAGE_SIZE * 2)
+        expect(document.getElementById('couponLoadMoreBtn')).toBeNull()
+    })
+
+    it('a backend that claims more but returns nothing new ends at a button, never a loop', async () => {
+        const { observer } = await bootPopup()
+        // Every further page repeats page 1 while still claiming hasMore.
+        for (const page of [2, 3, 4, 5, 6, 7]) {
+            servedRows.set(page, {
+                coupons: CATALOG.slice(0, PAGE_SIZE),
+                hasMore: true,
+            })
+        }
+
+        observer.scrollIntoView()
+        await settle()
+
+        expect(codesOnScreen()).toHaveLength(PAGE_SIZE)
+        expect(document.getElementById('couponLoadMoreBtn')).not.toBeNull()
+        // Bounded: it gave up after a few empty pages rather than spinning.
+        expect(requestedUrls.length).toBeLessThanOrEqual(5)
+    })
+})
+
+describe('popup coupon list — without IntersectionObserver', () => {
+    it('falls back to a Load more button that pages the list', async () => {
+        await bootPopup({ withObserver: false })
+
+        expect(codesOnScreen()).toHaveLength(PAGE_SIZE)
+        const button = document.getElementById('couponLoadMoreBtn')
+        expect(button).not.toBeNull()
+
+        button.dispatchEvent(new window.Event('click', { bubbles: true }))
+        await settle()
+
+        expect(codesOnScreen()).toHaveLength(PAGE_SIZE * 2)
+        expect(requestedUrls[1].searchParams.get('page')).toBe('2')
+    })
+})


### PR DESCRIPTION
The popup showed the first 20 coupons a store had and gave no sign there were more. On the day this was written eBay held 96 live codes in the catalog; a shopper could see 20 of them. The list now keeps loading as you scroll, and tells you when you've reached the end.

### Where the 20 came from

`background.js`'s `fetchCoupons` branch hard-coded `limit=20` on the request. The API was never the limit: `/api/coupons` already accepted `page`/`limit` and already answered with a `page/limit/total/hasMore` envelope — the extension asked for one page and threw the envelope away.

### API

No new parameters. `page` + `limit` were already there, so the work was to keep them honest and start using them:

- **`limit` and `offset` are now a TOTAL order.** `ORDER BY rating DESC, created_at DESC` is not: a store's coupons routinely share a rating (0 is the default) and can share a `created_at` down to the ingest batch, and Postgres may return tied rows in a different physical order per query. Two pages are two queries, so a tied row could come back on both (a duplicate) or on neither — and the second case is the dangerous one, because no client-side dedupe can see a row that was never sent. `rankingOrderSql()` now appends `id DESC` as a tiebreaker.
- The un-paginated response is otherwise **unchanged**, and that is pinned first as characterization: same five keys, same `page:1 / limit:10`, same `LIMIT 10 OFFSET 0`, same 60s edge cache, and a separate pin on the exact request every *shipped* extension makes (`site` + `key_words` + `limit=20`). The SSR site, the toolbar badge and every installed extension call this route without paging params and must not notice a new consumer arrived.
- `background.js` omits `page` entirely for page 1, so the page-1 URL is byte-for-byte the one it has always produced.

### Extension

- `fetchCouponsPage()` (coupon-fetch.js) returns `{coupons, page, total, hasMore}`; `fetchCoupons()` is now a thin wrapper over it that returns just the codes, so the apply flow is untouched and there is still exactly **one** path that talks to the service worker about coupons. A backend answering without the envelope degrades to `hasMore:false` — the pre-paging behaviour.
- **IntersectionObserver, not a button** — the observer was tried first and works. Its target is the list footer, rooted on the scrolling `.coupon-list` with a 120px `rootMargin`, so the next page is usually already there when you reach the bottom. The footer has four states: a `.skeleton.skeleton-ticket` ghost while loading (which also gives the observer real height to cross, and is the "more is coming" cue), the end note, a quiet **Load more codes** button on failure, and that same button as the fallback when `IntersectionObserver` doesn't exist.
- **Failure is quiet.** A failed page leaves the codes already on screen alone and swaps the ghost for a retry button — no error banner over a list that still works, and never a spinner that spins forever.
- **Dedupe on append**, keyed on the catalog id (code as fallback). A live catalog isn't a snapshot; an ingest between two requests can hand the same row back on both. A page that is entirely duplicates is chased up to 3 times (the footer hasn't moved, so the observer has no boundary left to cross) and then ends at a button rather than a loop.
- **Copy handlers moved to delegation** on the list. Appended rows would otherwise be decorative — a coupon you can see, click, and not copy.
- The card markup was extracted into one `couponItemHtml()` used by both the first page and every append, so an appended row can't quietly lose its badge or restriction warning.
- Two new CSS rules, both on existing `--cm-*` tokens; every state reuses existing classes (`.skeleton`, `.supported-sites-btn`).

### Proof

**Real Chromium** (throwaway harness, not committed): with a 96-code store, the observer fires inside the real 320px scrolling list, walks pages 1→5, renders all 96 cards with **0 duplicates**, ends on "You've seen all 96 codes", and the body has no horizontal overflow. This is the one thing jsdom cannot prove.

**Extension suite: 718 → 729.** New `tests/popup-coupon-paging.test.mjs` (11) runs the REAL producer against the REAL popup — `background.js`'s own onMessage handler builds the URL and shapes the response, and the popup realm's `sendMessage` is *bridged* into it rather than answered with a hand-written payload:

- renders the first page and, because the store holds more, a footer
- asks for page 1 with NO page parameter (shipped request shape unchanged)
- no footer at all when the first page already is the whole store
- fetches page 2 with the right parameters, through the real worker, and appends it
- a code that shifts between pages is appended ONCE
- copy still works on a row that arrived with page 2
- stops cleanly on the last page, says how many there were, and stops observing
- a failed page leaves a quiet retry button instead of an endless spinner
- the retry button actually loads the page that failed
- a backend that claims more but returns nothing new ends at a button, never a loop
- without `IntersectionObserver`, a Load more button pages the list

**App suite: 699 → 717.** New `tests/unit/coupons-pagination.test.ts` (18): the un-paginated characterization above, page windows, `hasMore` at the boundary, an out-of-range offset as an empty last page, the `limit`≤50 / `page`≤500 caps and their junk-input table, and the tiebreaker.

**Red-proofed**, all three:
- delete the append dedupe → 2 paging tests fail (40 cards instead of 37; the duplicate assertion fires)
- drop the `page` passthrough in `background.js` → 6 of 11 fail
- drop `, id DESC` → the ordering pin fails

`popup-sizing.test.mjs` green (the 320px arithmetic is untouched). `test:guards` 57/57. Also green: both prettier checks, oxlint, eslint (warning count identical to baseline), `tsc --noEmit`, knip on both packages.

### Two gate notes

- `.size-limit.js`: popup 30→33 KB and background 7.5→7.8 KB, each with a dated reason beside the number. Minified popup measured 30.97 KB — that buys the observer, the fetch/append/dedupe loop, the four footer states and the delegated handlers. Background was raised at 2.7% headroom rather than left one honest edit away from red.
- `no-raw-coupon-status.test.ts` now skips `.size-cache/`. That directory is gitignored build output of the size gate over the same sources the gate already walks, but minification inlines the generated constants — so running `pnpm size` locally left this suite red. A gate firing on its own build output is noise, not a finding.
