### PR TITLE
fix(pwa): prune manifest icons to a correct square-only set

### DIFF
--- a/apps/caramel-app/public/manifest.json
+++ b/apps/caramel-app/public/manifest.json
@@ -11,453 +11,52 @@
     "theme_color": "#ea6925",
     "icons": [
         {
-            "src": "/app/windows11/SmallTile.scale-100.png",
-            "sizes": "71x71"
+            "src": "/app/android/android-launchericon-48-48.png",
+            "sizes": "48x48",
+            "type": "image/png",
+            "purpose": "any"
         },
         {
-            "src": "/app/windows11/SmallTile.scale-125.png",
-            "sizes": "89x89"
+            "src": "/app/android/android-launchericon-72-72.png",
+            "sizes": "72x72",
+            "type": "image/png",
+            "purpose": "any"
         },
         {
-            "src": "/app/windows11/SmallTile.scale-150.png",
-            "sizes": "107x107"
+            "src": "/app/android/android-launchericon-96-96.png",
+            "sizes": "96x96",
+            "type": "image/png",
+            "purpose": "any"
         },
         {
-            "src": "/app/windows11/SmallTile.scale-200.png",
-            "sizes": "142x142"
+            "src": "/app/android/android-launchericon-144-144.png",
+            "sizes": "144x144",
+            "type": "image/png",
+            "purpose": "any"
         },
         {
-            "src": "/app/windows11/SmallTile.scale-400.png",
-            "sizes": "284x284"
+            "src": "/app/android/android-launchericon-192-192.png",
+            "sizes": "192x192",
+            "type": "image/png",
+            "purpose": "any"
         },
         {
-            "src": "/app/windows11/Square150x150Logo.scale-100.png",
-            "sizes": "150x150"
+            "src": "/app/ios/512.png",
+            "sizes": "512x512",
+            "type": "image/png",
+            "purpose": "any"
         },
         {
-            "src": "/app/windows11/Square150x150Logo.scale-125.png",
-            "sizes": "188x188"
-        },
-        {
-            "src": "/app/windows11/Square150x150Logo.scale-150.png",
-            "sizes": "225x225"
-        },
-        {
-            "src": "/app/windows11/Square150x150Logo.scale-200.png",
-            "sizes": "300x300"
-        },
-        {
-            "src": "/app/windows11/Square150x150Logo.scale-400.png",
-            "sizes": "600x600"
-        },
-        {
-            "src": "/app/windows11/Wide310x150Logo.scale-100.png",
-            "sizes": "310x150"
-        },
-        {
-            "src": "/app/windows11/Wide310x150Logo.scale-125.png",
-            "sizes": "388x188"
-        },
-        {
-            "src": "/app/windows11/Wide310x150Logo.scale-150.png",
-            "sizes": "465x225"
-        },
-        {
-            "src": "/app/windows11/Wide310x150Logo.scale-200.png",
-            "sizes": "620x300"
-        },
-        {
-            "src": "/app/windows11/Wide310x150Logo.scale-400.png",
-            "sizes": "1240x600"
-        },
-        {
-            "src": "/app/windows11/LargeTile.scale-100.png",
-            "sizes": "310x310"
-        },
-        {
-            "src": "/app/windows11/LargeTile.scale-125.png",
-            "sizes": "388x388"
-        },
-        {
-            "src": "/app/windows11/LargeTile.scale-150.png",
-            "sizes": "465x465"
-        },
-        {
-            "src": "/app/windows11/LargeTile.scale-200.png",
-            "sizes": "620x620"
-        },
-        {
-            "src": "/app/windows11/LargeTile.scale-400.png",
-            "sizes": "1240x1240"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.scale-100.png",
-            "sizes": "44x44"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.scale-125.png",
-            "sizes": "55x55"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.scale-150.png",
-            "sizes": "66x66"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.scale-200.png",
-            "sizes": "88x88"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.scale-400.png",
-            "sizes": "176x176"
-        },
-        {
-            "src": "/app/windows11/StoreLogo.scale-100.png",
-            "sizes": "50x50"
-        },
-        {
-            "src": "/app/windows11/StoreLogo.scale-125.png",
-            "sizes": "63x63"
-        },
-        {
-            "src": "/app/windows11/StoreLogo.scale-150.png",
-            "sizes": "75x75"
-        },
-        {
-            "src": "/app/windows11/StoreLogo.scale-200.png",
-            "sizes": "100x100"
-        },
-        {
-            "src": "/app/windows11/StoreLogo.scale-400.png",
-            "sizes": "200x200"
-        },
-        {
-            "src": "/app/windows11/SplashScreen.scale-100.png",
-            "sizes": "620x300"
-        },
-        {
-            "src": "/app/windows11/SplashScreen.scale-125.png",
-            "sizes": "775x375"
-        },
-        {
-            "src": "/app/windows11/SplashScreen.scale-150.png",
-            "sizes": "930x450"
-        },
-        {
-            "src": "/app/windows11/SplashScreen.scale-200.png",
-            "sizes": "1240x600"
-        },
-        {
-            "src": "/app/windows11/SplashScreen.scale-400.png",
-            "sizes": "2480x1200"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.targetsize-16.png",
-            "sizes": "16x16"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.targetsize-20.png",
-            "sizes": "20x20"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.targetsize-24.png",
-            "sizes": "24x24"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.targetsize-30.png",
-            "sizes": "30x30"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.targetsize-32.png",
-            "sizes": "32x32"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.targetsize-36.png",
-            "sizes": "36x36"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.targetsize-40.png",
-            "sizes": "40x40"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.targetsize-44.png",
-            "sizes": "44x44"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.targetsize-48.png",
-            "sizes": "48x48"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.targetsize-60.png",
-            "sizes": "60x60"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.targetsize-64.png",
-            "sizes": "64x64"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.targetsize-72.png",
-            "sizes": "72x72"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.targetsize-80.png",
-            "sizes": "80x80"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.targetsize-96.png",
-            "sizes": "96x96"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.targetsize-256.png",
-            "sizes": "256x256"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-unplated_targetsize-16.png",
-            "sizes": "16x16"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-unplated_targetsize-20.png",
-            "sizes": "20x20"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-unplated_targetsize-24.png",
-            "sizes": "24x24"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-unplated_targetsize-30.png",
-            "sizes": "30x30"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-unplated_targetsize-32.png",
-            "sizes": "32x32"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-unplated_targetsize-36.png",
-            "sizes": "36x36"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-unplated_targetsize-40.png",
-            "sizes": "40x40"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-unplated_targetsize-44.png",
-            "sizes": "44x44"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-unplated_targetsize-48.png",
-            "sizes": "48x48"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-unplated_targetsize-60.png",
-            "sizes": "60x60"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-unplated_targetsize-64.png",
-            "sizes": "64x64"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-unplated_targetsize-72.png",
-            "sizes": "72x72"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-unplated_targetsize-80.png",
-            "sizes": "80x80"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-unplated_targetsize-96.png",
-            "sizes": "96x96"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-unplated_targetsize-256.png",
-            "sizes": "256x256"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-lightunplated_targetsize-16.png",
-            "sizes": "16x16"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-lightunplated_targetsize-20.png",
-            "sizes": "20x20"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-lightunplated_targetsize-24.png",
-            "sizes": "24x24"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-lightunplated_targetsize-30.png",
-            "sizes": "30x30"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-lightunplated_targetsize-32.png",
-            "sizes": "32x32"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-lightunplated_targetsize-36.png",
-            "sizes": "36x36"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-lightunplated_targetsize-40.png",
-            "sizes": "40x40"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-lightunplated_targetsize-44.png",
-            "sizes": "44x44"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-lightunplated_targetsize-48.png",
-            "sizes": "48x48"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-lightunplated_targetsize-60.png",
-            "sizes": "60x60"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-lightunplated_targetsize-64.png",
-            "sizes": "64x64"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-lightunplated_targetsize-72.png",
-            "sizes": "72x72"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-lightunplated_targetsize-80.png",
-            "sizes": "80x80"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-lightunplated_targetsize-96.png",
-            "sizes": "96x96"
-        },
-        {
-            "src": "/app/windows11/Square44x44Logo.altform-lightunplated_targetsize-256.png",
-            "sizes": "256x256"
+            "src": "/app/ios/1024.png",
+            "sizes": "1024x1024",
+            "type": "image/png",
+            "purpose": "any"
         },
         {
             "src": "/app/android/android-launchericon-512-512.png",
             "sizes": "512x512",
+            "type": "image/png",
             "purpose": "maskable"
-        },
-        {
-            "src": "/app/android/android-launchericon-192-192.png",
-            "sizes": "192x192"
-        },
-        {
-            "src": "/app/android/android-launchericon-144-144.png",
-            "sizes": "144x144"
-        },
-        {
-            "src": "/app/android/android-launchericon-96-96.png",
-            "sizes": "96x96"
-        },
-        {
-            "src": "/app/android/android-launchericon-72-72.png",
-            "sizes": "72x72"
-        },
-        {
-            "src": "/app/android/android-launchericon-48-48.png",
-            "sizes": "48x48"
-        },
-        {
-            "src": "/app/ios/16.png",
-            "sizes": "16x16"
-        },
-        {
-            "src": "/app/ios/20.png",
-            "sizes": "20x20"
-        },
-        {
-            "src": "/app/ios/29.png",
-            "sizes": "29x29"
-        },
-        {
-            "src": "/app/ios/32.png",
-            "sizes": "32x32"
-        },
-        {
-            "src": "/app/ios/40.png",
-            "sizes": "40x40"
-        },
-        {
-            "src": "/app/ios/50.png",
-            "sizes": "50x50"
-        },
-        {
-            "src": "/app/ios/57.png",
-            "sizes": "57x57"
-        },
-        {
-            "src": "/app/ios/58.png",
-            "sizes": "58x58"
-        },
-        {
-            "src": "/app/ios/60.png",
-            "sizes": "60x60"
-        },
-        {
-            "src": "/app/ios/64.png",
-            "sizes": "64x64"
-        },
-        {
-            "src": "/app/ios/72.png",
-            "sizes": "72x72"
-        },
-        {
-            "src": "/app/ios/76.png",
-            "sizes": "76x76"
-        },
-        {
-            "src": "/app/ios/80.png",
-            "sizes": "80x80"
-        },
-        {
-            "src": "/app/ios/87.png",
-            "sizes": "87x87"
-        },
-        {
-            "src": "/app/ios/100.png",
-            "sizes": "100x100"
-        },
-        {
-            "src": "/app/ios/114.png",
-            "sizes": "114x114"
-        },
-        {
-            "src": "/app/ios/120.png",
-            "sizes": "120x120"
-        },
-        {
-            "src": "/app/ios/128.png",
-            "sizes": "128x128"
-        },
-        {
-            "src": "/app/ios/144.png",
-            "sizes": "144x144"
-        },
-        {
-            "src": "/app/ios/152.png",
-            "sizes": "152x152"
-        },
-        {
-            "src": "/app/ios/167.png",
-            "sizes": "167x167"
-        },
-        {
-            "src": "/app/ios/180.png",
-            "sizes": "180x180"
-        },
-        {
-            "src": "/app/ios/192.png",
-            "sizes": "192x192"
-        },
-        {
-            "src": "/app/ios/256.png",
-            "sizes": "256x256"
-        },
-        {
-            "src": "/app/ios/512.png",
-            "sizes": "512x512"
-        },
-        {
-            "src": "/app/ios/1024.png",
-            "sizes": "1024x1024"
         }
     ],
     "id": "grab.caramel",


### PR DESCRIPTION
`apps/caramel-app/public/manifest.json` was a raw unpruned PWABuilder dump: **112 `icons[]` entries**, 10 of them **non-square** — including Windows `SplashScreen.scale-400.png` at **2480x1200** and the `Wide310x150Logo.*` tile plates. Any consumer that picks "the largest icon" (stores, link unfurlers, install UI, AI crawlers) got a wide splash image instead of an app icon.

## Change

`icons[]` pruned 112 -> 8. Manifest pruning **only** — no icon artwork was replaced, recoloured, or regenerated; every entry still points at the same files already in the repo.

Kept (all verified square and present on disk):

| size | src | purpose |
|---|---|---|
| 48x48 | `/app/android/android-launchericon-48-48.png` | any |
| 72x72 | `/app/android/android-launchericon-72-72.png` | any |
| 96x96 | `/app/android/android-launchericon-96-96.png` | any |
| 144x144 | `/app/android/android-launchericon-144-144.png` | any |
| 192x192 | `/app/android/android-launchericon-192-192.png` | any |
| 512x512 | `/app/ios/512.png` | any |
| 1024x1024 | `/app/ios/1024.png` | any |
| 512x512 | `/app/android/android-launchericon-512-512.png` | **maskable** |

The maskable declaration is preserved exactly as it was — same file, same purpose. It was the only `purpose` set anywhere in the old 112-entry array, and because the old array had no `purpose: "any"` 512, the `any` 512 slot is now filled by `/app/ios/512.png`.

Removed: 10 non-square splash/wide-tile entries, plus the redundant Windows tile/targetsize/altform and iOS ladders that added no resolution the kept set doesn't already cover. `type: "image/png"` and an explicit `purpose` are now declared on every entry.

## Not in scope

- No artwork change — pruning only.
- No `android/`, `ios/`, or native shell launcher icon sets.
- No store metadata, no uploads.

## Verification

- `pnpm vitest run tests/unit/manifest-sync.test.ts tests/unit/repo-integrity.test.ts` — **51 passed, 0 failed**. Neither gate needed changing: both read the *browser-extension* manifests (`apps/caramel-extension/manifest.json` and `manifest-firefox.json`), not this PWA manifest, so the 112-entry shape was never hard-coded in a test.
- Full pre-commit gate (lint-staged, `pnpm -r type-check`, knip x2, `prisma validate`) ran and passed.
- All 8 kept `src` paths resolve on disk; 0 dead references (there were 0 dead references before, too).
- 0 non-square entries remain.
- Parsed-JSON diff with `icons` removed is **byte-identical** to `origin/main` — `name`, `short_name`, `theme_color`, `background_color`, `start_url`, `scope`, `display`, `id`, `lang`, `dir`, `orientation`, `display_override` and `shortcuts` are all untouched.