### PR TITLE
E2E: signup suite gets a budget that survives a cold CI runner

### DIFF
--- a/apps/caramel-app/e2e/auth-flows.spec.ts
+++ b/apps/caramel-app/e2e/auth-flows.spec.ts
@@ -158,6 +158,15 @@ test.describe('Auth Flows — Login', () => {
 })
 
 test.describe('Auth Flows — Signup', () => {
+    // slow() = triple the 30s default. The waitForURL below already carries a
+    // 30s budget of its own, so the DEFAULT test timeout expired first and
+    // silently capped it — the redirect test died at exactly 30000ms on
+    // 2026-08-10 (third signup flake that week; failOnFlakyTests turns one
+    // slow CI boot into a red gate). The app is measured-fast (signup POST
+    // 0.8s live); what's slow is a cold CI runner hydrating /signup and
+    // loading /verify.
+    test.slow()
+
     test('successful signup redirects to /verify?signup=success', async ({
         page,
     }) => {


### PR DESCRIPTION
## What

The two signup E2E tests have flaked four times across two days (existing-email toast twice on 2026-08-09, both signup tests again on 2026-08-10), each time costing a gate rerun. Root cause for the redirect test: its `waitForURL` carries a 30s budget, but the DEFAULT per-test timeout is also 30s — setup (goto, four fills, route interception, click) spends part of it, so the wait never actually had 30s. The test died at exactly 30000ms.

`test.slow()` on the signup describe triples the per-test budget (90s). The app itself is measured-fast (signup POST 0.8s live) — what is slow is a cold CI runner hydrating `/signup`; a budget below that reality makes the gate red on infrastructure, not on the product.