### PR TITLE
Layout: overflow-x-clip so position:sticky works app-wide again

### DIFF
--- a/apps/caramel-app/src/components/profile/ProfileNav.tsx
+++ b/apps/caramel-app/src/components/profile/ProfileNav.tsx
@@ -21,7 +21,8 @@ import { useEffect, useState } from 'react'
 // first card on small screens. Both drive the same scroll-spy state, so the
 // active section is always shown in whichever presentation is visible.
 // (Why fixed and not sticky: see the positioning note in profileStyles.ts —
-// sticky is inert app-wide behind Layout.tsx's overflow-x-hidden.)
+// built while sticky was inert app-wide; kept fixed since it works and is
+// pinned by tests.)
 //
 // Sections are passed in rather than hardcoded because the page's section set
 // is DYNAMIC — "Your reports" renders only when the user has reports. A fixed

--- a/apps/caramel-app/src/layouts/Layout/Layout.tsx
+++ b/apps/caramel-app/src/layouts/Layout/Layout.tsx
@@ -21,9 +21,16 @@ export default function Layout({ children }: LayoutProps) {
         // needed here. Don't reintroduce a background: it would repaint the
         // whole viewport light until hydration, the flash this all exists to
         // kill.
+        // overflow-x-CLIP, not -hidden: `hidden` creates a scroll container,
+        // which silently becomes the containing block for every
+        // `position: sticky` inside it — the site header (sticky top-4)
+        // scrolled away on every page (measured top:-1184 on /privacy,
+        // 2026-08-10). `clip` cuts horizontal overflow identically but
+        // creates NO scroll container, so sticky works against the viewport
+        // again. Same one-char class swap Tailwind ships for exactly this.
         <div
             ref={ref}
-            className={`flex min-h-screen flex-col overflow-x-hidden scroll-smooth ${
+            className={`flex min-h-screen flex-col overflow-x-clip scroll-smooth ${
                 isDarkMode ? 'dark' : 'light'
             } font-Roboto`}
         >

--- a/apps/caramel-app/src/lib/profile/profileStyles.ts
+++ b/apps/caramel-app/src/lib/profile/profileStyles.ts
@@ -146,15 +146,14 @@ export const linkRowFocusClasses =
 // Section navigation
 //
 // POSITIONING NOTE — why the rail is `fixed` and not `sticky`:
-// `position: sticky` DOES NOT WORK anywhere in this app. Layout.tsx wraps every
-// page in `flex min-h-screen flex-col overflow-x-hidden`, and an ancestor with
-// a non-visible overflow becomes the sticky scroll container; since that
-// wrapper grows with its content and never scrolls internally, nothing inside
-// it can ever stick. Measured, not assumed: on /privacy the app's OWN header
-// (`sticky top-4`) scrolls from top 16 to top -1184 after a 1200px scroll.
-// Fixing that belongs in Layout.tsx (`overflow-x: clip` keeps the same
-// clipping without creating a scroll container) and would change the scrolled
-// appearance of every page, so it is deliberately NOT done here.
+// When this rail was built (2026-08-10), `position: sticky` was inert
+// app-wide — Layout.tsx's `overflow-x-hidden` wrapper was the sticky scroll
+// container, and nothing inside it could stick (measured: the site header at
+// top -1184 on /privacy). Layout.tsx has since moved to `overflow-x-clip`,
+// which clips without creating a scroll container, so sticky works again.
+// The rail stays `fixed` because it is proven, live, and its own tests pin
+// this shape — converting it to sticky is a pure refactor with no user-visible
+// win, not a bug.
 //
 // `position: fixed` is unaffected (there is no transform/filter ancestor), so
 // the rail uses it.


### PR DESCRIPTION
## What

`position: sticky` has been inert across the entire app: Layout.tsx wraps every page in `overflow-x-hidden`, and a non-visible overflow ancestor becomes the sticky scroll container — since that wrapper never scrolls internally, nothing inside it could ever stick. Measured on /privacy: the site header (`sticky top-4`) scrolls from top 16 to top **-1184** after a 1200px scroll. The header — the menu — disappears on every page the moment you scroll.

One-class fix: `overflow-x-hidden` → `overflow-x-clip`. `clip` cuts horizontal overflow identically but creates no scroll container, so sticky resolves against the viewport again and the header stays visible while scrolling.

The profile section rail keeps its `position: fixed` implementation (built while sticky was broken, proven live, pinned by tests) — its comments now record the history instead of claiming sticky is still broken.

## Risk

Changes the SCROLLED appearance of every page (the header now follows). At scroll position 0 — where visual baselines capture — nothing moves.