### PR TITLE
feat(extension): gate manual fallback to popup guest cap + report link (v1.3.1)

### DIFF
--- a/apps/caramel-extension/UI-helpers.js
+++ b/apps/caramel-extension/UI-helpers.js
@@ -18,6 +18,12 @@ const CARAMEL_X_ICON =
 // asks the API for, so in practice this shows everything we fetched.
 const CARAMEL_MANUAL_LIST_MAX = 20
 
+// Guests get the SAME teaser cap here as the popup's coupon list
+// (popup.js GUEST_COUPON_LIMIT). Without it the manual fallback quietly hands a
+// signed-out shopper up to 20 codes while the popup shows them 6 — leaking the
+// gated value and skipping the sign-in nudge. Keep in sync with popup.js.
+const CARAMEL_MANUAL_GUEST_LIMIT = 6
+
 // Functional-minimum styles used ONLY when the stylesheet fetch fails.
 const CARAMEL_UI_FALLBACK_CSS =
     '.cm-scrim{width:100%;height:100vh;display:flex;align-items:center;justify-content:center;padding:20px;background:rgba(15,12,10,.5)}' +
@@ -644,6 +650,10 @@ async function showFinalModal(
     couponList = [],
 ) {
     hideTestingModal()
+    // Login state drives the manual-list teaser cap below — same gate as the
+    // popup's coupon list. Signed-out ⇒ 6-code teaser + sign-in nudge.
+    const _session = await caramelGetSession()
+    const loggedIn = !!_session?.token
     const prevFocus = document.activeElement
     const { host, root } = await createCaramelShadowHost(
         'caramel-final-overlay',
@@ -674,7 +684,7 @@ async function showFinalModal(
     // sometimes just our synthetic input not registering, so hiding them could
     // bury a code that works when pasted by hand — but leading with the codes
     // the user just watched fail reads as if we learned nothing.
-    const manualCodes = (
+    const _manualAll = (
         !isSuccess && Array.isArray(couponList) ? couponList : []
     )
         .filter(c => c && c.code)
@@ -684,10 +694,18 @@ async function showFinalModal(
                 (a.c.rejected ? 1 : 0) - (b.c.rejected ? 1 : 0) || a.i - b.i,
         )
         .map(x => x.c)
-        // Matches the API's own per-store fetch limit, so the list shows every
-        // code we have rather than a second, tighter cap on top of the
-        // attempt cap. The list scrolls; hiding codes helps nobody.
-        .slice(0, CARAMEL_MANUAL_LIST_MAX)
+    // The catalog count for this store — the number the sign-in nudge promises,
+    // matching the popup's "of N codes" gate.
+    const manualTotal = _manualAll.length
+    // Members see the full list (API's own per-store fetch limit); guests see
+    // the same teaser the popup shows. The gate only bites when it actually
+    // hides something (a store with ≤ the guest cap looks identical to both).
+    const manualGuestGated =
+        !loggedIn && manualTotal > CARAMEL_MANUAL_GUEST_LIMIT
+    const manualCodes = _manualAll.slice(
+        0,
+        manualGuestGated ? CARAMEL_MANUAL_GUEST_LIMIT : CARAMEL_MANUAL_LIST_MAX,
+    )
     const hasManual = manualCodes.length > 0
 
     const esc = s =>
@@ -769,6 +787,21 @@ ${
               .join('')}</div>`
         : ''
 
+    // Guest teaser gate — same shape as the popup's couponGuestGateHtml: name
+    // what's hidden, offer the one action that reveals it (opens the popup to
+    // sign in, mirroring the isSignIn primary button below).
+    const manualGateHtml = manualGuestGated
+        ? `<div class="caramel-manual-gate">
+<button type="button" id="caramel-manual-login" class="caramel-manual-gate-btn">Sign in for all ${manualTotal} codes</button>
+</div>`
+        : ''
+
+    // Graceful escape hatch when auto-apply didn't land: a quiet link to the
+    // prod support/feedback form so a shopper can report a broken store or code.
+    const feedbackHtml = hasManual
+        ? `<a id="caramel-manual-feedback" class="caramel-manual-feedback" href="${esc(CARAMEL_ENV.baseUrl)}/support" target="_blank" rel="noopener noreferrer">Report a problem</a>`
+        : ''
+
     // Success states group the outcome into ONE panel so the amount reads as
     // the headline and the code sits under it as a ticket. `.caramel-final-code`
     // keeps the code as its FIRST <span> — the label is a sibling, never a span
@@ -799,9 +832,12 @@ ${savedMoney ? '' : `<p class="caramel-final-hint">Discount visible in your cart
         ? 'Sign In'
         : isSuccess
           ? 'Proceed to Checkout'
-          : hasManual
-            ? 'Done'
-            : 'Got it'
+          : 'Got it'
+    // The manual "Grab a code" card carries its own actions (copy buttons, the
+    // unlock nudge, the report link) and three ways out (×, scrim, Esc) — a
+    // generic "Done" button under all that is just clutter, so drop it. Sign-in
+    // and success states still need their promise-button.
+    const showPrimary = isSignIn || isSuccess || !hasManual
 
     modal.innerHTML = `
 <button id="caramel-final-close" class="cm-close-fab" title="Close" aria-label="Close">${CARAMEL_X_ICON}</button>
@@ -809,8 +845,10 @@ ${savedMoney ? '' : `<p class="caramel-final-hint">Discount visible in your cart
 <h2>${heading}</h2>
 <p class="caramel-final-msg">${esc(finalMessage)}</p>
 ${manualBlock}
+${manualGateHtml}
+${feedbackHtml}
 ${winBlock}
-<button id="caramel-final-ok-btn">${primaryLabel}</button>
+${showPrimary ? `<button id="caramel-final-ok-btn">${primaryLabel}</button>` : ''}
 `
 
     scrim.appendChild(modal)
@@ -859,6 +897,15 @@ ${winBlock}
     scrim.addEventListener('click', ev => {
         if (ev.target === scrim) closeFinal()
     })
+
+    // Guest teaser gate: same destination as the isSignIn button — open the
+    // popup so the shopper signs in, then the full list is theirs.
+    const manualLoginBtn = modal.querySelector('#caramel-manual-login')
+    if (manualLoginBtn)
+        manualLoginBtn.addEventListener('click', () => {
+            closeFinal()
+            currentBrowser.runtime.sendMessage({ action: 'openPopup' })
+        })
 
     // Close on the primary button; Esc closes too (keyboard).
     const okBtn = modal.querySelector('#caramel-final-ok-btn')

--- a/apps/caramel-extension/assets/content-ui.css
+++ b/apps/caramel-extension/assets/content-ui.css
@@ -494,6 +494,48 @@ button:focus {
     background: var(--cm-tier-green-bg);
     color: var(--cm-tier-green-text);
 }
+/* Guest teaser gate under the manual list — the button alone ("Sign in for all
+ * N codes") carries the nudge; no separate count line. */
+.caramel-manual-gate {
+    flex: none;
+    text-align: center;
+    margin: 4px 0 2px;
+}
+.caramel-manual-gate-btn {
+    width: 100%;
+    background: var(--cm-brand);
+    color: var(--cm-on-brand);
+    padding: 9px 14px;
+    border-radius: var(--cm-radius-sm);
+    font-size: 13px;
+    font-weight: 600;
+    transition: background var(--cm-dur-fast) var(--cm-ease);
+}
+.caramel-manual-gate-btn:hover {
+    background: var(--cm-brand-strong);
+}
+.caramel-manual-gate-btn:focus-visible {
+    outline: 3px solid var(--cm-brand);
+    outline-offset: 2px;
+}
+/* Quiet "report a problem" link → prod support/feedback form. */
+.caramel-manual-feedback {
+    flex: none;
+    display: inline-block;
+    margin: 8px 0 2px;
+    font-size: var(--cm-text-xs);
+    color: var(--cm-text-muted);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+.caramel-manual-feedback:hover {
+    color: var(--cm-text-secondary);
+}
+.caramel-manual-feedback:focus-visible {
+    outline: 2px solid var(--cm-brand);
+    outline-offset: 2px;
+    border-radius: 2px;
+}
 
 @media (prefers-reduced-motion: reduce) {
     .cm-prompt,

--- a/apps/caramel-extension/manifest-firefox.json
+++ b/apps/caramel-extension/manifest-firefox.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Caramel - Trusted Honey Alternative",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "Open‑source coupon extension that auto‑applies deals without selling data or hijacking commissions.",
     "browser_specific_settings": {
         "gecko": {

--- a/apps/caramel-extension/manifest.json
+++ b/apps/caramel-extension/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Caramel - Trusted Honey Alternative",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "Open‑source coupon extension that auto‑applies deals without selling data or hijacking commissions.",
     "browser_specific_settings": {
         "gecko": {

--- a/apps/caramel-extension/package.json
+++ b/apps/caramel-extension/package.json
@@ -1,6 +1,6 @@
 {
     "name": "caramel-extension",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "Caramel browser extension",
     "private": true,
     "scripts": {

--- a/apps/caramel-extension/tests/final-modal-exits.test.mjs
+++ b/apps/caramel-extension/tests/final-modal-exits.test.mjs
@@ -138,10 +138,13 @@ describe('the button only promises what happened', () => {
         expect(label()).toBe('Proceed to Checkout')
     })
 
-    it('says Done when the card is a list of codes to copy', async () => {
+    it('drops the primary button entirely on a list-of-codes card (lighter UI)', async () => {
+        // The card carries its own controls (copy buttons, the report link) and
+        // three ways out (×, scrim, Esc) — a generic "Done" under all that is
+        // just clutter.
         await showFinalModal(0, null, null, false, [{ code: 'SAVE10' }])
 
-        expect(label()).toBe('Done')
+        expect(root().querySelector('#caramel-final-ok-btn')).toBeNull()
     })
 
     it('says Sign In when that is the ask', async () => {

--- a/apps/caramel-extension/tests/manual-list-guest-gate.test.mjs
+++ b/apps/caramel-extension/tests/manual-list-guest-gate.test.mjs
@@ -1,0 +1,142 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import {
+    EXT_ROOT,
+    backStorageArea,
+    loadExtensionSource,
+    loadExtensionSources,
+} from './_load.mjs'
+
+// The manual "Grab a code" fallback must not hand a signed-out shopper more
+// codes than the popup does. The popup caps a guest at GUEST_COUPON_LIMIT (6)
+// with a sign-in nudge (popup.js couponGuestGateHtml); before this the fallback
+// showed up to CARAMEL_MANUAL_LIST_MAX (20) to EVERYONE — a guest could copy
+// more codes here than the popup would ever show them, leaking the gated value
+// and skipping the growth nudge. Members still get the full list. This pins the
+// consistency so the two surfaces can't drift apart again.
+
+let showFinalModal
+
+const root = () =>
+    document.getElementById('caramel-final-overlay')?.shadowRoot ?? null
+const rows = () => root()?.querySelectorAll('.caramel-manual-row') ?? []
+const gate = () => root()?.querySelector('.caramel-manual-gate') ?? null
+const loginBtn = () => root()?.querySelector('#caramel-manual-login') ?? null
+const feedbackLink = () =>
+    root()?.querySelector('#caramel-manual-feedback') ?? null
+const mounted = () => !!document.getElementById('caramel-final-overlay')
+
+const click = el =>
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }))
+
+// N distinct code rows — every one un-rejected, so ordering is stable.
+const codes = n =>
+    Array.from({ length: n }, (_, i) => ({
+        code: `CODE${i + 1}`,
+        title: `${i + 1}% off`,
+    }))
+
+const asGuest = () => {
+    backStorageArea('local', {})
+    backStorageArea('sync', {})
+}
+const asMember = () => {
+    backStorageArea('local', { token: 'tok', user: { username: 'shopper' } })
+    backStorageArea('sync', {})
+}
+
+beforeAll(() => {
+    loadExtensionSource('coupon-constants.generated.js', [])
+    ;({ showFinalModal } = loadExtensionSources(
+        [
+            'caramel-base.js',
+            'dom-utils.js',
+            'store-detect.js',
+            'coupon-apply.js',
+            'coupon-fetch.js',
+            'coupon-runner.js',
+            'UI-helpers.js',
+        ],
+        ['showFinalModal'],
+    ))
+    globalThis.currentBrowser.runtime.getURL = p => p
+    globalThis.fetch = async relPath => ({
+        ok: true,
+        text: async () => readFileSync(join(EXT_ROOT, relPath), 'utf8'),
+    })
+})
+
+beforeEach(() => {
+    document.body.innerHTML = ''
+})
+
+describe('the fallback code list matches the popup guest cap', () => {
+    it('caps a signed-out shopper at the guest limit (6) when there are more', async () => {
+        asGuest()
+        await showFinalModal(0, null, null, false, codes(10))
+
+        expect(rows().length).toBe(6)
+    })
+
+    it('offers the one action that reveals the rest — the count lives in the button', async () => {
+        asGuest()
+        await showFinalModal(0, null, null, false, codes(10))
+
+        expect(gate()).not.toBeNull()
+        expect(loginBtn()).not.toBeNull()
+        expect(loginBtn().textContent).toMatch(/Sign in for all 10 codes/)
+    })
+
+    it('shows a signed-in shopper the full list, with no gate', async () => {
+        asMember()
+        await showFinalModal(0, null, null, false, codes(10))
+
+        expect(rows().length).toBe(10)
+        expect(gate()).toBeNull()
+    })
+
+    it('does not gate a guest when the store has at or under the cap', async () => {
+        // The gate only exists when it hides something — a short list looks
+        // identical to guest and member (popup rule).
+        asGuest()
+        await showFinalModal(0, null, null, false, codes(4))
+
+        expect(rows().length).toBe(4)
+        expect(gate()).toBeNull()
+    })
+
+    it('the sign-in nudge opens the popup and closes the card', async () => {
+        asGuest()
+        const sent = []
+        globalThis.currentBrowser.runtime.sendMessage = msg => sent.push(msg)
+        await showFinalModal(0, null, null, false, codes(10))
+
+        click(loginBtn())
+
+        expect(mounted()).toBe(false)
+        expect(sent).toContainEqual({ action: 'openPopup' })
+    })
+})
+
+describe('the fallback offers a graceful way to report a problem', () => {
+    it('links to the prod support/feedback form whenever codes are offered', async () => {
+        asGuest()
+        await showFinalModal(0, null, null, false, codes(3))
+
+        const link = feedbackLink()
+        expect(link).not.toBeNull()
+        expect(link.getAttribute('href')).toMatch(
+            /^https:\/\/grabcaramel\.com\/support$/,
+        )
+        expect(link.getAttribute('target')).toBe('_blank')
+        expect(link.getAttribute('rel')).toMatch(/noopener/)
+    })
+
+    it('does not show the report link on a success card', async () => {
+        asMember()
+        await showFinalModal(12.5, 'SAVE10')
+
+        expect(feedbackLink()).toBeNull()
+    })
+})


### PR DESCRIPTION
Ships the extension UX pass the owner asked for on the auto-apply "Grab a code" fallback, and bumps the extension to **1.3.1** (the release train for the post-1.3.0 main fixes + this).

## What changed (extension only)
- **Fallback list now matches the popup's guest cap.** The manual "Grab a code" list was showing up to `CARAMEL_MANUAL_LIST_MAX` (20) to *everyone* — a signed-out shopper could copy more codes here than the popup (`GUEST_COUPON_LIMIT` = 6) ever shows them, leaking the gated value and skipping the sign-in nudge. Guests now see 6 + a **"Sign in for all N codes"** button (opens the popup); members still see the full list. Login state via `caramelGetSession()`.
- **Report-a-problem link** to the prod `/support` form at the foot of the fallback card (opens in a new tab), so a shopper can flag a broken store/code.
- **Removed the "Done" button** on the fallback card — lighter UI; the × / scrim / Esc are the three ways out.

## Proof
- `vitest` **744** (new `tests/manual-list-guest-gate.test.mjs`: guest -> 6, member -> full, no-gate-when-<=cap, sign-in button opens popup, report link -> `/support`, no link on a win; updated `final-modal-exits` for the dropped button).
- guards **57/57**, eslint clean (pre-existing `no-console` in untouched `caramel-base.js`), prettier clean, knip ok.

Tag `v1.3.1` after merge fires the release (Chrome draft, Firefox submit, Apple upload); Chrome draft then published via the manual submit workflow.