### PR TITLE
Retry status presents as Unverified while verification is paused

### DIFF
--- a/apps/caramel-app/src/lib/coupons.ts
+++ b/apps/caramel-app/src/lib/coupons.ts
@@ -66,9 +66,14 @@ const STATUS_TABLE = [
     },
     {
         status: 'retry',
-        label: 'Checking…',
+        label: 'Unverified',
         tier: 'grey',
-        // Mid-verification (a prior attempt failed transiently).
+        // Mid-verification in the DB (a prior attempt failed transiently) —
+        // but presented as plain "Unverified", the same badge as `pending`.
+        // The old "Checking…" label promised live activity, and while the
+        // verification pipeline is paused (post-cutover hold, 2026-08-10)
+        // rows sat on that promise for days. "Unverified" is true in both
+        // worlds: pipeline running or not, the code has no proof yet.
         visible: true,
         restricted: false,
     },

--- a/apps/caramel-app/tests/unit/coupons.test.ts
+++ b/apps/caramel-app/tests/unit/coupons.test.ts
@@ -112,7 +112,10 @@ describe('STATUS_META — label + tier, verbatim from coupon-card.tsx STATUS_BAD
             category_restricted: { label: 'Category-limited', tier: 'amber' },
             seller_specific: { label: 'Seller-specific', tier: 'amber' },
             pending: { label: 'Unverified', tier: 'grey' },
-            retry: { label: 'Checking…', tier: 'grey' },
+            // retry shares pending's label on purpose: "Checking…" promised
+            // live verification, and with the pipeline paused (2026-08-10)
+            // rows wore it for days. See coupons.ts.
+            retry: { label: 'Unverified', tier: 'grey' },
             invalid: { label: 'Not valid', tier: 'red' },
             expired: { label: 'Expired', tier: 'red' },
         })

--- a/apps/caramel-extension/coupon-constants.generated.js
+++ b/apps/caramel-extension/coupon-constants.generated.js
@@ -60,7 +60,7 @@ window.CaramelCoupons = {
             tier: 'grey',
         },
         retry: {
-            label: 'Checking…',
+            label: 'Unverified',
             tier: 'grey',
         },
         invalid: {


### PR DESCRIPTION
## What

The popup and store pages showed "Checking…" on `retry`-status coupons. That label promises live verification activity — but the verification pipeline is ON HOLD since the prod cutover, so those rows have been stuck saying "Checking…" for days (owner report). Nothing is checking.

`retry` now presents with the same badge as `pending`: **Unverified**, grey. That sentence is true whether the pipeline is running or paused — the code has no proof yet. The DB status vocabulary is untouched; this is presentation only, and when verification resumes, rows that get proven move to their real verdicts exactly as before.

One STATUS_META entry in `src/lib/coupons.ts` (the single source of truth), the regenerated `coupon-constants.generated.js` (extension side picks it up on its next build), and the label pin in `tests/unit/coupons.test.ts`.