### PR TITLE
Guest coupon teaser gate + settings alignment (extension popup)

### DIFF
--- a/apps/caramel-extension/assets/styles.css
+++ b/apps/caramel-extension/assets/styles.css
@@ -504,6 +504,15 @@ body {
     font-size: var(--cm-text-xs);
     color: var(--cm-text-secondary);
 }
+/* Guest teaser gate: sits inside .coupon-list after the capped rows, so it
+   scrolls into view exactly where the hidden codes would have been. */
+.coupon-guest-gate {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 6px;
+    padding: 2px 2px 10px;
+}
 .coupon-list::-webkit-scrollbar {
     width: 8px;
 }
@@ -1055,6 +1064,7 @@ body {
     margin: 2px 0 4px;
     font-size: var(--cm-text-md);
     color: var(--cm-text-primary);
+    text-align: left;
 }
 .settings-row {
     display: flex;
@@ -1072,6 +1082,9 @@ body {
     flex-direction: column;
     gap: 2px;
     min-width: 0;
+    /* #mainContent centers text globally; without this the short title
+       centers over its wider description and the rows look misaligned. */
+    text-align: left;
 }
 .settings-copy span {
     font-size: var(--cm-text-base);

--- a/apps/caramel-extension/popup.js
+++ b/apps/caramel-extension/popup.js
@@ -1306,6 +1306,26 @@ function couponIdentity(c) {
  * page, not to walk a catalog the backend keeps re-serving. */
 const COUPON_PAGE_EMPTY_LIMIT = 3
 
+/* Guests see a teaser, not the catalog. OWNER RULE (2026-08-10): "for guests
+ * dont show all coupons" — the full list, and the infinite scroll that walks
+ * it, are signed-in features. Six rows is about two screens of the 320px
+ * list: enough to prove the codes are real, small enough that signing in
+ * visibly buys something. The gate only exists when it hides something — a
+ * guest on a store with this many codes or fewer sees exactly what a member
+ * sees. */
+const GUEST_COUPON_LIMIT = 6
+
+/* Bottom of a guest's capped list: name what's hidden and the one action that
+ * reveals it. `total` is the CATALOG count — the same number a member's
+ * scroll ends on — so the promise on the button is exactly what signing in
+ * delivers. */
+function couponGuestGateHtml(shown, total) {
+    return `<div id="couponGuestGate" class="coupon-guest-gate">
+        <p class="coupon-list-note">Showing ${shown} of ${total} codes</p>
+        <button type="button" id="couponLoginGateBtn" class="supported-sites-btn">Log in to see all ${total} codes</button>
+    </div>`
+}
+
 /* Wording for the bottom of the list. "N codes" counts what the CATALOG holds
  * for this store, which is the number the shopper is really asking about when
  * they scroll to the end. */
@@ -1464,6 +1484,16 @@ function renderCouponsView(coupons, user, domain, meta) {
         observer: null,
     }
 
+    /* Guest cap (GUEST_COUPON_LIMIT): slice AFTER the paging state is built so
+     * `paging.total` still carries the real catalog size the gate advertises.
+     * hasMore is forced off — the gate replaces the pager, so a guest's list
+     * never grows past the teaser no matter how the shopper scrolls. */
+    const guestGated = !user && paging.total > GUEST_COUPON_LIMIT
+    const visibleCoupons = guestGated
+        ? coupons.slice(0, GUEST_COUPON_LIMIT)
+        : coupons
+    if (guestGated) paging.hasMore = false
+
     const headerLeft = user
         ? `
         <img
@@ -1510,9 +1540,10 @@ function renderCouponsView(coupons, user, domain, meta) {
         ${
             coupons.length === 0
                 ? '<p>No coupons available for this store right now.</p>'
-                : coupons.map(couponItemHtml).join('')
+                : visibleCoupons.map(couponItemHtml).join('')
         }
         ${paging.hasMore ? '<div id="couponListFooter" class="coupon-list-footer"></div>' : ''}
+        ${guestGated ? couponGuestGateHtml(visibleCoupons.length, paging.total) : ''}
       </div>
     </div>
 
@@ -1543,6 +1574,14 @@ function renderCouponsView(coupons, user, domain, meta) {
     const loginToggle = document.getElementById('loginToggleBtn')
     if (loginToggle)
         loginToggle.addEventListener('click', () =>
+            renderSignInPrompt(selfCallback),
+        )
+
+    /* guest gate at the foot of the capped list — same destination as the
+       header Log in button, offered where the capped list actually ends */
+    const gateBtn = document.getElementById('couponLoginGateBtn')
+    if (gateBtn)
+        gateBtn.addEventListener('click', () =>
             renderSignInPrompt(selfCallback),
         )
 

--- a/apps/caramel-extension/tests/popup-coupon-paging.test.mjs
+++ b/apps/caramel-extension/tests/popup-coupon-paging.test.mjs
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
+    backStorageArea,
     getOnMessageListeners,
     loadExtensionSource,
     loadExtensionSources,
@@ -62,6 +63,16 @@ function installCatalogFetch(storeSize = CATALOG_SIZE) {
     servedRows = new Map()
     globalThis.fetch = async url => {
         const parsed = new URL(String(url))
+        // The signed-in boots fire validateStoredSession in parallel; answer
+        // its /api/extension/me probe with a real profile shape so it neither
+        // signs the popup out nor writes a garbage user into storage.
+        if (parsed.pathname === '/api/extension/me') {
+            return {
+                ok: true,
+                status: 200,
+                json: async () => ({ username: 'tester', image: '' }),
+            }
+        }
         requestedUrls.push(parsed)
         const page = Number(parsed.searchParams.get('page') || '1')
         const limit = Number(parsed.searchParams.get('limit') || '10')
@@ -139,8 +150,17 @@ function installObserverStub() {
 }
 
 /** Boots the popup against the real background handler and renders page 1.
- * Returns the observer control plus what the popup rendered. */
-async function bootPopup({ withObserver = true, storeSize } = {}) {
+ * Returns the observer control plus what the popup rendered.
+ *
+ * `signedIn` defaults to true because the DEEP list is a member feature since
+ * the guest cap (GUEST_COUPON_LIMIT in popup.js): every paging behavior below
+ * only exists behind a session, and the "guest gate" suite at the bottom is
+ * what pins the logged-out shape. */
+async function bootPopup({
+    withObserver = true,
+    storeSize,
+    signedIn = true,
+} = {}) {
     installCatalogFetch(storeSize)
 
     // Realm A — the REAL service worker. Its handler stays callable after the
@@ -183,6 +203,19 @@ async function bootPopup({ withObserver = true, storeSize } = {}) {
         cb(undefined)
     }
     globalThis.currentBrowser.storage.sync.get = (_keys, cb) => cb({})
+    // Session lives in storage.LOCAL (token + user). ALWAYS back the area —
+    // the stub is shared across boots in this file, so a guest boot that
+    // skipped this would inherit the previous signed-in boot's token and
+    // silently test the wrong user.
+    backStorageArea(
+        'local',
+        signedIn
+            ? {
+                  token: 'tok_paging_suite',
+                  user: { username: 'tester', image: '' },
+              }
+            : {},
+    )
 
     const observer = withObserver ? installObserverStub() : null
     if (!withObserver) delete globalThis.IntersectionObserver
@@ -422,5 +455,64 @@ describe('popup coupon list — without IntersectionObserver', () => {
 
         expect(codesOnScreen()).toHaveLength(PAGE_SIZE * 2)
         expect(requestedUrls[1].searchParams.get('page')).toBe('2')
+    })
+})
+
+describe('popup coupon list — guest gate', () => {
+    // OWNER RULE (2026-08-10): "for guests dont show all coupons". A guest gets
+    // a teaser of GUEST_COUPON_LIMIT rows and a login gate naming the real
+    // catalog size; the infinite scroll above is a member feature.
+    const GUEST_LIMIT = 6
+
+    it('caps a guest at the teaser with a gate naming the full count, and never wires the pager', async () => {
+        const { observer } = await bootPopup({ signedIn: false })
+
+        expect(codesOnScreen()).toHaveLength(GUEST_LIMIT)
+        expect(footer()).toBeNull()
+        // No live observer: scrolling a guest's list must not grow it.
+        expect(observer.instances.filter(o => !o.disconnected)).toHaveLength(0)
+
+        const gate = document.getElementById('couponGuestGate')
+        expect(gate).not.toBeNull()
+        expect(gate.textContent).toContain(
+            `Showing ${GUEST_LIMIT} of ${CATALOG_SIZE} codes`,
+        )
+        const button = document.getElementById('couponLoginGateBtn')
+        expect(button.textContent).toContain(
+            `Log in to see all ${CATALOG_SIZE} codes`,
+        )
+        // One request, page 1 — the cap is presentation, not a smaller fetch,
+        // so logging in can widen the list without a new contract.
+        expect(requestedUrls).toHaveLength(1)
+    })
+
+    it('leaves a small store ungated — the gate only exists when it hides something', async () => {
+        // Positive precondition: the deep-store boot above DOES gate, so an
+        // absent gate here means "nothing hidden", not "gate never renders".
+        await bootPopup({ signedIn: false, storeSize: 3 })
+
+        expect(codesOnScreen()).toEqual(['SAVE01', 'SAVE02', 'SAVE03'])
+        expect(document.getElementById('couponGuestGate')).toBeNull()
+        expect(footer()).toBeNull()
+    })
+
+    it('sends the gate tap to the sign-in view', async () => {
+        await bootPopup({ signedIn: false })
+
+        const button = document.getElementById('couponLoginGateBtn')
+        button.dispatchEvent(new window.Event('click', { bubbles: true }))
+        await settle()
+
+        // The coupon list is gone and the sign-in form is up.
+        expect(document.getElementById('couponList')).toBeNull()
+        expect(document.getElementById('loginForm')).not.toBeNull()
+    })
+
+    it('shows a member the full first page on the same store a guest sees capped', async () => {
+        await bootPopup()
+
+        expect(codesOnScreen()).toHaveLength(PAGE_SIZE)
+        expect(document.getElementById('couponGuestGate')).toBeNull()
+        expect(footer()).not.toBeNull()
     })
 })


### PR DESCRIPTION
## What

Two owner-reported popup issues:

**Guest coupon cap.** Owner rule: guests must not see the full catalog. A logged-out popup now shows a 6-code teaser followed by a gate — "Showing 6 of N codes" + a "Log in to see all N codes" button that opens the sign-in view. The infinite scroll (#180) is now a member feature: the pager is never wired for guests, so scrolling cannot grow the list. The gate only exists when it hides something — a guest on a store with ≤6 codes sees exactly what a member sees. The cap is presentation-only (same page-1 fetch), so signing in widens the list with no contract change.

**Settings alignment.** `#mainContent { text-align: center }` inherited into `.settings-copy`, centering each setting's short title over its wider description. Settings copy and the section title now left-align.

## Tests

`tests/popup-coupon-paging.test.mjs` now boots signed-in by default (the deep list is a member feature) with the session backed in storage.local, and a new **guest gate** suite pins: the 6-row cap + gate wording + no live IntersectionObserver for guests; a 3-code store staying ungated (with the deep-store positive precondition); the gate tap landing on the sign-in form; and the same store rendering the full first page for a member. 733/733 green.

Verified visually in Chrome (devtools MCP) on ebay.com as guest: 6 cards, gate row, settings view left-aligned.