### PR TITLE
Cart intent: a cart living on a cart.* host opens the gate

### DIFF
--- a/apps/caramel-extension/store-detect.js
+++ b/apps/caramel-extension/store-detect.js
@@ -263,9 +263,20 @@ function _caramelReferrerCartBounce() {
  * because "the gate opened" is not a useful thing to read in a dev console
  * without knowing which of four rules opened it.
  */
+/* Does this HOST name a cart or checkout? Some platforms put the cart word in
+ * the hostname, not the path: eBay's cart lives at cart.ebay.com/ (path "/"),
+ * and checkout.* subdomains are a common SFCC/legacy shape. Same vocabulary as
+ * CARAMEL_CART_PATH_RE, and only the FIRST label — a cart word deeper in the
+ * host (secure.cart.example) is not what this page calls itself. Still a rule
+ * about URL shape, never about one store. */
+function _caramelCartHostname(hostname) {
+    return /^(cart|carts|basket|checkout|checkouts)\./i.test(hostname)
+}
+
 function _caramelCartIntentSignal() {
     if (CARAMEL_CART_PATH_RE.test(location.pathname + location.search))
         return 'path'
+    if (_caramelCartHostname(location.hostname)) return 'host'
     for (const [key, value] of new URLSearchParams(location.search)) {
         if (!CARAMEL_CART_INTENT_PARAM_RE.test(key)) continue
         if (CARAMEL_FALSY_FLAG_VALUES.has(String(value).trim().toLowerCase()))

--- a/apps/caramel-extension/tests/cart-capability-gate.test.mjs
+++ b/apps/caramel-extension/tests/cart-capability-gate.test.mjs
@@ -29,8 +29,10 @@ function setReferrer(value) {
     Object.defineProperty(document, 'referrer', { value, configurable: true })
 }
 
+let _caramelCartHostname
+
 beforeAll(() => {
-    ;({ isCheckout } = loadExtensionSources(
+    ;({ isCheckout, _caramelCartHostname } = loadExtensionSources(
         [
             'coupon-constants.generated.js',
             'caramel-base.js',
@@ -40,7 +42,7 @@ beforeAll(() => {
             'coupon-fetch.js',
             'coupon-runner.js',
         ],
-        ['isCheckout'],
+        ['isCheckout', '_caramelCartHostname'],
     ))
 })
 
@@ -286,5 +288,32 @@ describe('isCheckout — cart intent the path does not spell out', () => {
             expect(await isCheckout()).toBe(false)
             expect(probeCalls).toBe(0)
         })
+    })
+})
+
+describe('cart intent named by the HOST, not the path', () => {
+    // eBay's cart is cart.ebay.com/ — path "/", nothing for the path rule to
+    // read. The host rule speaks the same vocabulary, first label only.
+    it('recognises a cart word as the first hostname label', () => {
+        for (const host of [
+            'cart.ebay.com',
+            'checkout.store.example',
+            'basket.shop.co.uk',
+            'Checkouts.example.com',
+        ]) {
+            expect(_caramelCartHostname(host), host).toBe(true)
+        }
+    })
+
+    it('refuses cart words that are buried, partial, or absent', () => {
+        for (const host of [
+            'secure.cart.example.com', // not what THIS page calls itself
+            'www.ebay.com',
+            'cartoon.example.com', // word must end at the label dot
+            'mycart.example.com',
+            'pay.ebay.com', // deliberately out: "pay" is not cart vocabulary
+        ]) {
+            expect(_caramelCartHostname(host), host).toBe(false)
+        }
     })
 })

--- a/apps/caramel-extension/tests/cart-host-intent.test.mjs
+++ b/apps/caramel-extension/tests/cart-host-intent.test.mjs
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+// @vitest-environment-options { "url": "https://cart.example.com/" }
+import { beforeEach, describe, expect, it } from 'vitest'
+import { loadExtensionSources } from './_load.mjs'
+
+// The wire-proof for the HOST cart-intent rule (cart-capability-gate.test.mjs
+// pins the vocabulary itself): this realm's whole document lives at
+// cart.example.com with a bare "/" path — eBay's exact cart shape — so nothing
+// here can pass the PATH rule. If the host branch were unplugged, every
+// assertion below would go red for the same reason eBay's cart sat silent.
+
+let isCheckout
+let probeCalls
+
+beforeEach(() => {
+    document.body.innerHTML = ''
+    probeCalls = 0
+    ;({ isCheckout } = loadExtensionSources(
+        [
+            'coupon-constants.generated.js',
+            'caramel-base.js',
+            'dom-utils.js',
+            'store-detect.js',
+            'coupon-apply.js',
+            'coupon-fetch.js',
+            'coupon-runner.js',
+        ],
+        ['isCheckout'],
+    ))
+    globalThis.getDomainRecord = async () => null
+    globalThis.waitForElement = async () => {
+        throw new Error('not found')
+    }
+    globalThis.probeCartJson = async () => {
+        probeCalls++
+        return { token: 't', total_price: 4499, item_count: 2, currency: 'USD' }
+    }
+})
+
+describe('a cart that lives on a cart.* host with a bare "/" path', () => {
+    it('reaches the capability probe and opens the gate', async () => {
+        expect(await isCheckout()).toBe(true)
+        expect(probeCalls).toBe(1)
+    })
+
+    it('still respects the probe saying the cart is empty', async () => {
+        globalThis.probeCartJson = async () => ({
+            token: 't',
+            total_price: 0,
+            item_count: 0,
+            currency: 'USD',
+        })
+
+        expect(await isCheckout()).toBe(false)
+    })
+})


### PR DESCRIPTION
## What

Fleet-wide detection gap the eBay investigation surfaced: the cart-intent rules read the path, query, hash, and referrer — never the HOST. A store whose cart lives at `cart.<domain>/` (path `/`, eBay's exact shape) or `checkout.<domain>` (common SFCC/legacy shape) could never open the capability gate from its URL.

New rule, same vocabulary as `CARAMEL_CART_PATH_RE`, first hostname label only: `cart.` / `carts.` / `basket.` / `checkout.` / `checkouts.`. A cart word buried deeper (`secure.cart.example`) or partial (`cartoon.example.com`) stays out, and `pay.` is deliberately not vocabulary. Generic URL shape — no store-specific rules.

## Tests

- Vocabulary pins (positives + buried/partial/absent negatives) in `cart-capability-gate.test.mjs`
- `cart-host-intent.test.mjs`: a realm whose document actually lives at `https://cart.example.com/` — nothing there can pass the path rule, so the suite goes red if the host branch is unplugged; pins the probe firing and the empty-cart refusal