### PR TITLE
WXT migration P0: scaffold + parity harness + safety net

### DIFF
--- a/.github/workflows/checks-extension.yml
+++ b/.github/workflows/checks-extension.yml
@@ -39,6 +39,17 @@ jobs:
         run: pnpm run test
       - name: Check bundle size
         run: pnpm run size
+      # WXT migration parity harness (P0, 2026-08-12): builds the old dist AND
+      # the WXT .output per browser, then asserts semantic manifest parity
+      # (scripts/parity-expected-diffs.json is the shrink-only allowlist),
+      # NEVER_SHIP file inventory, and the build-time env stamp in both build
+      # systems. Every migration phase must keep this green.
+      - name: Run WXT parity harness
+        run: pnpm run test:parity
+      # TypeScript gate for the WXT surfaces (wxt.config.ts, entrypoints/) —
+      # strict tsc, no any; `wxt prepare` generates .wxt/ types first.
+      - name: Type-check WXT surfaces
+        run: pnpm run type-check
       # Proves the allowlist in scripts/build-dist.mjs actually produces a
       # loadable package — tests/package-contents.test.mjs checks the file list,
       # this checks the build runs and lands the files it promises.

--- a/apps/caramel-extension/.gitignore
+++ b/apps/caramel-extension/.gitignore
@@ -17,6 +17,14 @@
 # minified copies the size gate weighs — rebuilt by `pnpm size`, never shipped
 /.size-cache
 
+# WXT (migration P0): generated types + build output — never committed, never
+# shipped until the parity harness clears the .output artifacts
+/.wxt
+/.output
+
+# parity-harness build of the old dist — compared, never shipped
+/dist-parity
+
 # misc
 .DS_Store
 *.pem

--- a/apps/caramel-extension/entrypoints/background.ts
+++ b/apps/caramel-extension/entrypoints/background.ts
@@ -1,0 +1,12 @@
+/**
+ * TODO(WXT-P1): SCAFFOLD STUB — not the real service worker. The shipping
+ * background is still background.js (Chrome MV3 service_worker; Firefox
+ * background.scripts with caramel-env.js prepended). P1 ports it here.
+ */
+export default defineBackground(() => {
+    // Stamp-first: the flat alias mirrors caramel-env.js, which
+    // scripts/test-extension.mjs reads out of the live worker to prove which
+    // deployment a loaded build resolved to.
+    globalThis.CARAMEL_ENV = Object.freeze(__CARAMEL_ENV__)
+    globalThis.CARAMEL_BASE_URL = __CARAMEL_ENV__.baseUrl
+})

--- a/apps/caramel-extension/entrypoints/content.ts
+++ b/apps/caramel-extension/entrypoints/content.ts
@@ -1,0 +1,17 @@
+/**
+ * TODO(WXT-P1): SCAFFOLD STUB — not the real content script. The shipping
+ * content-script realm is still the 11-file global-scope chain listed in
+ * manifest.json. P1 converts that chain to ES modules and composes it HERE in
+ * the same load order. Until then this stub exists so `wxt build` produces an
+ * output the parity harness (scripts/parity-harness.mjs) can diff.
+ */
+export default defineContentScript({
+    matches: ['https://*/*'],
+    main() {
+        // Stamp-first doctrine: CARAMEL_ENV is assigned before anything else
+        // evaluates, exactly like caramel-env.js loading first in manifest
+        // order today. __CARAMEL_ENV__ is inlined at build time from the
+        // ENVIRONMENTS table in scripts/build-dist.mjs (see wxt.config.ts).
+        globalThis.CARAMEL_ENV = Object.freeze(__CARAMEL_ENV__)
+    },
+})

--- a/apps/caramel-extension/entrypoints/popup/index.html
+++ b/apps/caramel-extension/entrypoints/popup/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+    <!-- TODO(WXT-P2): SCAFFOLD STUB — not the real popup. The shipping popup is
+         still index.html + popup.js (vanilla). P2 rewrites it here as React
+         components on the shared UI package, behavior-identical against the P0
+         characterization pins. -->
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Caramel</title>
+    </head>
+    <body>
+        <main>Caramel</main>
+    </body>
+</html>

--- a/apps/caramel-extension/eslint.config.cjs
+++ b/apps/caramel-extension/eslint.config.cjs
@@ -8,7 +8,15 @@ module.exports = [
     {
         // GENERATED — not hand-maintained (F-006). Regenerate via
         // `pnpm --filter caramel-app generate:coupon-constants`.
-        ignores: ['coupon-constants.generated.js'],
+        // Build outputs (old build: dist*/; WXT: .output/, .wxt/) are
+        // artifacts, never sources — the parity harness owns their contents.
+        ignores: [
+            'coupon-constants.generated.js',
+            'dist/**',
+            'dist-*/**',
+            '.output/**',
+            '.wxt/**',
+        ],
     },
     {
         files: ['**/*.{js,html}'],

--- a/apps/caramel-extension/package.json
+++ b/apps/caramel-extension/package.json
@@ -9,12 +9,17 @@
         "prettier-write": "prettier --write '**/*.{js,html,css,json,md}'",
         "build": "node scripts/build-dist.mjs",
         "build:dev": "node scripts/build-dist.mjs --env=development",
+        "wxt:prepare": "wxt prepare",
+        "wxt:build": "wxt build",
+        "wxt:build:firefox": "wxt build -b firefox --mv3",
+        "type-check": "wxt prepare && tsc --noEmit",
         "package": "zip -r extension.zip ./dist",
         "dev": "web-ext run --target=chromium --source-dir=. --watch-file=./**/*",
         "test": "vitest run",
         "test:e2e": "node scripts/test-extension.mjs",
         "test:guards": "node scripts/test-guards.mjs",
         "test:smoke": "node scripts/smoke-package.mjs ./dist production",
+        "test:parity": "node scripts/parity-harness.mjs",
         "size": "node scripts/measure-size.mjs && size-limit",
         "knip": "knip"
     },
@@ -31,7 +36,9 @@
         "prettier": "3.6.2",
         "prettier-plugin-organize-imports": "4.1.0",
         "size-limit": "12.1.0",
+        "typescript": "5.9.2",
         "vitest": "4.1.10",
-        "web-ext": "8.10.0"
+        "web-ext": "8.10.0",
+        "wxt": "0.21.4"
     }
 }

--- a/apps/caramel-extension/scripts/build-dist.d.mts
+++ b/apps/caramel-extension/scripts/build-dist.d.mts
@@ -1,0 +1,36 @@
+/**
+ * Hand-written declarations for build-dist.mjs, so wxt.config.ts (strict TS)
+ * can import the ENVIRONMENTS table — the one env source of truth — without
+ * pulling every .mjs script into the TypeScript program via allowJs.
+ * Keep in lockstep with build-dist.mjs; the shapes below are load-bearing for
+ * the WXT env stamp (wxt.config.ts) and the parity harness.
+ */
+export interface CaramelEnvironment {
+    readonly baseUrl: string
+    readonly trustedOrigins: readonly string[]
+    readonly verbose: boolean
+}
+
+export declare const ENVIRONMENTS: {
+    readonly production: CaramelEnvironment
+    readonly development: CaramelEnvironment
+}
+
+export declare const SHIPPED: string[]
+export declare const NEVER_SHIP: string[]
+export declare const GENERATED: string[]
+export declare const ENV_FILE: string
+
+export declare function renderEnvStamp(
+    name: keyof typeof ENVIRONMENTS,
+): string
+
+export declare function contentScriptRealmSources(
+    files: string[],
+    options?: { stamp?: string },
+): string[]
+
+export declare function buildDist(options: {
+    outDir: string
+    environment?: string
+}): Promise<{ environment: string; entries: number }>

--- a/apps/caramel-extension/scripts/parity-expected-diffs.json
+++ b/apps/caramel-extension/scripts/parity-expected-diffs.json
@@ -1,0 +1,118 @@
+{
+    "_doc": [
+        "Allowlist of KNOWN differences between the committed golden manifests and the WXT-generated ones, consumed by scripts/parity-harness.mjs.",
+        "Every entry names the phase that retires it. The harness fails on any diff NOT listed here AND on any entry that no longer occurs — this file only shrinks.",
+        "diffs[].path uses the harness's /key/subkey notation; arrays diff as one unit at their own path.",
+        "missingReferences[] are manifest-referenced files a stub build does not carry yet.",
+        "Red-proofed 2026-08-12: removing a live entry AND adding a stale one each failed the harness (exit 1)."
+    ],
+    "diffs": [
+        {
+            "browser": "chrome",
+            "path": "/icons",
+            "reason": "stub build ships no icons yet; P1 moves icons/ into WXT's public dir",
+            "retiredBy": "P1",
+            "added": "2026-08-12"
+        },
+        {
+            "browser": "chrome",
+            "path": "/action/default_icon",
+            "reason": "stub build ships no icons yet; P1 moves icons/ into WXT's public dir",
+            "retiredBy": "P1",
+            "added": "2026-08-12"
+        },
+        {
+            "browser": "chrome",
+            "path": "/action/default_title",
+            "reason": "WXT derives default_title from the popup <title>; harmless addition, golden adopts it at P2",
+            "retiredBy": "P2",
+            "added": "2026-08-12"
+        },
+        {
+            "browser": "chrome",
+            "path": "/action/default_popup",
+            "reason": "WXT names the popup page popup.html; golden index.html dies with the vanilla popup at P2",
+            "retiredBy": "P2",
+            "added": "2026-08-12"
+        },
+        {
+            "browser": "chrome",
+            "path": "/content_scripts",
+            "reason": "stub content script until the P1 ESM port composes the 11-file chain (js list becomes the bundle, css re-attaches)",
+            "retiredBy": "P1",
+            "added": "2026-08-12"
+        },
+        {
+            "browser": "firefox",
+            "path": "/icons",
+            "reason": "stub build ships no icons yet; P1 moves icons/ into WXT's public dir",
+            "retiredBy": "P1",
+            "added": "2026-08-12"
+        },
+        {
+            "browser": "firefox",
+            "path": "/action/default_icon",
+            "reason": "stub build ships no icons yet; P1 moves icons/ into WXT's public dir",
+            "retiredBy": "P1",
+            "added": "2026-08-12"
+        },
+        {
+            "browser": "firefox",
+            "path": "/action/default_title",
+            "reason": "WXT derives default_title from the popup <title>; harmless addition, golden adopts it at P2",
+            "retiredBy": "P2",
+            "added": "2026-08-12"
+        },
+        {
+            "browser": "firefox",
+            "path": "/action/default_popup",
+            "reason": "WXT names the popup page popup.html; golden index.html dies with the vanilla popup at P2",
+            "retiredBy": "P2",
+            "added": "2026-08-12"
+        },
+        {
+            "browser": "firefox",
+            "path": "/content_scripts",
+            "reason": "stub content script until the P1 ESM port composes the 11-file chain (js list becomes the bundle, css re-attaches)",
+            "retiredBy": "P1",
+            "added": "2026-08-12"
+        },
+        {
+            "browser": "firefox",
+            "path": "/background/scripts",
+            "reason": "the env stamp is BUNDLED into background.js instead of a separate manifest entry — the stamp-first guarantee moves from manifest order into the module graph (P1 pins it there)",
+            "retiredBy": "P1",
+            "added": "2026-08-12"
+        }
+    ],
+    "missingReferences": [
+        {
+            "browser": "chrome",
+            "path": "index.html",
+            "reason": "web_accessible_resources still names the vanilla popup page; resolved when P2 lands the React popup and the WAR list is re-derived",
+            "retiredBy": "P2",
+            "added": "2026-08-12"
+        },
+        {
+            "browser": "firefox",
+            "path": "index.html",
+            "reason": "web_accessible_resources still names the vanilla popup page; resolved when P2 lands the React popup and the WAR list is re-derived",
+            "retiredBy": "P2",
+            "added": "2026-08-12"
+        },
+        {
+            "browser": "chrome",
+            "path": "assets/*",
+            "reason": "stub build ships no assets yet; P1 moves assets/ into WXT's public dir",
+            "retiredBy": "P1",
+            "added": "2026-08-12"
+        },
+        {
+            "browser": "firefox",
+            "path": "assets/*",
+            "reason": "stub build ships no assets yet; P1 moves assets/ into WXT's public dir",
+            "retiredBy": "P1",
+            "added": "2026-08-12"
+        }
+    ]
+}

--- a/apps/caramel-extension/scripts/parity-harness.mjs
+++ b/apps/caramel-extension/scripts/parity-harness.mjs
@@ -1,0 +1,307 @@
+/**
+ * WXT migration parity harness (P0 deliverable, 2026-08-12).
+ *
+ * The migration's standing regression gate: proves the WXT build (`.output/`)
+ * converges on the hand-rolled build (`scripts/build-dist.mjs` → dist/) and
+ * that neither world can ship the two incident classes this repo already paid
+ * for — tooling files in the store package, and a store build stamped dev.
+ *
+ * Three assertion families, per browser:
+ *
+ *   1. SEMANTIC MANIFEST DIFF — the committed manifests (manifest.json /
+ *      manifest-firefox.json) are the golden spec; the WXT-generated manifests
+ *      are diffed against them path by path. Every difference must be listed
+ *      in scripts/parity-expected-diffs.json with a reason and the phase that
+ *      retires it. An UNLISTED diff fails; a listed diff that no longer occurs
+ *      ALSO fails (stale entry — the allowlist only shrinks, so "parity" can
+ *      never quietly mean "whatever it currently emits").
+ *
+ *   2. FILE INVENTORY — the old dist must contain exactly SHIPPED+GENERATED;
+ *      no NEVER_SHIP name may exist in dist OR in any .output build; every
+ *      file a generated manifest references must exist in its build.
+ *
+ *   3. ENV STAMP — production builds of BOTH worlds must carry the production
+ *      baseUrl and ZERO dev origins in any shipped .js; a --mode development
+ *      WXT build must carry the dev stamp. This is the Firefox/Safari
+ *      shipped-dev-build incident, pinned against the new build system.
+ *
+ * Runs standalone (like test-guards.mjs): `pnpm test:parity`. Builds
+ * everything it checks into gitignored directories; never touches dist/.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+    buildDist,
+    ENVIRONMENTS,
+    GENERATED,
+    NEVER_SHIP,
+    SHIPPED,
+} from './build-dist.mjs'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const OUT = join(ROOT, '.output')
+const DIST_PARITY = join(ROOT, 'dist-parity')
+
+const EXPECTED = JSON.parse(
+    readFileSync(join(ROOT, 'scripts', 'parity-expected-diffs.json'), 'utf8'),
+)
+
+const failures = []
+let checks = 0
+const check = (ok, label) => {
+    checks += 1
+    if (ok) console.log(`  PASS  ${label}`)
+    else {
+        failures.push(label)
+        console.error(`  FAIL  ${label}`)
+    }
+}
+
+/* ------------------------------------------------------------------ builds */
+
+// The four artifacts under test. wxt is invoked through its own bin so the
+// harness runs identically on a dev machine and in CI (no npx resolution).
+const WXT_BIN = join(ROOT, 'node_modules', 'wxt', 'bin', 'wxt.mjs')
+const wxt = args =>
+    execFileSync(process.execPath, [WXT_BIN, ...args], {
+        cwd: ROOT,
+        stdio: ['ignore', 'ignore', 'inherit'],
+    })
+
+console.log('building: old dist (production) + WXT chrome/firefox/dev …')
+await buildDist({ outDir: DIST_PARITY })
+wxt(['build'])
+wxt(['build', '-b', 'firefox', '--mv3'])
+wxt(['build', '--mode', 'development'])
+
+const BUILDS = {
+    chrome: {
+        golden: JSON.parse(readFileSync(join(ROOT, 'manifest.json'), 'utf8')),
+        outDir: join(OUT, 'chrome-mv3'),
+    },
+    firefox: {
+        golden: JSON.parse(
+            readFileSync(join(ROOT, 'manifest-firefox.json'), 'utf8'),
+        ),
+        outDir: join(OUT, 'firefox-mv3'),
+    },
+}
+const DEV_OUT = join(OUT, 'chrome-mv3-dev')
+
+/* ------------------------------------------------- 1. semantic manifest diff */
+
+/** Keys whose array ORDER is meaningless — compared as sets. Content-script
+ *  js order is load-bearing and is deliberately NOT here. */
+const UNORDERED = new Set(['permissions', 'host_permissions', 'matches'])
+
+const sortIf = (key, value) =>
+    Array.isArray(value) && UNORDERED.has(key) ? value.toSorted() : value
+
+/** Flat list of {path, golden, actual} differences between two manifests.
+ *  Arrays diff as one unit at their own path — a reshaped content-script list
+ *  is ONE diff to explain, not eleven. */
+function diffManifests(golden, actual, path = '') {
+    const diffs = []
+    const keys = new Set([...Object.keys(golden), ...Object.keys(actual)])
+    for (const key of keys) {
+        const p = `${path}/${key}`
+        const g = sortIf(key, golden[key])
+        const a = sortIf(key, actual[key])
+        if (g === undefined || a === undefined || typeof g !== typeof a) {
+            if (JSON.stringify(g) !== JSON.stringify(a))
+                diffs.push({ path: p, golden: g, actual: a })
+        } else if (Array.isArray(g) || typeof g !== 'object') {
+            if (JSON.stringify(g) !== JSON.stringify(a))
+                diffs.push({ path: p, golden: g, actual: a })
+        } else {
+            diffs.push(...diffManifests(g, a, p))
+        }
+    }
+    return diffs
+}
+
+for (const [browser, { golden, outDir }] of Object.entries(BUILDS)) {
+    const manifest = JSON.parse(
+        readFileSync(join(outDir, 'manifest.json'), 'utf8'),
+    )
+    const diffs = diffManifests(golden, manifest)
+    const expected = EXPECTED.diffs.filter(e => e.browser === browser)
+    const expectedPaths = new Set(expected.map(e => e.path))
+    const actualPaths = new Set(diffs.map(d => d.path))
+
+    for (const d of diffs) {
+        check(
+            expectedPaths.has(d.path),
+            `${browser} manifest ${d.path}: ${JSON.stringify(d.golden)} → ${JSON.stringify(d.actual)}` +
+                (expectedPaths.has(d.path) ? '' : ' (UNEXPECTED diff)'),
+        )
+    }
+    for (const e of expected) {
+        check(
+            actualPaths.has(e.path),
+            `${browser} expected-diff ${e.path} still occurs (else remove the stale entry: ${e.reason})`,
+        )
+    }
+}
+
+/* ------------------------------------------------------- 2. file inventory */
+
+const walk = dir =>
+    readdirSync(dir, { withFileTypes: true, recursive: true })
+        .filter(entry => entry.isFile())
+        .map(entry =>
+            // entry.path is the pre-22 name of parentPath — CI still runs both
+            relative(
+                dir,
+                join(entry.parentPath ?? entry.path, entry.name),
+            ).replaceAll('\\', '/'),
+        )
+
+// Old dist is exactly the allowlist — nothing more, nothing less.
+{
+    const files = walk(DIST_PARITY).toSorted()
+    const allowed = [...SHIPPED, ...GENERATED]
+    const allowedSet = new Set(allowed)
+    const ships = p =>
+        allowedSet.has(p) || allowed.some(entry => p.startsWith(entry + '/'))
+    const extras = files.filter(f => !ships(f))
+    check(
+        extras.length === 0,
+        `old dist contains only SHIPPED+GENERATED (extras: ${extras.join(', ') || 'none'})`,
+    )
+    const missing = allowed.filter(
+        entry =>
+            !files.includes(entry) &&
+            !files.some(f => f.startsWith(entry + '/')),
+    )
+    check(
+        missing.length === 0,
+        `old dist contains every SHIPPED+GENERATED entry (missing: ${missing.join(', ') || 'none'})`,
+    )
+}
+
+// NEVER_SHIP names must not exist in ANY artifact of either build system.
+for (const [label, dir] of [
+    ['old dist', DIST_PARITY],
+    ['wxt chrome', BUILDS.chrome.outDir],
+    ['wxt firefox', BUILDS.firefox.outDir],
+    ['wxt dev', DEV_OUT],
+]) {
+    const files = walk(dir)
+    const violations = NEVER_SHIP.filter(entry =>
+        files.some(f => f === entry || f.startsWith(entry + '/')),
+    )
+    check(
+        violations.length === 0,
+        `${label}: no NEVER_SHIP file reaches the package (found: ${violations.join(', ') || 'none'})`,
+    )
+}
+
+// Every file a generated manifest references must exist in its own build.
+// web_accessible_resources entries may be globs; a glob counts as satisfied
+// when any packaged file matches it. Missing references listed in the
+// expected-diffs "references" allowlist are stub gaps a later phase closes.
+for (const [browser, { outDir }] of Object.entries(BUILDS)) {
+    const manifest = JSON.parse(
+        readFileSync(join(outDir, 'manifest.json'), 'utf8'),
+    )
+    const files = walk(outDir)
+    const refs = []
+    for (const cs of manifest.content_scripts ?? []) {
+        refs.push(...(cs.js ?? []), ...(cs.css ?? []))
+    }
+    if (manifest.background?.service_worker)
+        refs.push(manifest.background.service_worker)
+    refs.push(...(manifest.background?.scripts ?? []))
+    if (manifest.action?.default_popup) refs.push(manifest.action.default_popup)
+    refs.push(...Object.values(manifest.icons ?? {}))
+    refs.push(...Object.values(manifest.action?.default_icon ?? {}))
+    for (const war of manifest.web_accessible_resources ?? [])
+        refs.push(...(war.resources ?? []))
+
+    const allowedMissing = new Set(
+        EXPECTED.missingReferences
+            .filter(e => e.browser === browser)
+            .map(e => e.path),
+    )
+    for (const ref of refs) {
+        const rel = ref.replace(/^\//, '')
+        const found = rel.includes('*')
+            ? files.some(f =>
+                  new RegExp(
+                      '^' +
+                          rel
+                              .replaceAll(/[.+^${}()|[\]\\]/g, '\\$&')
+                              .replaceAll('*', '.*') +
+                          '$',
+                  ).test(f),
+              )
+            : files.includes(rel)
+        if (found) {
+            check(true, `${browser}: manifest reference ${ref} exists`)
+            if (allowedMissing.has(ref))
+                check(
+                    false,
+                    `${browser}: ${ref} exists now — remove its stale missingReferences entry`,
+                )
+        } else {
+            check(
+                allowedMissing.has(ref),
+                `${browser}: manifest references ${ref} which is missing from the build` +
+                    (allowedMissing.has(ref) ? ' (allowlisted stub gap)' : ''),
+            )
+        }
+    }
+}
+
+/* ------------------------------------------------------------ 3. env stamp */
+
+const PROD = ENVIRONMENTS.production
+const DEV = ENVIRONMENTS.development
+const jsFiles = dir => walk(dir).filter(f => f.endsWith('.js'))
+const readAll = (dir, list) =>
+    list.map(f => readFileSync(join(dir, f), 'utf8')).join('\n')
+
+for (const [label, dir] of [
+    ['old dist (production)', DIST_PARITY],
+    ['wxt chrome (production)', BUILDS.chrome.outDir],
+    ['wxt firefox (production)', BUILDS.firefox.outDir],
+]) {
+    const all = readAll(dir, jsFiles(dir))
+    check(
+        all.includes(PROD.baseUrl),
+        `${label}: carries the production baseUrl ${PROD.baseUrl}`,
+    )
+    for (const origin of DEV.trustedOrigins) {
+        check(
+            !all.includes(origin),
+            `${label}: no dev origin ${origin} in any shipped js`,
+        )
+    }
+    check(!all.includes(DEV.baseUrl), `${label}: no dev baseUrl in shipped js`)
+}
+{
+    const all = readAll(DEV_OUT, jsFiles(DEV_OUT))
+    check(
+        all.includes(DEV.baseUrl),
+        `wxt --mode development: carries the dev baseUrl ${DEV.baseUrl}`,
+    )
+    check(
+        all.includes('"isProduction":false') ||
+            all.includes('isProduction: false') ||
+            all.includes('isProduction:!1') ||
+            all.includes('isProduction:false'),
+        'wxt --mode development: stamp says isProduction false',
+    )
+}
+
+/* ------------------------------------------------------------------ report */
+
+console.log(`\n${checks - failures.length}/${checks} parity checks passed.`)
+if (failures.length > 0) {
+    console.error(`\n${failures.length} parity failure(s).`)
+    process.exit(1)
+}

--- a/apps/caramel-extension/tests/background-caller-relay.test.mjs
+++ b/apps/caramel-extension/tests/background-caller-relay.test.mjs
@@ -1,0 +1,97 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+import { getOnMessageListeners, loadExtensionSource } from './_load.mjs'
+
+// WXT-migration P0 characterization pins (2026-08-12): the worker half of the
+// checkout-modal caller relay (popup half: popup-caller-relay.test.mjs).
+//
+// Contract under pin (background.js:267-283):
+//   - openPopup from a store tab opens a POPUP WINDOW whose URL carries
+//     `index.html?isPopup=true&callerId=<sender tab id>` — the query string
+//     popup.js reads at module-eval time.
+//   - `userLoggedInFromPopup_<id>` routes {action:'userLoggedIn'} to tab <id>
+//     AS A NUMBER (the worker parses the id with split('_')[1] + parseInt —
+//     which only works while the prefix contains exactly one underscore, the
+//     trailing one; the round-trip test below is what breaks if anyone
+//     renames the action to snake_case).
+
+let handler
+
+beforeAll(() => {
+    loadExtensionSource('background.js', [])
+    ;[handler] = getOnMessageListeners()
+})
+
+const invoke = (message, sender = {}) =>
+    new Promise(resolve => {
+        handler(message, sender, resolve)
+    })
+
+describe('background.js caller relay', () => {
+    it('openPopup opens a popup window addressed back to the calling tab', async () => {
+        const created = []
+        globalThis.chrome.runtime.getURL = p =>
+            'chrome-extension://test-ext-id/' + p
+        globalThis.chrome.windows.create = w => created.push(w)
+
+        const resp = await invoke({ action: 'openPopup' }, { tab: { id: 42 } })
+
+        expect(resp).toEqual({ success: true })
+        expect(created).toHaveLength(1)
+        expect(created[0].url).toBe(
+            'chrome-extension://test-ext-id/index.html?isPopup=true&callerId=42',
+        )
+        expect(created[0].type).toBe('popup')
+    })
+
+    it('a senderless openPopup still opens, with an empty callerId (toolbar-branch popup)', async () => {
+        const created = []
+        globalThis.chrome.runtime.getURL = p =>
+            'chrome-extension://test-ext-id/' + p
+        globalThis.chrome.windows.create = w => created.push(w)
+
+        await invoke({ action: 'openPopup' }, {})
+
+        expect(created[0].url).toBe(
+            'chrome-extension://test-ext-id/index.html?isPopup=true&callerId=',
+        )
+    })
+
+    it('userLoggedInFromPopup_<id> routes userLoggedIn to that tab, id as a NUMBER', async () => {
+        const sent = []
+        globalThis.chrome.tabs.sendMessage = (tabId, message) => {
+            sent.push({ tabId, message })
+        }
+
+        const resp = await invoke({ action: 'userLoggedInFromPopup_42' })
+
+        expect(resp).toEqual({ success: true })
+        expect(sent).toEqual([
+            { tabId: 42, message: { action: 'userLoggedIn' } },
+        ])
+        expect(sent[0].tabId).toBeTypeOf('number')
+    })
+
+    it('round trip: the callerId the worker MINTS survives its own parse', async () => {
+        // Producer: capture the popup URL openPopup builds for tab 1337.
+        const created = []
+        globalThis.chrome.runtime.getURL = p =>
+            'chrome-extension://test-ext-id/' + p
+        globalThis.chrome.windows.create = w => created.push(w)
+        await invoke({ action: 'openPopup' }, { tab: { id: 1337 } })
+
+        // The popup reads the id off location.search (popup.js:55) and echoes
+        // it back inside the action string (popup.js:61) — replicate exactly.
+        const callerId = new URL(created[0].url).searchParams.get('callerId')
+
+        // Consumer: the echoed action must land on the ORIGINAL tab.
+        const sent = []
+        globalThis.chrome.tabs.sendMessage = (tabId, message) => {
+            sent.push({ tabId, message })
+        }
+        await invoke({ action: 'userLoggedInFromPopup_' + callerId })
+
+        expect(sent).toEqual([
+            { tabId: 1337, message: { action: 'userLoggedIn' } },
+        ])
+    })
+})

--- a/apps/caramel-extension/tests/popup-caller-relay.test.mjs
+++ b/apps/caramel-extension/tests/popup-caller-relay.test.mjs
@@ -1,0 +1,152 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { loadExtensionSource, loadExtensionSources } from './_load.mjs'
+
+// WXT-migration P0 characterization pins (2026-08-12): the checkout-modal
+// caller relay had ZERO coverage, and it is exactly the seam the React/WXT
+// popup rewrite disturbs — CARAMEL_CALLER_ID is read from location.search AT
+// MODULE-EVALUATION TIME (popup.js:55), and its failure mode is silent: the
+// modal's "Sign In" flow simply never resumes in the originating tab.
+//
+// The contract under pin (popup half — background.js's half is pinned in
+// background-caller-relay.test.mjs, including the round trip):
+//   - opened with ?callerId=<tabId>, a successful login sends the worker
+//     `userLoggedInFromPopup_<tabId>` (single underscore before the id — the
+//     worker parses with split('_')[1]) and closes the window ~150ms later,
+//     WITHOUT re-rendering; a dead originating tab must not prevent the close.
+//   - opened normally (toolbar), it re-renders via initPopup() and neither
+//     messages the worker nor closes.
+//
+// popup.js is evaluated per describe-block with the URL already in place,
+// because the id is captured at eval time — a pin in itself: set the URL
+// after load and the relay silently degrades to the toolbar branch.
+
+const POPUP_DOM =
+    '<div id="loading-container"></div>' +
+    '<button id="settingsIcon" style="display:none"></button>' +
+    '<div id="auth-container"></div>'
+
+const loadPopupAt = urlPath => {
+    history.replaceState(null, '', urlPath)
+    document.body.innerHTML = POPUP_DOM
+    loadExtensionSource('coupon-constants.generated.js', [])
+    loadExtensionSources(
+        [
+            'caramel-base.js',
+            'dom-utils.js',
+            'store-detect.js',
+            'coupon-apply.js',
+            'coupon-fetch.js',
+            'coupon-runner.js',
+        ],
+        [],
+    )
+    window.close = vi.fn()
+    return loadExtensionSource('popup.js', ['afterLoginSuccess'])
+        .afterLoginSuccess
+}
+
+describe('caller relay — popup opened by the checkout modal (?callerId=42)', () => {
+    let afterLoginSuccess
+
+    beforeAll(() => {
+        afterLoginSuccess = loadPopupAt('/index.html?isPopup=true&callerId=42')
+    })
+
+    it('notifies the worker with userLoggedInFromPopup_<callerId> and closes ~150ms later, without re-rendering', () => {
+        vi.useFakeTimers()
+        try {
+            const sent = []
+            globalThis.currentBrowser.runtime.sendMessage = m => {
+                sent.push(m)
+                return Promise.resolve()
+            }
+            globalThis.initPopup = vi.fn()
+            window.close = vi.fn()
+
+            afterLoginSuccess()
+
+            // The exact action string is the wire contract: background.js
+            // parses the id with split('_')[1], so the prefix must keep its
+            // single trailing underscore and contain no other one.
+            expect(sent).toEqual([{ action: 'userLoggedInFromPopup_42' }])
+            expect(globalThis.initPopup).not.toHaveBeenCalled()
+
+            // The close is DELAYED so the message reaches the worker first.
+            vi.advanceTimersByTime(149)
+            expect(window.close).not.toHaveBeenCalled()
+            vi.advanceTimersByTime(1)
+            expect(window.close).toHaveBeenCalledTimes(1)
+        } finally {
+            vi.useRealTimers()
+        }
+    })
+
+    it('still closes when the originating tab is gone (sendMessage throws)', () => {
+        vi.useFakeTimers()
+        try {
+            globalThis.currentBrowser.runtime.sendMessage = () => {
+                throw new Error('Could not establish connection')
+            }
+            globalThis.initPopup = vi.fn()
+            window.close = vi.fn()
+
+            expect(() => afterLoginSuccess()).not.toThrow()
+
+            vi.advanceTimersByTime(150)
+            expect(window.close).toHaveBeenCalledTimes(1)
+            expect(globalThis.initPopup).not.toHaveBeenCalled()
+        } finally {
+            vi.useRealTimers()
+        }
+    })
+
+    it('swallows an async rejection from a dead tab (promise-shaped sendMessage)', async () => {
+        vi.useFakeTimers()
+        try {
+            globalThis.currentBrowser.runtime.sendMessage = () =>
+                Promise.reject(new Error('Receiving end does not exist'))
+            window.close = vi.fn()
+
+            afterLoginSuccess()
+            // Let the rejection settle; an unhandled rejection would fail the
+            // suite via vitest's global handler.
+            await Promise.resolve()
+            await Promise.resolve()
+
+            vi.advanceTimersByTime(150)
+            expect(window.close).toHaveBeenCalledTimes(1)
+        } finally {
+            vi.useRealTimers()
+        }
+    })
+})
+
+describe('caller relay — plain toolbar popup (no callerId)', () => {
+    let afterLoginSuccess
+
+    beforeAll(() => {
+        afterLoginSuccess = loadPopupAt('/index.html')
+    })
+
+    it('re-renders in place: initPopup runs, no worker message, no close', () => {
+        vi.useFakeTimers()
+        try {
+            const sent = []
+            globalThis.currentBrowser.runtime.sendMessage = m => {
+                sent.push(m)
+                return Promise.resolve()
+            }
+            globalThis.initPopup = vi.fn()
+            window.close = vi.fn()
+
+            afterLoginSuccess()
+
+            expect(globalThis.initPopup).toHaveBeenCalledTimes(1)
+            expect(sent).toEqual([])
+            vi.advanceTimersByTime(1000)
+            expect(window.close).not.toHaveBeenCalled()
+        } finally {
+            vi.useRealTimers()
+        }
+    })
+})

--- a/apps/caramel-extension/tests/popup-email-login.test.mjs
+++ b/apps/caramel-extension/tests/popup-email-login.test.mjs
@@ -1,0 +1,217 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { loadExtensionSource, loadExtensionSources } from './_load.mjs'
+
+// WXT-migration P0 characterization pins (2026-08-12)
+//
+// The email/password login form (popup.js:1032-1079) is the ONE sign-in path
+// with no automated coverage of what a user sees when it goes wrong — the
+// happy path is proven E2E against prod, and OAuth has four suites of its own.
+// The React popup rewrite reimplements this handler, so its FAILURE copy and
+// its one piece of conditional UI (the "Verify your email" link) are frozen
+// here first. These pins describe the CURRENT vanilla behavior exactly; they
+// are not an endorsement of the copy (see the two notes below), they are the
+// contract the rewrite must either reproduce or consciously change.
+//
+// Note 1 — every failure reads "Login failed: <reason>". The non-ok branch
+// does not render the server's message itself: it THROWS it (popup.js:1068)
+// and the single catch at :1076 prefixes every message it receives. So a
+// server saying "Invalid credentials" surfaces as "Login failed: Invalid
+// credentials", not as the bare string.
+//
+// Note 2 — a non-ok response carrying no `error` field therefore stutters:
+// the fallback is itself the string 'Login failed' (:1055), which the catch
+// then prefixes, producing "Login failed: Login failed". Pinned as-is.
+//
+// Harness mirrors popup-oauth-cancel.test.mjs (same fixture, same load order,
+// window.close stubbed because jsdom's real one tears down the environment).
+let renderSignInPrompt
+let loginRequests
+let loginResponse
+
+beforeAll(() => {
+    document.body.innerHTML =
+        '<div id="loading-container"></div>' +
+        '<button id="settingsIcon" style="display:none"></button>' +
+        '<div id="auth-container"></div>'
+
+    loadExtensionSource('coupon-constants.generated.js', [])
+    loadExtensionSources(
+        [
+            'caramel-base.js',
+            'dom-utils.js',
+            'store-detect.js',
+            'coupon-apply.js',
+            'coupon-fetch.js',
+            'coupon-runner.js',
+        ],
+        [],
+    )
+    globalThis.currentBrowser.tabs.create = () => {}
+    window.close = vi.fn()
+    ;({ renderSignInPrompt } = loadExtensionSource('popup.js', [
+        'renderSignInPrompt',
+    ]))
+})
+
+beforeEach(async () => {
+    loginRequests = []
+    loginResponse = { ok: true, status: 200, json: async () => ({}) }
+    globalThis.fetch = async (url, init) => {
+        loginRequests.push({ url: String(url), init })
+        if (loginResponse instanceof Error) throw loginResponse
+        return loginResponse
+    }
+    // caramel-base.js's session writer is a top-level function declaration, so
+    // it is a replaceable global here. Stubbing it keeps a successful login
+    // from continuing into afterLoginSuccess()/initPopup() — this suite is
+    // about the form, not about what the popup renders next.
+    globalThis.caramelSetSession = vi.fn()
+    await renderSignInPrompt()
+})
+
+/** Fills the form and submits it, then flushes the un-awaited async handler. */
+const submitLogin = async (
+    email = 'shopper@example.com',
+    password = 'hunter2',
+) => {
+    document.getElementById('email').value = email
+    document.getElementById('password').value = password
+    document
+        .getElementById('loginForm')
+        .dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    await new Promise(r => setTimeout(r, 0))
+    await new Promise(r => setTimeout(r, 0))
+}
+
+const errorBox = () => document.getElementById('loginErrorMessage')
+const resendBox = () => document.getElementById('resendVerificationContainer')
+
+const rejectWith = body => {
+    loginResponse = { ok: false, status: 401, json: async () => body }
+}
+
+describe('popup email/password login — the happy path', () => {
+    it('POSTs the credentials to /api/extension/login and hands the session to caramelSetSession', async () => {
+        loginResponse = {
+            ok: true,
+            status: 200,
+            json: async () => ({
+                token: 'fresh-token',
+                username: 'shopper',
+                image: 'https://cdn.example.com/a.png',
+            }),
+        }
+
+        await submitLogin('shopper@example.com', 'hunter2')
+
+        const [request] = loginRequests
+        expect(request.url).toBe(
+            `${globalThis.CARAMEL_ENV.baseUrl}/api/extension/login`,
+        )
+        expect(request.init.method).toBe('POST')
+        expect(JSON.parse(request.init.body)).toEqual({
+            email: 'shopper@example.com',
+            password: 'hunter2',
+        })
+        expect(globalThis.caramelSetSession).toHaveBeenCalledWith(
+            {
+                token: 'fresh-token',
+                user: {
+                    username: 'shopper',
+                    image: 'https://cdn.example.com/a.png',
+                },
+            },
+            expect.any(Function),
+        )
+        expect(errorBox().style.display).toBe('none')
+    })
+})
+
+describe('popup email/password login — what the user sees when it fails', () => {
+    it('shows the rejection reason, prefixed, and leaves the verify-email link hidden', async () => {
+        rejectWith({ error: 'Invalid credentials' })
+
+        await submitLogin()
+
+        // See Note 1: the server's reason arrives via a thrown Error, so the
+        // catch's "Login failed: " prefix is part of what ships.
+        expect(errorBox().textContent).toBe('Login failed: Invalid credentials')
+        expect(errorBox().style.display).toBe('block')
+        // A wrong password is not an unverified account — offering "Verify
+        // your email" here would send the user down a dead end.
+        expect(resendBox().style.display).toBe('none')
+    })
+
+    it('reveals the verify-email link when the rejection is about verification', async () => {
+        rejectWith({ error: 'Please verify your email' })
+
+        await submitLogin()
+
+        expect(errorBox().textContent).toBe(
+            'Login failed: Please verify your email',
+        )
+        expect(resendBox().style.display).toBe('block')
+    })
+
+    it('matches the verification wording case-insensitively and on any of its three spellings', async () => {
+        // popup.js:1058-1062 lowercases the message and tests three substrings.
+        // Each spelling is a real backend phrasing; missing one strands the
+        // user on an unverified account with no route out of the popup.
+        for (const message of [
+            'Email VERIFICATION required',
+            'Account is not verified',
+            'Please Verify your address',
+        ]) {
+            rejectWith({ error: message })
+            await renderSignInPrompt()
+            await submitLogin()
+            expect(resendBox().style.display, message).toBe('block')
+        }
+    })
+
+    it('keeps the verify-email link hidden for an unrelated rejection', async () => {
+        rejectWith({ error: 'Too many attempts, try again later' })
+
+        await submitLogin()
+
+        expect(resendBox().style.display).toBe('none')
+    })
+
+    it("reports a network failure with the browser's own message, not a blank box", async () => {
+        loginResponse = new Error('Failed to fetch')
+
+        await submitLogin()
+
+        expect(errorBox().textContent).toBe('Login failed: Failed to fetch')
+        expect(errorBox().style.display).toBe('block')
+        expect(globalThis.caramelSetSession).not.toHaveBeenCalled()
+    })
+
+    it('falls back to bare copy when the rejection carries no error field — and stutters doing it', async () => {
+        rejectWith({})
+
+        await submitLogin()
+
+        // See Note 2: 'Login failed' is the fallback message, and the catch
+        // prefixes it again. This is the current shipped string.
+        expect(errorBox().textContent).toBe('Login failed: Login failed')
+        expect(errorBox().style.display).toBe('block')
+    })
+
+    it('clears the previous failure before the next attempt, so stale copy never outlives it', async () => {
+        rejectWith({ error: 'Please verify your email' })
+        await submitLogin()
+        expect(resendBox().style.display).toBe('block')
+
+        loginResponse = {
+            ok: true,
+            status: 200,
+            json: async () => ({ token: 't', username: 'u', image: null }),
+        }
+        await submitLogin()
+
+        expect(errorBox().textContent).toBe('')
+        expect(errorBox().style.display).toBe('none')
+        expect(resendBox().style.display).toBe('none')
+    })
+})

--- a/apps/caramel-extension/tests/popup-oauth-authorize-request.test.mjs
+++ b/apps/caramel-extension/tests/popup-oauth-authorize-request.test.mjs
@@ -1,0 +1,217 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+    backStorageArea,
+    loadExtensionSource,
+    loadExtensionSources,
+} from './_load.mjs'
+
+// WXT-migration P0 characterization pins (2026-08-12): the REQUEST half of the
+// popup OAuth flow. popup-oauth-success/cancel.test.mjs pin the response half
+// thoroughly, but nothing asserted what we SEND — the authorize URL's shape,
+// that the redirect_uri is identity.getRedirectURL()'s output (encoded), that
+// the provider window is launched interactive and with the backend's own
+// authorizationUrl — nor the authorize-hop failure branches, the
+// resolve-undefined cancel, the session-write lastError path, or the
+// visibility gate on re-render. Those are exactly what a rewrite rewrites.
+// Mechanics under pin: popup.js handleSocialSignIn (:668-855).
+//
+// Harness mirrors popup-oauth-cancel.test.mjs.
+
+let renderSignInPrompt
+
+beforeAll(() => {
+    document.body.innerHTML =
+        '<div id="loading-container"></div>' +
+        '<button id="settingsIcon" style="display:none"></button>' +
+        '<div id="auth-container"></div>'
+
+    loadExtensionSource('coupon-constants.generated.js', [])
+    loadExtensionSources(
+        [
+            'caramel-base.js',
+            'dom-utils.js',
+            'store-detect.js',
+            'coupon-apply.js',
+            'coupon-fetch.js',
+            'coupon-runner.js',
+        ],
+        [],
+    )
+    globalThis.currentBrowser.tabs.create = () => {}
+    window.close = vi.fn()
+    ;({ renderSignInPrompt } = loadExtensionSource('popup.js', [
+        'renderSignInPrompt',
+    ]))
+    realCaramelSetSession = globalThis.caramelSetSession
+})
+
+// The lastError test swaps caramelSetSession out; every test starts real.
+let realCaramelSetSession
+
+const REDIRECT = 'https://ext-id.chromiumapp.org/'
+
+/** identity present; launchWebAuthFlow behaviour injected, calls recorded. */
+const withIdentity = launchWebAuthFlow => {
+    const launches = []
+    globalThis.currentBrowser.identity = {
+        launchWebAuthFlow: args => {
+            launches.push(args)
+            return launchWebAuthFlow(args)
+        },
+        getRedirectURL: () => REDIRECT,
+    }
+    globalThis.currentBrowser.chrome = undefined
+    return launches
+}
+
+/** Recording fetch: authorize GET then (optionally) the exchange POST. */
+const recordFetch = ({
+    authorize = {
+        ok: true,
+        json: async () => ({
+            authorizationUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+        }),
+    },
+    exchange = {
+        ok: true,
+        json: async () => ({ token: 'tok', username: 'ada', image: null }),
+    },
+} = {}) => {
+    const calls = []
+    globalThis.fetch = async (url, opts) => {
+        calls.push({ url: String(url), opts })
+        return String(url).includes('/api/extension/oauth/authorize')
+            ? authorize
+            : exchange
+    }
+    return calls
+}
+
+const clickProvider = async id => {
+    document.getElementById(id).click()
+    await new Promise(r => setTimeout(r, 0))
+    await new Promise(r => setTimeout(r, 0))
+}
+
+const errorText = () => document.getElementById('loginErrorMessage').textContent
+
+beforeEach(async () => {
+    globalThis.caramelSetSession = realCaramelSetSession
+    recordFetch()
+    await renderSignInPrompt()
+})
+
+describe('popup OAuth — the authorize request we send', () => {
+    it('builds the authorize URL from the env base, the clicked provider, and the ENCODED getRedirectURL() output, then launches the backend-issued URL interactively', async () => {
+        const calls = recordFetch()
+        // Provider window stays open: the request half is fully observable
+        // without ever settling the flow.
+        const launches = withIdentity(() => new Promise(() => {}))
+
+        await clickProvider('googleSignInBtn')
+
+        expect(calls).toHaveLength(1)
+        expect(calls[0].url).toBe(
+            `${CARAMEL_ENV.baseUrl}/api/extension/oauth/authorize?provider=google&redirect_uri=${encodeURIComponent(REDIRECT)}`,
+        )
+        expect(launches).toEqual([
+            {
+                url: 'https://accounts.google.com/o/oauth2/v2/auth',
+                interactive: true,
+            },
+        ])
+    })
+
+    it('sends provider=apple for the Apple button, same URL grammar', async () => {
+        const calls = recordFetch()
+        withIdentity(() => new Promise(() => {}))
+
+        await clickProvider('appleSignInBtn')
+
+        expect(calls[0].url).toBe(
+            `${CARAMEL_ENV.baseUrl}/api/extension/oauth/authorize?provider=apple&redirect_uri=${encodeURIComponent(REDIRECT)}`,
+        )
+    })
+
+    it("surfaces the backend's own error when the authorize hop answers non-ok, and never launches a window", async () => {
+        recordFetch({
+            authorize: {
+                ok: false,
+                status: 503,
+                json: async () => ({ error: 'OAuth backend down' }),
+            },
+        })
+        const launches = withIdentity(() => new Promise(() => {}))
+
+        await clickProvider('googleSignInBtn')
+
+        expect(errorText()).toBe('OAuth sign-in failed: OAuth backend down')
+        expect(launches).toEqual([])
+        expect(document.getElementById('googleSignInBtn').disabled).toBe(false)
+        expect(document.getElementById('appleSignInBtn').disabled).toBe(false)
+    })
+
+    it('treats a 200 with no authorizationUrl as a failure, not a launch of `undefined`', async () => {
+        recordFetch({ authorize: { ok: true, json: async () => ({}) } })
+        const launches = withIdentity(() => new Promise(() => {}))
+
+        await clickProvider('googleSignInBtn')
+
+        expect(errorText()).toMatch(/Failed to get OAuth authorization URL/)
+        expect(launches).toEqual([])
+    })
+})
+
+describe('popup OAuth — settle paths the response suites never reach', () => {
+    it('an engine that RESOLVES undefined on window-close still reads as a cancel', async () => {
+        // Chrome rejects instead (pinned in popup-oauth-cancel.test.mjs); the
+        // !finalCallbackUrl guard covers engines that resolve undefined.
+        withIdentity(async () => undefined)
+
+        await clickProvider('googleSignInBtn')
+
+        expect(errorText()).toBe('Sign-in was cancelled.')
+    })
+
+    it('a session write that fails via chrome.runtime.lastError surfaces the reason and stays signed out', async () => {
+        withIdentity(async () => `${REDIRECT}?code=CODE123&state=S1`)
+        globalThis.initPopup = vi.fn()
+        // Real chrome semantics: lastError is set only inside the failing
+        // callback. caramelSetSession is a top-level function declaration, so
+        // the eval realm resolves it through globalThis — replaceable here.
+        globalThis.caramelSetSession = (_session, cb) => {
+            globalThis.chrome.runtime.lastError = { message: 'disk full' }
+            cb()
+            globalThis.chrome.runtime.lastError = undefined
+        }
+
+        await clickProvider('googleSignInBtn')
+        await vi.waitFor(() =>
+            expect(errorText()).toBe('OAuth sign-in failed: disk full'),
+        )
+
+        expect(globalThis.initPopup).not.toHaveBeenCalled()
+        expect(document.getElementById('googleSignInBtn').disabled).toBe(false)
+    })
+
+    it('a popup already hidden (no caller) banks the session but does not re-render', async () => {
+        withIdentity(async () => `${REDIRECT}?code=CODE123&state=S1`)
+        const local = backStorageArea('local', {})
+        backStorageArea('sync', {})
+        globalThis.initPopup = vi.fn()
+        Object.defineProperty(document, 'visibilityState', {
+            configurable: true,
+            get: () => 'hidden',
+        })
+
+        try {
+            await clickProvider('googleSignInBtn')
+            await vi.waitFor(() => expect(local.token).toBe('tok'))
+            // The settle delay (popup.js:815) has already elapsed once the
+            // token is visible; the gate (:819) must have skipped the render.
+            expect(globalThis.initPopup).not.toHaveBeenCalled()
+        } finally {
+            delete document.visibilityState
+        }
+    })
+})

--- a/apps/caramel-extension/tests/popup-profile-card.test.mjs
+++ b/apps/caramel-extension/tests/popup-profile-card.test.mjs
@@ -1,0 +1,171 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+    backStorageArea,
+    loadExtensionSource,
+    loadExtensionSources,
+} from './_load.mjs'
+
+// WXT-migration P0 characterization pins (2026-08-12)
+//
+// renderProfileCard (popup.js:1085-1115) had ZERO coverage. It is the view a
+// SIGNED-IN user gets whenever the popup cannot read a web tab URL — opened on
+// a new tab, on a chrome:// page, or as its own window — so it is the only
+// place some users ever see their account in the extension, and the only
+// signed-in surface with no coupon list to prove it rendered at all.
+//
+// Three things are frozen: what it paints (username + avatar, with the bundled
+// default when the account has no image), that the `token && !url` branch in
+// initPopup (popup.js:358) really routes here, and that its Log out button is
+// wired to the shared revoke path. The logout MECHANICS (revoke before clear,
+// offline still signs out) are already pinned in popup-logout-revoke.test.mjs
+// — this suite only proves this view's button reaches them, so the rewrite
+// cannot ship a profile card whose logout quietly does nothing.
+let renderProfileCard
+let initPopup
+let tabUrlAnswer
+
+beforeAll(() => {
+    document.body.innerHTML =
+        '<div id="loading-container"></div>' +
+        '<button id="settingsIcon" style="display:none"></button>' +
+        '<div id="auth-container"></div>'
+
+    loadExtensionSource('coupon-constants.generated.js', [])
+    loadExtensionSources(
+        [
+            'caramel-base.js',
+            'dom-utils.js',
+            'store-detect.js',
+            'coupon-apply.js',
+            'coupon-fetch.js',
+            'coupon-runner.js',
+        ],
+        [],
+    )
+    globalThis.currentBrowser.tabs.create = () => {}
+    window.close = vi.fn()
+
+    globalThis.currentBrowser.runtime.sendMessage = (message, cb) => {
+        if (message?.action === 'getActiveTabDomainRecord') {
+            cb(tabUrlAnswer)
+        } else {
+            cb(undefined)
+        }
+    }
+    ;({ renderProfileCard, initPopup } = loadExtensionSource('popup.js', [
+        'renderProfileCard',
+        'initPopup',
+    ]))
+})
+
+beforeEach(() => {
+    document.getElementById('auth-container').innerHTML = ''
+    // A chrome:// tab is a real signed-in-user-with-no-store situation and the
+    // exact input popup.js:310 nulls out, which is what sends initPopup down
+    // the profile-card branch.
+    tabUrlAnswer = { url: 'chrome://newtab/' }
+    // ALWAYS two separate objects: the session lives in local, and a shared
+    // object would let caramelGetSession's pre-migration sync adoption path
+    // see a token it should never find.
+    backStorageArea('local', {
+        token: 'stored-token',
+        user: { username: 'shopper', image: '' },
+    })
+    backStorageArea('sync', {})
+    // The /api/extension/me probe initPopup fires in parallel. A 5xx is the
+    // one answer validateStoredSession treats as "backend hiccup, change
+    // nothing" — so it cannot rewrite the stored user mid-assertion.
+    globalThis.fetch = async () => ({
+        ok: false,
+        status: 503,
+        json: async () => ({}),
+    })
+})
+
+const cardHtml = () => document.getElementById('auth-container').innerHTML
+
+describe('popup profile card — what a signed-in user with no store tab sees', () => {
+    it('paints the account username and its avatar', () => {
+        renderProfileCard({
+            username: 'shopper',
+            image: 'https://cdn.example.com/avatar.png',
+        })
+
+        expect(cardHtml()).toContain('@shopper')
+        const avatar = document.querySelector('.coupons-profile-image')
+        expect(avatar.getAttribute('src')).toBe(
+            'https://cdn.example.com/avatar.png',
+        )
+    })
+
+    it('falls back to the bundled default avatar when the account has no image', () => {
+        // Both shapes an account with no picture arrives in: absent, and the
+        // empty string the login response actually sends. `image?.length` is
+        // what decides, so '' must fall back rather than render src="".
+        for (const user of [
+            { username: 'shopper', image: null },
+            { username: 'shopper', image: '' },
+            { username: 'shopper' },
+        ]) {
+            renderProfileCard(user)
+            expect(
+                document
+                    .querySelector('.coupons-profile-image')
+                    .getAttribute('src'),
+                JSON.stringify(user),
+            ).toBe('assets/default-profile.png')
+        }
+    })
+
+    it('is the view initPopup routes to when there is a session but no readable tab URL', async () => {
+        const seen = []
+        const real = globalThis.renderProfileCard
+        globalThis.renderProfileCard = user => {
+            seen.push(user)
+            return real(user)
+        }
+        try {
+            await initPopup()
+        } finally {
+            globalThis.renderProfileCard = real
+        }
+
+        expect(seen).toHaveLength(1)
+        expect(seen[0]).toEqual({ username: 'shopper', image: '' })
+        expect(cardHtml()).toContain('@shopper')
+    })
+
+    it('shows the settings gear, which is hidden until a view asks for it', () => {
+        document.getElementById('settingsIcon').style.display = 'none'
+
+        renderProfileCard({ username: 'shopper', image: '' })
+
+        const gear = document.getElementById('settingsIcon')
+        expect(gear.style.display).toBe('block')
+        expect(typeof gear.onclick).toBe('function')
+    })
+
+    it('wires Log out to the shared revoke path rather than clearing storage itself', () => {
+        renderProfileCard({ username: 'shopper', image: '' })
+
+        const logoutBtn = document.getElementById('logoutBtn')
+        expect(
+            logoutBtn,
+            'the profile card renders a logout button',
+        ).toBeTruthy()
+
+        const real = globalThis.signOutAndRevoke
+        const spy = vi.fn()
+        globalThis.signOutAndRevoke = spy
+        try {
+            logoutBtn.click()
+        } finally {
+            globalThis.signOutAndRevoke = real
+        }
+
+        expect(spy).toHaveBeenCalledTimes(1)
+        // Second argument is the pressed control — signOutAndRevoke disables
+        // it while the revoke is in flight, so passing it is load-bearing.
+        expect(spy.mock.calls[0][1]).toBe(logoutBtn)
+    })
+})

--- a/apps/caramel-extension/tests/popup-signin-widgets.test.mjs
+++ b/apps/caramel-extension/tests/popup-signin-widgets.test.mjs
@@ -1,0 +1,152 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { loadExtensionSource, loadExtensionSources } from './_load.mjs'
+
+// WXT-migration P0 characterization pins (2026-08-12)
+//
+// The sign-in prompt's three small widgets, none of them covered by the four
+// OAuth suites that share this view. Each is the kind of detail a rewrite
+// drops silently because nothing looks broken in a screenshot:
+//
+//   1. The password show/hide toggle (popup.js:986-1004). It flips the input
+//      type AND keeps aria-pressed/aria-label/the two icons in sync — a
+//      rewrite that only swaps the type leaves a screen reader announcing
+//      "Show password" on a field that is already showing it.
+//   2. The Back button (popup.js:880, :972-976, :983-984). It exists ONLY when
+//      renderSignInPrompt was handed a function, because `returnView` is what
+//      the template branches on; a Back button with nothing behind it would be
+//      a dead control, and no Back button at all strands a user who reached
+//      sign-in from another view.
+//   3. The settings gear is hidden here (popup.js:980-981). It is a shared
+//      header element other views turn ON (wireSettingsGear sets display
+//      block), so this view must actively turn it back off — index.html's
+//      contract is "shown only when the user is logged in".
+//
+// Harness mirrors popup-oauth-cancel.test.mjs.
+let renderSignInPrompt
+
+beforeAll(() => {
+    document.body.innerHTML =
+        '<div id="loading-container"></div>' +
+        '<button id="settingsIcon" style="display:none"></button>' +
+        '<div id="auth-container"></div>'
+
+    loadExtensionSource('coupon-constants.generated.js', [])
+    loadExtensionSources(
+        [
+            'caramel-base.js',
+            'dom-utils.js',
+            'store-detect.js',
+            'coupon-apply.js',
+            'coupon-fetch.js',
+            'coupon-runner.js',
+        ],
+        [],
+    )
+    globalThis.currentBrowser.tabs.create = () => {}
+    window.close = vi.fn()
+    ;({ renderSignInPrompt } = loadExtensionSource('popup.js', [
+        'renderSignInPrompt',
+    ]))
+})
+
+beforeEach(() => {
+    globalThis.fetch = async () => ({ ok: true, json: async () => ({}) })
+})
+
+const toggle = () => document.getElementById('togglePasswordBtn')
+const passwordInput = () => document.getElementById('password')
+
+describe('popup sign-in prompt — password show/hide toggle', () => {
+    beforeEach(async () => {
+        await renderSignInPrompt()
+    })
+
+    it('starts masked, with the button announcing the action it offers', () => {
+        expect(passwordInput().type).toBe('password')
+        expect(toggle().getAttribute('aria-pressed')).toBe('false')
+        expect(toggle().getAttribute('aria-label')).toBe('Show password')
+        expect(document.getElementById('eyeIcon').style.display).toBe('')
+        expect(document.getElementById('eyeOffIcon').style.display).toBe('none')
+    })
+
+    it('reveals the password and flips the accessible state and icons with it', () => {
+        toggle().click()
+
+        expect(passwordInput().type).toBe('text')
+        expect(toggle().getAttribute('aria-pressed')).toBe('true')
+        expect(toggle().getAttribute('aria-label')).toBe('Hide password')
+        expect(document.getElementById('eyeIcon').style.display).toBe('none')
+        expect(document.getElementById('eyeOffIcon').style.display).toBe('')
+    })
+
+    it('masks it again on a second press, back to the exact starting state', () => {
+        toggle().click()
+        toggle().click()
+
+        expect(passwordInput().type).toBe('password')
+        expect(toggle().getAttribute('aria-pressed')).toBe('false')
+        expect(toggle().getAttribute('aria-label')).toBe('Show password')
+        expect(document.getElementById('eyeIcon').style.display).toBe('')
+        expect(document.getElementById('eyeOffIcon').style.display).toBe('none')
+    })
+
+    it('does not disturb what the user typed', () => {
+        passwordInput().value = 'hunter2'
+
+        toggle().click()
+
+        expect(document.getElementById('password').value).toBe('hunter2')
+    })
+})
+
+describe('popup sign-in prompt — the Back button', () => {
+    it('renders and calls the handler it was given', async () => {
+        const back = vi.fn()
+
+        await renderSignInPrompt(back)
+
+        const backBtn = document.getElementById('backBtn')
+        expect(
+            backBtn,
+            'a return view was supplied, so Back must exist',
+        ).toBeTruthy()
+        backBtn.click()
+        expect(back).toHaveBeenCalledTimes(1)
+    })
+
+    it('is absent entirely when there is nowhere to go back to', async () => {
+        // Both shapes of "no return view": called with nothing (the popup's own
+        // top-level sign-in) and called with a non-function, which :880 folds
+        // to null rather than wiring a listener that would throw on click.
+        for (const backFn of [undefined, null, 'renderCouponsView']) {
+            await renderSignInPrompt(backFn)
+            expect(
+                document.getElementById('backBtn'),
+                String(backFn),
+            ).toBeNull()
+        }
+    })
+
+    it('drops a stale Back button when the view is re-rendered without one', async () => {
+        await renderSignInPrompt(vi.fn())
+        expect(document.getElementById('backBtn')).toBeTruthy()
+
+        await renderSignInPrompt()
+
+        expect(document.getElementById('backBtn')).toBeNull()
+    })
+})
+
+describe('popup sign-in prompt — the settings gear', () => {
+    it('is hidden, even when a previous view turned it on', async () => {
+        // wireSettingsGear (popup.js:270) is what leaves it visible; signing
+        // out must not strand a gear over a signed-out popup.
+        document.getElementById('settingsIcon').style.display = 'block'
+
+        await renderSignInPrompt()
+
+        expect(document.getElementById('settingsIcon').style.display).toBe(
+            'none',
+        )
+    })
+})

--- a/apps/caramel-extension/tsconfig.json
+++ b/apps/caramel-extension/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "./.wxt/tsconfig.json",
+    "compilerOptions": {
+        "strict": true,
+        "noUncheckedIndexedAccess": true,
+        "noImplicitOverride": true,
+        "skipLibCheck": true
+    },
+    "include": ["entrypoints", "types", "wxt.config.ts", ".wxt/wxt.d.ts"]
+}

--- a/apps/caramel-extension/types/caramel-env.d.ts
+++ b/apps/caramel-extension/types/caramel-env.d.ts
@@ -1,0 +1,18 @@
+/**
+ * The build-time environment stamp inlined by wxt.config.ts (vite `define`),
+ * successor to the generated caramel-env.js. Values come from the ENVIRONMENTS
+ * table in scripts/build-dist.mjs — the single source of truth.
+ */
+interface CaramelEnvStamp {
+    readonly name: 'production' | 'development'
+    readonly isProduction: boolean
+    readonly baseUrl: string
+    readonly trustedOrigins: readonly string[]
+    readonly verbose: boolean
+}
+
+declare const __CARAMEL_ENV__: CaramelEnvStamp
+
+declare var CARAMEL_ENV: CaramelEnvStamp
+
+declare var CARAMEL_BASE_URL: string

--- a/apps/caramel-extension/wxt.config.ts
+++ b/apps/caramel-extension/wxt.config.ts
@@ -1,0 +1,87 @@
+/**
+ * WXT build config — the migration target for the hand-rolled
+ * `scripts/build-dist.mjs` build (WXT migration P0, 2026-08-12).
+ *
+ * TODO(WXT-P1): this is a SCAFFOLD. The shipping build is still
+ * `scripts/build-dist.mjs` → dist/; the entrypoints under `entrypoints/` are
+ * stubs. Nothing under `.output/` may be shipped until the P1 ESM port lands
+ * and `scripts/parity-harness.mjs` reports zero unexpected diffs.
+ *
+ * Doctrine carried over from build-dist.mjs (the env block there explains the
+ * shipped Firefox/Safari dev-stamp incident this design prevents):
+ *   - Which deployment a build talks to is decided AT BUILD TIME, never at
+ *     runtime. `wxt build` defaults to production mode; a dev-stamped build
+ *     takes an explicit `--mode development`. The environment table itself is
+ *     imported from scripts/build-dist.mjs — one source of truth, no drift.
+ *   - One config generates BOTH browser manifests (`-b firefox`); the
+ *     `identity` permission and extension-pages CSP are Chrome-only, exactly
+ *     like the committed manifest.json / manifest-firefox.json twins.
+ */
+import { defineConfig } from 'wxt'
+
+import { ENVIRONMENTS } from './scripts/build-dist.mjs'
+
+type EnvironmentName = keyof typeof ENVIRONMENTS
+
+function resolveEnvironment(mode: string): EnvironmentName {
+    // Vite modes map onto the build-dist environment table 1:1. Anything else
+    // fails the build loudly — a typo must never fall back to either stamp.
+    if (mode !== 'production' && mode !== 'development') {
+        throw new Error(
+            `unknown mode "${mode}" — expected one of ${Object.keys(ENVIRONMENTS).join(', ')}`,
+        )
+    }
+    return mode
+}
+
+export default defineConfig({
+    manifest: ({ browser }) => ({
+        name: 'Caramel - Trusted Honey Alternative',
+        description:
+            'Open‑source coupon extension that auto‑applies deals without selling data or hijacking commissions.',
+        browser_specific_settings: {
+            gecko: { id: 'caramel@devino.ca' },
+        },
+        // `identity` (launchWebAuthFlow) exists on Chrome/Edge/Safari builds
+        // only; its absence on Firefox is what routes popup sign-in through
+        // the website flow. See popup.js popupOAuthSupported().
+        permissions:
+            browser === 'firefox'
+                ? ['tabs', 'activeTab', 'storage', 'alarms']
+                : ['tabs', 'activeTab', 'storage', 'identity', 'alarms'],
+        host_permissions: ['https://*/*'],
+        web_accessible_resources: [
+            {
+                resources: ['index.html', 'assets/*'],
+                matches: ['<all_urls>'],
+            },
+        ],
+        ...(browser === 'firefox'
+            ? {}
+            : {
+                  content_security_policy: {
+                      extension_pages:
+                          "script-src 'self'; object-src 'self'; frame-ancestors 'none'",
+                  },
+              }),
+    }),
+    vite: ({ mode }) => {
+        const environment = resolveEnvironment(mode)
+        const env = ENVIRONMENTS[environment]
+        return {
+            define: {
+                // The build-time environment stamp, successor to the generated
+                // caramel-env.js. Entrypoints assign it to globalThis.CARAMEL_ENV
+                // before any other code runs (stamp-first, like manifest order
+                // guaranteed for caramel-env.js today).
+                __CARAMEL_ENV__: JSON.stringify({
+                    name: environment,
+                    isProduction: environment === 'production',
+                    baseUrl: env.baseUrl,
+                    trustedOrigins: env.trustedOrigins,
+                    verbose: env.verbose,
+                }),
+            },
+        }
+    },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         version: 1.0.9
       '@prisma/client':
         specifier: 6.14.0
-        version: 6.14.0(prisma@6.14.0(typescript@5.9.2))(typescript@5.9.2)
+        version: 6.14.0(prisma@6.14.0(magicast@0.5.4)(typescript@5.9.2))(typescript@5.9.2)
       '@react-email/render':
         specifier: 1.2.1
         version: 1.2.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -76,7 +76,7 @@ importers:
         version: 9.3.0(@types/react@19.1.11)(immer@10.1.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.185.1)
       '@sentry/nextjs':
         specifier: 10.65.0
-        version: 10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(@types/node@24.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(react@19.2.3)(webpack@5.104.1(postcss@8.5.23))
+        version: 10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(@types/node@24.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(react@19.2.3)(webpack@5.104.1(esbuild@0.25.12)(postcss@8.5.23))
       '@use-gesture/react':
         specifier: 10.3.1
         version: 10.3.1(react@19.2.3)
@@ -85,7 +85,7 @@ importers:
         version: 3.0.2
       better-auth:
         specifier: 1.6.23
-        version: 1.6.23(@opentelemetry/api@1.9.1)(@prisma/client@6.14.0(prisma@6.14.0(typescript@5.9.2))(typescript@5.9.2))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(@types/node@24.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(prisma@6.14.0(typescript@5.9.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)))
+        version: 1.6.23(@opentelemetry/api@1.9.1)(@prisma/client@6.14.0(prisma@6.14.0(magicast@0.5.4)(typescript@5.9.2))(typescript@5.9.2))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(@types/node@24.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(prisma@6.14.0(magicast@0.5.4)(typescript@5.9.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)))
       formik:
         specifier: 2.4.9
         version: 2.4.9(@types/react@19.1.11)(react@19.2.3)
@@ -109,10 +109,10 @@ importers:
         version: 1.405.3
       posthog-node:
         specifier: 5.46.0
-        version: 5.46.0
+        version: 5.46.0(rxjs@6.6.7)
       prisma:
         specifier: 6.14.0
-        version: 6.14.0(typescript@5.9.2)
+        version: 6.14.0(magicast@0.5.4)(typescript@5.9.2)
       rate-limiter-flexible:
         specifier: 11.0.0
         version: 11.0.0
@@ -242,10 +242,10 @@ importers:
         version: 5.9.2
       vite-tsconfig-paths:
         specifier: 5.1.4
-        version: 5.1.4(typescript@5.9.2)(vite@8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))
+        version: 5.1.4(typescript@5.9.2)(vite@8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))
 
   apps/caramel-extension:
     devDependencies:
@@ -285,14 +285,36 @@ importers:
       size-limit:
         specifier: 12.1.0
         version: 12.1.0(jiti@2.6.1)
+      typescript:
+        specifier: 5.9.2
+        version: 5.9.2
       vitest:
         specifier: 4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))
       web-ext:
         specifier: 8.10.0
-        version: 8.10.0
+        version: 8.10.0(body-parser@1.20.6)(express@4.22.2)(node-fetch@2.7.0)
+      wxt:
+        specifier: 0.21.4
+        version: 0.21.4(esbuild@0.25.12)(eslint@8.57.1)(rolldown@1.1.5)(rollup@4.62.2)(typescript@5.9.2)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))(web-ext@8.10.0(body-parser@1.20.6)(express@4.22.2)(node-fetch@2.7.0))(webpack@5.104.1(esbuild@0.25.12))
 
 packages:
+
+  '@1natsu/wait-element@4.2.0':
+    resolution: {integrity: sha512-Om0Q+WE9mNrpY4AwMTvkFiYHv8VM7TML3PvOqXy+w6kAjLjKhGYHYX+305+a6J8RVpds9s7IF2Z5aOPYwULFNw==}
+
+  '@aklinker1/rollup-plugin-visualizer@5.12.0':
+    resolution: {integrity: sha512-X24LvEGw6UFmy0lpGJDmXsMyBD58XmX1bbwsaMLhNoM+UMQfQ3b2RtC+nz4b/NoRK5r6QJSKJHBNVeUdwqybaQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+    peerDependencies:
+      rollup: 2.x || 3.x || 4.x
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@aklinker1/zero-zip@1.0.1':
+    resolution: {integrity: sha512-07a596Bd1QO0bi3tIyt2xruq6vKk7hCUt9enHBwggvipB0iiycoJ9/CqzN6UFawaKbOi6NBfMlUxUXzIOZ7Dsg==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -2167,6 +2189,10 @@ packages:
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
+  '@topcli/prompts@4.0.0':
+    resolution: {integrity: sha512-kkKYPb4k/6kRdnESt77B5vJrrYnYHIYczwv0P1c+tfN/IWEx3KZeKEHoUq7sImIyBEXWdA2uakIroD9pmRJziQ==}
+    engines: {node: '>=22.0.0'}
+
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
 
@@ -2224,8 +2250,17 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/filesystem@0.0.36':
+    resolution: {integrity: sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==}
+
+  '@types/filewriter@0.0.33':
+    resolution: {integrity: sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==}
+
   '@types/gtag.js@0.0.20':
     resolution: {integrity: sha512-wwAbk3SA2QeU67unN7zPxjEHmPmlXwZXZvQEpbEUQuMCRGgKyE1m6XDuTUA9b6pCGb/GqJmdfMOY5LuDjJSbbg==}
+
+  '@types/har-format@1.2.16':
+    resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
   '@types/hoist-non-react-statics@3.3.7':
     resolution: {integrity: sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==}
@@ -2576,6 +2611,21 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
+  '@webext-core/fake-browser@2.0.1':
+    resolution: {integrity: sha512-4x5z1z8F0KU8ShF4ForXJ8qnA8oZTy7HYjI91Mbpdzp3H3hU9HR6TNPUxfWtSpFz2FwgEircuJKQg0qFIn6RLg==}
+
+  '@webext-core/isolated-element@3.0.0':
+    resolution: {integrity: sha512-PmSIBMSe+rFw6eXzpJoV+glc1HPO40clcT9FJ7rSfCQzNewK8/nQZoBYWen2cMqdXdBNM9to/IbNNu5mdQLaPg==}
+
+  '@webext-core/match-patterns@2.0.0':
+    resolution: {integrity: sha512-EsyMMKfQuSE4rWCjP/TifwvUWlhC/OhiGn5OK3p9F0d57UmtLib0nzguzPKyxM1/kZV7SkE+jYXkE8gsdPRLmw==}
+
+  '@wxt-dev/browser@0.2.5':
+    resolution: {integrity: sha512-676RhVsOFNSZnisfeM9U40DdYjZmx5whJuBHJ7v4R2sR6e/SYfuIuzmJf3owr2n82d2vCDwGNbvt4nLU14sGZg==}
+
+  '@wxt-dev/storage@1.2.9':
+    resolution: {integrity: sha512-dh9TJwvLBM2x4wyy9nE7eYE3wA8pgz1TXSyz7RbdjkJxLfFfWkbeIqiU7VkGy7Vx8sJBmQjoSpk9zSUb3Bjy0Q==}
+
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
@@ -2599,6 +2649,11 @@ packages:
 
   acorn@8.17.0:
     resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -2981,6 +3036,10 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
+  boolbase@2.0.0:
+    resolution: {integrity: sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==}
+    engines: {node: '>=20.19.0'}
+
   boxen@8.0.1:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
@@ -3040,6 +3099,18 @@ packages:
     peerDependenciesMeta:
       magicast:
         optional: true
+
+  c12@3.3.4:
+    resolution: {integrity: sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==}
+    peerDependencies:
+      magicast: '*'
+    peerDependenciesMeta:
+      magicast:
+        optional: true
+
+  cac@7.0.0:
+    resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
+    engines: {node: '>=20.19.0'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -3135,6 +3206,9 @@ packages:
 
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
+  citty@0.2.2:
+    resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
 
   cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
@@ -3241,8 +3315,14 @@ packages:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
     engines: {'0': node >= 0.8}
 
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
   confbox@0.2.2:
     resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
+
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
 
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
@@ -3313,6 +3393,10 @@ packages:
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
+  css-select@7.0.0:
+    resolution: {integrity: sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g==}
+    engines: {node: '>=20.19.0'}
+
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
@@ -3321,10 +3405,17 @@ packages:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
 
+  css-what@8.0.0:
+    resolution: {integrity: sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw==}
+    engines: {node: '>=20.19.0'}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssom@0.5.0:
+    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -3551,18 +3642,34 @@ packages:
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
+  dom-serializer@3.1.1:
+    resolution: {integrity: sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==}
+    engines: {node: '>=20.19.0'}
+
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domelementtype@3.0.0:
+    resolution: {integrity: sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==}
+    engines: {node: '>=20.19.0'}
 
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  domhandler@6.0.1:
+    resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
+    engines: {node: '>=20.19.0'}
 
   dompurify@3.4.13:
     resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  domutils@4.0.2:
+    resolution: {integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==}
+    engines: {node: '>=20.19.0'}
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -3571,6 +3678,10 @@ packages:
   dot-prop@9.0.0:
     resolution: {integrity: sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==}
     engines: {node: '>=18'}
+
+  dotenv-expand@13.0.0:
+    resolution: {integrity: sha512-aBfBS8eYIeXmpHI9ThIlA7/WLq+SLt18iXUZhb52rW89QLKQFoIpPG1bPeewoPZsTyjSSO3T7234FBVUM1V2rA==}
+    engines: {node: '>=12'}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -3636,6 +3747,10 @@ packages:
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   entities@8.0.0:
@@ -3713,6 +3828,10 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   escodegen@2.1.0:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
@@ -3932,6 +4051,9 @@ packages:
   exsolve@1.0.7:
     resolution: {integrity: sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==}
 
+  exsolve@1.1.1:
+    resolution: {integrity: sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==}
+
   external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
@@ -4019,6 +4141,10 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  filesize@11.0.22:
+    resolution: {integrity: sha512-RlCVs9CY+oSsRnNZn95J9vDXjNjOwddKyTFjOYtA4yxYVIxBnwiVVGJX+TFhsmu3uUf81JDGyijtYL9xgawlTw==}
+    engines: {node: '>= 10.8.0'}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -4172,6 +4298,10 @@ packages:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
     hasBin: true
 
+  giget@3.3.1:
+    resolution: {integrity: sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==}
+    hasBin: true
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -4287,9 +4417,15 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
+  hookable@6.1.1:
+    resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-escaper@3.0.3:
+    resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
 
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
@@ -4297,6 +4433,9 @@ packages:
 
   htmlparser2@10.0.0:
     resolution: {integrity: sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==}
+
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
@@ -4664,6 +4803,9 @@ packages:
     resolution: {integrity: sha512-c80Qupofp43y4cJ7+8TTDN/AsDwLi5oOm/plBrWI+iQt485vKXCco+yVmOwEgdo9VOdsYTuV0UlTeetVPTriXA==}
     engines: {node: '>=12'}
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -4880,6 +5022,15 @@ packages:
     resolution: {integrity: sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  linkedom@0.18.13:
+    resolution: {integrity: sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      canvas: '>= 2'
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   lint-staged@16.4.0:
     resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
     engines: {node: '>=20.17'}
@@ -4892,6 +5043,10 @@ packages:
   loader-runner@4.3.2:
     resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
     engines: {node: '>=6.11.5'}
+
+  local-pkg@1.2.1:
+    resolution: {integrity: sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==}
+    engines: {node: '>=14'}
 
   localforage@1.10.0:
     resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
@@ -4968,12 +5123,22 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magic-string@1.1.1:
+    resolution: {integrity: sha512-qFemKPzc3ttrYVaMmnSkGtGc5nE6Ncl4bj7c9IE6C9OUIRXjf6PzJ+UZ1xhVIjYc7dolHq3qKzpAJPZUbvNj+A==}
+
+  magicast@0.5.4:
+    resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
+
   make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  many-keys-map@3.0.3:
+    resolution: {integrity: sha512-1DiZmDHPXMBgMRjeUtHy1q1VYmeJscHxhIAexX9z/zjRMP80+0ETuPfssi8z+kMY4DwUgsKuHqpjxgmeA9gBNA==}
+    engines: {node: '>=18'}
 
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
@@ -5085,6 +5250,9 @@ packages:
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
@@ -5207,9 +5375,13 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
-  nypm@0.6.1:
-    resolution: {integrity: sha512-hlacBiRiv1k9hZFiphPUkfSQ/ZfQzZDzC+8z0wL3lvDAOUu/2NnChkKuMoMjNur/9OpKuz2QsIeiPVN0xM5Q0w==}
-    engines: {node: ^14.16.0 || >=16.10.0}
+  nth-check@3.0.1:
+    resolution: {integrity: sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==}
+    engines: {node: '>=20.19.0'}
+
+  nypm@0.6.9:
+    resolution: {integrity: sha512-zxlE2yvSWZWmHcNdT3+5zV2lrCogeE9YOklHrR3dFjqutq5wO7GFDYLFDRXLsYnJzwvy/im9fYoxePvS0VTW0w==}
+    engines: {node: '>=18'}
     hasBin: true
 
   object-assign@4.1.1:
@@ -5443,6 +5615,9 @@ packages:
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
+  perfect-debounce@2.1.0:
+    resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -5476,8 +5651,14 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  pkg-types@2.3.1:
+    resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
   playwright-core@1.57.0:
     resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
@@ -5716,6 +5897,11 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  publish-browser-extension@6.1.1:
+    resolution: {integrity: sha512-ovfBOz+cZIOBHZ+oxTfpv1kSGU7ruzy8CXoFGvhXsUbJuty45srGzf1ufEePs69virOWXfFbhZRoNQUdgPvwXA==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -5737,6 +5923,9 @@ packages:
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
+
+  quansync@0.2.11:
+    resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
   query-selector-shadow-dom@1.0.1:
     resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
@@ -5760,6 +5949,9 @@ packages:
 
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
+
+  rc9@3.0.1:
+    resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -6050,6 +6242,9 @@ packages:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
 
+  scule@1.3.0:
+    resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
+
   selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
 
@@ -6225,6 +6420,10 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
   spawn-sync@1.0.15:
     resolution: {integrity: sha512-9DWBgrgYZzNghseho0JOuh+5fg9u6QWhAWa51QC7+U5rCheZ/j1DrEZnyE0RBBRqZ9uEXGPgSSM0nky6burpVw==}
 
@@ -6373,6 +6572,9 @@ packages:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
 
+  strip-literal@4.0.0:
+    resolution: {integrity: sha512-PaqAvfUZKBwc/SLmNZtHmzK+v19Z4O4eS3cKPeGvbIv/U3pnyEq4Tuw3/4v/FwfM8VQaEawsyCcOQ0P+kpwWWw==}
+
   stubborn-fs@2.0.0:
     resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
 
@@ -6399,6 +6601,10 @@ packages:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  superlock@1.3.5:
+    resolution: {integrity: sha512-XpWNthvezZnWp0u7/UL8rBbBOnq2Qx39fw+0RNMC/+eotOd81glzsmIWVH0ejarhTeDQihxOKSbjm2XXFo5a8w==}
+    engines: {node: '>= 14'}
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -6442,6 +6648,9 @@ packages:
 
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
+  tasuku@2.3.0:
+    resolution: {integrity: sha512-9Jtk+XAnttslCw4i9RceSZGr2PT5TLn0vUyWnoP2SdlSYzkiYRY6kB5qnPi5IQ/Em8e4oBow1rpaA39iijTIrA==}
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
@@ -6542,6 +6751,9 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tiny-open@1.3.0:
+    resolution: {integrity: sha512-GUFS8yjJZq0oWqCKCJVHcBgMpmi2WEGXY1le3E5ncR0DsgTII5uUyxtfk8/vGyDDGBE42UYHR6Ocvlk8mkXSRg==}
+
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
@@ -6550,6 +6762,10 @@ packages:
 
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.14:
@@ -6764,6 +6980,12 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  uhyphen@0.2.0:
+    resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
+
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
@@ -6778,6 +7000,18 @@ packages:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
+  unimport@6.4.0:
+    resolution: {integrity: sha512-JJOOuNMFq8b4ZPBKwQUxEcba4MplskDzYI1Lvrf8rJfWphZTWvPNXWa493qsPngHUmub89w6C7j+SeLWTE/UIQ==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      oxc-parser: '*'
+      rolldown: ^1.0.0
+    peerDependenciesMeta:
+      oxc-parser:
+        optional: true
+      rolldown:
+        optional: true
+
   unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
@@ -6789,6 +7023,43 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  unplugin-utils@0.3.2:
+    resolution: {integrity: sha512-xVToRh2CTmLk2HnEG7ac4rl1MJTT3RFkpS8B++/SnB0kXvuaavD+n3m/vrzyWQOdJNSZQACnbz01pnppbwV5BA==}
+    engines: {node: '>=20.19.0'}
+
+  unplugin@3.3.0:
+    resolution: {integrity: sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@farmfe/core': '*'
+      '@rspack/core': '*'
+      bun-types-no-globals: '*'
+      esbuild: '*'
+      rolldown: '*'
+      rollup: '*'
+      unloader: '*'
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      '@farmfe/core':
+        optional: true
+      '@rspack/core':
+        optional: true
+      bun-types-no-globals:
+        optional: true
+      esbuild:
+        optional: true
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+      unloader:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -6995,6 +7266,9 @@ packages:
     resolution: {integrity: sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==}
     engines: {node: '>=10.13.0'}
 
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
   webpack@5.104.1:
     resolution: {integrity: sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==}
     engines: {node: '>=10.13.0'}
@@ -7118,6 +7392,23 @@ packages:
   wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
+
+  wxt@0.21.4:
+    resolution: {integrity: sha512-iyVMTXb37BQAbsPHCuPzrK3ZxnO9pZmvbKl7VJWIHe3RG40On2NyP2FOjArtOITO96plEYnh3o+iUlRp9qE90w==}
+    engines: {bun: '>=1.2.0', node: '>=22'}
+    hasBin: true
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=5.4'
+      vite: ^6.3.4 || ^7.0.0 || ^8.0.0-0
+      web-ext: '>=9.2.0'
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+      typescript:
+        optional: true
+      web-ext:
+        optional: true
 
   xdg-basedir@4.0.0:
     resolution: {integrity: sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==}
@@ -7247,6 +7538,22 @@ packages:
         optional: true
 
 snapshots:
+
+  '@1natsu/wait-element@4.2.0':
+    dependencies:
+      defu: 6.1.7
+      many-keys-map: 3.0.3
+
+  '@aklinker1/rollup-plugin-visualizer@5.12.0(rollup@4.62.2)':
+    dependencies:
+      open: 8.4.2
+      picomatch: 2.3.2
+      source-map: 0.7.6
+      yargs: 17.7.2
+    optionalDependencies:
+      rollup: 4.62.2
+
+  '@aklinker1/zero-zip@1.0.1': {}
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -7574,13 +7881,13 @@ snapshots:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/prisma-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@prisma/client@6.14.0(prisma@6.14.0(typescript@5.9.2))(typescript@5.9.2))(prisma@6.14.0(typescript@5.9.2))':
+  '@better-auth/prisma-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@prisma/client@6.14.0(prisma@6.14.0(magicast@0.5.4)(typescript@5.9.2))(typescript@5.9.2))(prisma@6.14.0(magicast@0.5.4)(typescript@5.9.2))':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
-      '@prisma/client': 6.14.0(prisma@6.14.0(typescript@5.9.2))(typescript@5.9.2)
-      prisma: 6.14.0(typescript@5.9.2)
+      '@prisma/client': 6.14.0(prisma@6.14.0(magicast@0.5.4)(typescript@5.9.2))(typescript@5.9.2)
+      prisma: 6.14.0(magicast@0.5.4)(typescript@5.9.2)
 
   '@better-auth/telemetry@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
     dependencies:
@@ -8484,14 +8791,14 @@ snapshots:
 
   '@posthog/types@1.402.2': {}
 
-  '@prisma/client@6.14.0(prisma@6.14.0(typescript@5.9.2))(typescript@5.9.2)':
+  '@prisma/client@6.14.0(prisma@6.14.0(magicast@0.5.4)(typescript@5.9.2))(typescript@5.9.2)':
     optionalDependencies:
-      prisma: 6.14.0(typescript@5.9.2)
+      prisma: 6.14.0(magicast@0.5.4)(typescript@5.9.2)
       typescript: 5.9.2
 
-  '@prisma/config@6.14.0':
+  '@prisma/config@6.14.0(magicast@0.5.4)':
     dependencies:
-      c12: 3.1.0
+      c12: 3.1.0(magicast@0.5.4)
       deepmerge-ts: 7.1.5
       effect: 3.20.0
       empathic: 2.0.0
@@ -8797,7 +9104,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@sentry/bundler-plugins@10.65.0(rollup@4.62.2)(webpack@5.104.1(postcss@8.5.23))':
+  '@sentry/bundler-plugins@10.65.0(rollup@4.62.2)(webpack@5.104.1(esbuild@0.25.12)(postcss@8.5.23))':
     dependencies:
       '@babel/core': 7.29.7
       '@sentry/cli': 2.58.6
@@ -8808,7 +9115,7 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       rollup: 4.62.2
-      webpack: 5.104.1(postcss@8.5.23)
+      webpack: 5.104.1(esbuild@0.25.12)(postcss@8.5.23)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -8879,7 +9186,7 @@ snapshots:
       '@sentry/utils': 7.120.4
       localforage: 1.10.0
 
-  '@sentry/nextjs@10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(@types/node@24.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(react@19.2.3)(webpack@5.104.1(postcss@8.5.23))':
+  '@sentry/nextjs@10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(@types/node@24.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(react@19.2.3)(webpack@5.104.1(esbuild@0.25.12)(postcss@8.5.23))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@rollup/plugin-commonjs': 28.0.1(rollup@4.62.2)
@@ -8891,7 +9198,7 @@ snapshots:
       '@sentry/opentelemetry': 10.65.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
       '@sentry/react': 10.65.0(react@19.2.3)
       '@sentry/vercel-edge': 10.65.0
-      '@sentry/webpack-plugin': 5.4.0(rollup@4.62.2)(webpack@5.104.1(postcss@8.5.23))
+      '@sentry/webpack-plugin': 5.4.0(rollup@4.62.2)(webpack@5.104.1(esbuild@0.25.12)(postcss@8.5.23))
       next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(@types/node@24.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0)
       rollup: 4.62.2
       stacktrace-parser: 0.1.11
@@ -8987,10 +9294,10 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@sentry/core': 10.65.0
 
-  '@sentry/webpack-plugin@5.4.0(rollup@4.62.2)(webpack@5.104.1(postcss@8.5.23))':
+  '@sentry/webpack-plugin@5.4.0(rollup@4.62.2)(webpack@5.104.1(esbuild@0.25.12)(postcss@8.5.23))':
     dependencies:
-      '@sentry/bundler-plugins': 10.65.0(rollup@4.62.2)(webpack@5.104.1(postcss@8.5.23))
-      webpack: 5.104.1(postcss@8.5.23)
+      '@sentry/bundler-plugins': 10.65.0(rollup@4.62.2)(webpack@5.104.1(esbuild@0.25.12)(postcss@8.5.23))
+      webpack: 5.104.1(esbuild@0.25.12)(postcss@8.5.23)
     transitivePeerDependencies:
       - encoding
       - rollup
@@ -9035,6 +9342,8 @@ snapshots:
       '@types/react-dom': 19.1.7(@types/react@19.1.11)
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
+
+  '@topcli/prompts@4.0.0': {}
 
   '@tweenjs/tween.js@23.1.3': {}
 
@@ -9095,7 +9404,15 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/filesystem@0.0.36':
+    dependencies:
+      '@types/filewriter': 0.0.33
+
+  '@types/filewriter@0.0.33': {}
+
   '@types/gtag.js@0.0.20': {}
+
+  '@types/har-format@1.2.16': {}
 
   '@types/hoist-non-react-statics@3.3.7(@types/react@19.1.11)':
     dependencies:
@@ -9443,13 +9760,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.10(vite@8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.10(vite@8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))':
     dependencies:
@@ -9559,6 +9876,27 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
+  '@webext-core/fake-browser@2.0.1':
+    dependencies:
+      '@wxt-dev/browser': 0.2.5
+      lodash.merge: 4.6.2
+
+  '@webext-core/isolated-element@3.0.0':
+    dependencies:
+      is-potential-custom-element-name: 1.0.1
+
+  '@webext-core/match-patterns@2.0.0': {}
+
+  '@wxt-dev/browser@0.2.5':
+    dependencies:
+      '@types/filesystem': 0.0.36
+      '@types/har-format': 1.2.16
+
+  '@wxt-dev/storage@1.2.9':
+    dependencies:
+      '@wxt-dev/browser': 0.2.5
+      superlock: 1.3.5
+
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
@@ -9578,13 +9916,15 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  addons-linter@7.20.0:
+  acorn@8.18.0: {}
+
+  addons-linter@7.20.0(body-parser@1.20.6)(express@4.22.2)(node-fetch@2.7.0):
     dependencies:
       '@fluent/syntax': 0.19.0
       '@fregante/relaxed-json': 2.0.0
       '@mdn/browser-compat-data': 7.1.5
       addons-moz-compare: 1.3.0
-      addons-scanner-utils: 9.13.0
+      addons-scanner-utils: 9.13.0(body-parser@1.20.6)(express@4.22.2)(node-fetch@2.7.0)
       ajv: 8.17.1
       chalk: 4.1.2
       cheerio: 1.0.0-rc.12
@@ -9614,7 +9954,7 @@ snapshots:
 
   addons-moz-compare@1.3.0: {}
 
-  addons-scanner-utils@9.13.0:
+  addons-scanner-utils@9.13.0(body-parser@1.20.6)(express@4.22.2)(node-fetch@2.7.0):
     dependencies:
       '@types/yauzl': 2.10.3
       common-tags: 1.8.2
@@ -9622,6 +9962,10 @@ snapshots:
       strip-bom-stream: 4.0.0
       upath: 2.0.1
       yauzl: 2.10.0
+    optionalDependencies:
+      body-parser: 1.20.6
+      express: 4.22.2
+      node-fetch: 2.7.0
 
   adm-zip@0.5.18: {}
 
@@ -9877,14 +10221,14 @@ snapshots:
 
   bcryptjs@3.0.2: {}
 
-  better-auth@1.6.23(@opentelemetry/api@1.9.1)(@prisma/client@6.14.0(prisma@6.14.0(typescript@5.9.2))(typescript@5.9.2))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(@types/node@24.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(prisma@6.14.0(typescript@5.9.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))):
+  better-auth@1.6.23(@opentelemetry/api@1.9.1)(@prisma/client@6.14.0(prisma@6.14.0(magicast@0.5.4)(typescript@5.9.2))(typescript@5.9.2))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(@types/node@24.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(prisma@6.14.0(magicast@0.5.4)(typescript@5.9.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))):
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
       '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.3)
       '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
       '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@prisma/client@6.14.0(prisma@6.14.0(typescript@5.9.2))(typescript@5.9.2))(prisma@6.14.0(typescript@5.9.2))
+      '@better-auth/prisma-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@prisma/client@6.14.0(prisma@6.14.0(magicast@0.5.4)(typescript@5.9.2))(typescript@5.9.2))(prisma@6.14.0(magicast@0.5.4)(typescript@5.9.2))
       '@better-auth/telemetry': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
@@ -9897,12 +10241,12 @@ snapshots:
       nanostores: 1.4.0
       zod: 4.4.3
     optionalDependencies:
-      '@prisma/client': 6.14.0(prisma@6.14.0(typescript@5.9.2))(typescript@5.9.2)
+      '@prisma/client': 6.14.0(prisma@6.14.0(magicast@0.5.4)(typescript@5.9.2))(typescript@5.9.2)
       next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(@types/node@24.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0)
-      prisma: 6.14.0(typescript@5.9.2)
+      prisma: 6.14.0(magicast@0.5.4)(typescript@5.9.2)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -9942,6 +10286,8 @@ snapshots:
       - supports-color
 
   boolbase@1.0.0: {}
+
+  boolbase@2.0.0: {}
 
   boxen@8.0.1:
     dependencies:
@@ -10008,7 +10354,7 @@ snapshots:
 
   bytes@3.1.2: {}
 
-  c12@3.1.0:
+  c12@3.1.0(magicast@0.5.4):
     dependencies:
       chokidar: 4.0.3
       confbox: 0.2.2
@@ -10022,6 +10368,27 @@ snapshots:
       perfect-debounce: 1.0.0
       pkg-types: 2.3.0
       rc9: 2.1.2
+    optionalDependencies:
+      magicast: 0.5.4
+
+  c12@3.3.4(magicast@0.5.4):
+    dependencies:
+      chokidar: 5.0.0
+      confbox: 0.2.4
+      defu: 6.1.7
+      dotenv: 17.4.2
+      exsolve: 1.1.1
+      giget: 3.3.1
+      jiti: 2.6.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      pkg-types: 2.3.0
+      rc9: 3.0.1
+    optionalDependencies:
+      magicast: 0.5.4
+
+  cac@7.0.0: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -10142,6 +10509,8 @@ snapshots:
     dependencies:
       consola: 3.4.2
 
+  citty@0.2.2: {}
+
   cjs-module-lexer@2.2.0: {}
 
   cli-boxes@3.0.0: {}
@@ -10241,7 +10610,11 @@ snapshots:
       readable-stream: 2.3.8
       typedarray: 0.0.6
 
+  confbox@0.1.8: {}
+
   confbox@0.2.2: {}
+
+  confbox@0.2.4: {}
 
   config-chain@1.1.13:
     dependencies:
@@ -10319,6 +10692,14 @@ snapshots:
       domutils: 3.2.2
       nth-check: 2.1.1
 
+  css-select@7.0.0:
+    dependencies:
+      boolbase: 2.0.0
+      css-what: 8.0.0
+      domhandler: 6.0.1
+      domutils: 4.0.2
+      nth-check: 3.0.1
+
   css-tree@3.2.1:
     dependencies:
       mdn-data: 2.27.1
@@ -10326,7 +10707,11 @@ snapshots:
 
   css-what@6.2.2: {}
 
+  css-what@8.0.0: {}
+
   cssesc@3.0.0: {}
+
+  cssom@0.5.0: {}
 
   csstype@3.1.3: {}
 
@@ -10511,11 +10896,23 @@ snapshots:
       domhandler: 5.0.3
       entities: 4.5.0
 
+  dom-serializer@3.1.1:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      entities: 8.0.0
+
   domelementtype@2.3.0: {}
+
+  domelementtype@3.0.0: {}
 
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  domhandler@6.0.1:
+    dependencies:
+      domelementtype: 3.0.0
 
   dompurify@3.4.13:
     optionalDependencies:
@@ -10527,6 +10924,12 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
+  domutils@4.0.2:
+    dependencies:
+      dom-serializer: 3.1.1
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+
   dot-prop@5.3.0:
     dependencies:
       is-obj: 2.0.0
@@ -10534,6 +10937,10 @@ snapshots:
   dot-prop@9.0.0:
     dependencies:
       type-fest: 4.41.0
+
+  dotenv-expand@13.0.0:
+    dependencies:
+      dotenv: 17.4.2
 
   dotenv@16.6.1: {}
 
@@ -10587,6 +10994,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   entities@8.0.0: {}
 
@@ -10742,6 +11151,8 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   escodegen@2.1.0:
     dependencies:
       esprima: 4.0.1
@@ -10755,8 +11166,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.3
       eslint: 9.34.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.31.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.40.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.34.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.40.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.34.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.34.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.34.0(jiti@2.6.1))
@@ -10775,8 +11186,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.3
       eslint: 9.31.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.31.0(jiti@2.6.1)))(eslint@9.31.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.31.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.31.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.31.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.31.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.31.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.31.0(jiti@2.6.1))
@@ -10806,22 +11217,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.31.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.34.0(jiti@2.6.1)
-      get-tsconfig: 4.10.1
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.14
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.31.0(jiti@2.6.1))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.31.0(jiti@2.6.1)))(eslint@9.31.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.31.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -10832,29 +11228,32 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.31.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.31.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.40.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.31.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.34.0(jiti@2.6.1)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.34.0(jiti@2.6.1)
+      get-tsconfig: 4.10.1
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.14
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.40.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.40.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@9.34.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.40.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2)
       eslint: 9.34.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.31.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.31.0(jiti@2.6.1)))(eslint@9.31.0(jiti@2.6.1)))(eslint@9.31.0(jiti@2.6.1)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2)
-      eslint: 9.31.0(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.31.0(jiti@2.6.1)))(eslint@9.31.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -10868,11 +11267,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@9.31.0(jiti@2.6.1)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2)
+      eslint: 9.31.0(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.9
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-html@8.1.3:
     dependencies:
       htmlparser2: 10.0.0
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.40.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.40.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10883,7 +11292,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.34.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.40.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.31.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1)))(eslint@9.34.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.40.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@9.34.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -10896,35 +11305,6 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 8.40.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.31.0(jiti@2.6.1)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.31.0(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.31.0(jiti@2.6.1)))(eslint@9.31.0(jiti@2.6.1)))(eslint@9.31.0(jiti@2.6.1))
-      hasown: 2.0.2
-      is-core-module: 2.16.1
-      is-glob: 4.0.3
-      minimatch: 3.1.5
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -10942,6 +11322,35 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.31.0(jiti@2.6.1)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.31.0(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.47.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@9.31.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11309,6 +11718,8 @@ snapshots:
 
   exsolve@1.0.7: {}
 
+  exsolve@1.1.1: {}
+
   external-editor@3.1.0:
     dependencies:
       chardet: 0.7.0
@@ -11396,6 +11807,8 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  filesize@11.0.22: {}
 
   fill-range@7.1.1:
     dependencies:
@@ -11578,8 +11991,10 @@ snapshots:
       consola: 3.4.2
       defu: 6.1.7
       node-fetch-native: 1.6.7
-      nypm: 0.6.1
+      nypm: 0.6.9
       pathe: 2.0.3
+
+  giget@3.3.1: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -11686,11 +12101,15 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
+  hookable@6.1.1: {}
+
   html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
     dependencies:
       '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  html-escaper@3.0.3: {}
 
   html-to-text@9.0.5:
     dependencies:
@@ -11706,6 +12125,13 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.2.2
       entities: 6.0.1
+
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
 
   htmlparser2@8.0.2:
     dependencies:
@@ -12061,6 +12487,8 @@ snapshots:
 
   js-library-detector@6.7.0: {}
 
+  js-tokens@10.0.0: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.15.0:
@@ -12352,6 +12780,14 @@ snapshots:
 
   lines-and-columns@2.0.4: {}
 
+  linkedom@0.18.13:
+    dependencies:
+      css-select: 7.0.0
+      cssom: 0.5.0
+      html-escaper: 3.0.3
+      htmlparser2: 10.1.0
+      uhyphen: 0.2.0
+
   lint-staged@16.4.0:
     dependencies:
       commander: 14.0.3
@@ -12371,6 +12807,12 @@ snapshots:
       wrap-ansi: 9.0.2
 
   loader-runner@4.3.2: {}
+
+  local-pkg@1.2.1:
+    dependencies:
+      mlly: 1.8.2
+      pkg-types: 2.3.1
+      quansync: 0.2.11
 
   localforage@1.10.0:
     dependencies:
@@ -12438,11 +12880,23 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magic-string@1.1.1:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.4:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
   make-dir@3.1.0:
     dependencies:
       semver: 6.3.1
 
   make-error@1.3.6: {}
+
+  many-keys-map@3.0.3: {}
 
   marky@1.3.0: {}
 
@@ -12522,6 +12976,13 @@ snapshots:
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.18.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
 
   module-details-from-path@1.0.4: {}
 
@@ -12630,13 +13091,15 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nypm@0.6.1:
+  nth-check@3.0.1:
     dependencies:
-      citty: 0.1.6
-      consola: 3.4.2
+      boolbase: 2.0.0
+
+  nypm@0.6.9:
+    dependencies:
+      citty: 0.2.2
       pathe: 2.0.3
-      pkg-types: 2.3.0
-      tinyexec: 1.1.1
+      tinyexec: 1.3.0
 
   object-assign@4.1.1: {}
 
@@ -12926,6 +13389,8 @@ snapshots:
 
   perfect-debounce@1.0.0: {}
 
+  perfect-debounce@2.1.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -12958,10 +13423,22 @@ snapshots:
 
   pirates@4.0.7: {}
 
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
   pkg-types@2.3.0:
     dependencies:
       confbox: 0.2.2
       exsolve: 1.0.7
+      pathe: 2.0.3
+
+  pkg-types@2.3.1:
+    dependencies:
+      confbox: 0.2.4
+      exsolve: 1.1.1
       pathe: 2.0.3
 
   playwright-core@1.57.0: {}
@@ -13034,9 +13511,11 @@ snapshots:
     transitivePeerDependencies:
       - preact-render-to-string
 
-  posthog-node@5.46.0:
+  posthog-node@5.46.0(rxjs@6.6.7):
     dependencies:
       '@posthog/core': 1.46.9
+    optionalDependencies:
+      rxjs: 6.6.7
 
   potpack@1.0.2: {}
 
@@ -13078,9 +13557,9 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
-  prisma@6.14.0(typescript@5.9.2):
+  prisma@6.14.0(magicast@0.5.4)(typescript@5.9.2):
     dependencies:
-      '@prisma/config': 6.14.0
+      '@prisma/config': 6.14.0(magicast@0.5.4)
       '@prisma/engines': 6.14.0
     optionalDependencies:
       typescript: 5.9.2
@@ -13132,6 +13611,12 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  publish-browser-extension@6.1.1:
+    dependencies:
+      '@topcli/prompts': 4.0.0
+      cac: 7.0.0
+      tasuku: 2.3.0
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -13167,6 +13652,8 @@ snapshots:
       es-define-property: 1.0.1
       side-channel: 1.1.1
 
+  quansync@0.2.11: {}
+
   query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
@@ -13185,6 +13672,11 @@ snapshots:
       unpipe: 1.0.0
 
   rc9@2.1.2:
+    dependencies:
+      defu: 6.1.7
+      destr: 2.0.5
+
+  rc9@3.0.1:
     dependencies:
       defu: 6.1.7
       destr: 2.0.5
@@ -13539,6 +14031,8 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.20.0)
       ajv-keywords: 5.1.0(ajv@8.20.0)
 
+  scule@1.3.0: {}
+
   selderee@0.11.0:
     dependencies:
       parseley: 0.12.1
@@ -13759,6 +14253,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  source-map@0.7.6: {}
+
   spawn-sync@1.0.15:
     dependencies:
       concat-stream: 1.6.2
@@ -13932,6 +14428,10 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
+  strip-literal@4.0.0:
+    dependencies:
+      js-tokens: 10.0.0
+
   stubborn-fs@2.0.0:
     dependencies:
       stubborn-utils: 1.0.2
@@ -13956,6 +14456,8 @@ snapshots:
       mz: 2.7.0
       pirates: 4.0.7
       ts-interface-checker: 0.1.13
+
+  superlock@1.3.5: {}
 
   supports-color@5.5.0:
     dependencies:
@@ -14033,6 +14535,8 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
+  tasuku@2.3.0: {}
+
   teex@1.0.1:
     dependencies:
       streamx: 2.28.0
@@ -14040,15 +14544,27 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  terser-webpack-plugin@5.6.1(postcss@8.5.23)(webpack@5.104.1(postcss@8.5.23)):
+  terser-webpack-plugin@5.6.1(esbuild@0.25.12)(postcss@8.5.23)(webpack@5.104.1(esbuild@0.25.12)(postcss@8.5.23)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.49.0
-      webpack: 5.104.1(postcss@8.5.23)
+      webpack: 5.104.1(esbuild@0.25.12)(postcss@8.5.23)
     optionalDependencies:
+      esbuild: 0.25.12
       postcss: 8.5.23
+
+  terser-webpack-plugin@5.6.1(esbuild@0.25.12)(webpack@5.104.1(esbuild@0.25.12)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.49.0
+      webpack: 5.104.1(esbuild@0.25.12)
+    optionalDependencies:
+      esbuild: 0.25.12
+    optional: true
 
   terser@5.49.0:
     dependencies:
@@ -14105,11 +14621,15 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tiny-open@1.3.0: {}
+
   tiny-warning@1.0.3: {}
 
   tinybench@2.9.0: {}
 
   tinyexec@1.1.1: {}
+
+  tinyexec@1.3.0: {}
 
   tinyglobby@0.2.14:
     dependencies:
@@ -14326,6 +14846,10 @@ snapshots:
 
   typescript@5.9.2: {}
 
+  ufo@1.6.4: {}
+
+  uhyphen@0.2.0: {}
+
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -14339,6 +14863,34 @@ snapshots:
 
   undici@7.29.0: {}
 
+  unimport@6.4.0(esbuild@0.25.12)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.104.1(esbuild@0.25.12)):
+    dependencies:
+      acorn: 8.18.0
+      escape-string-regexp: 5.0.0
+      estree-walker: 3.0.3
+      local-pkg: 1.2.1
+      magic-string: 1.1.1
+      mlly: 1.8.2
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      pkg-types: 2.3.1
+      scule: 1.3.0
+      strip-literal: 4.0.0
+      tinyglobby: 0.2.17
+      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.104.1(esbuild@0.25.12))
+      unplugin-utils: 0.3.2
+    optionalDependencies:
+      rolldown: 1.1.5
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rollup
+      - unloader
+      - vite
+      - webpack
+
   unique-string@2.0.0:
     dependencies:
       crypto-random-string: 2.0.0
@@ -14346,6 +14898,23 @@ snapshots:
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
+
+  unplugin-utils@0.3.2:
+    dependencies:
+      pathe: 2.0.3
+      picomatch: 4.0.5
+
+  unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.104.1(esbuild@0.25.12)):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      picomatch: 4.0.5
+      webpack-virtual-modules: 0.6.2
+    optionalDependencies:
+      esbuild: 0.25.12
+      rolldown: 1.1.5
+      rollup: 4.62.2
+      vite: 8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)
+      webpack: 5.104.1(esbuild@0.25.12)
 
   unrs-resolver@1.11.1:
     dependencies:
@@ -14446,18 +15015,18 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-tsconfig-paths@5.1.4(typescript@5.9.2)(vite@8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)):
+  vite-tsconfig-paths@5.1.4(typescript@5.9.2)(vite@8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.2)
     optionalDependencies:
-      vite: 8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3):
+  vite@8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
@@ -14466,6 +15035,7 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.3.0
+      esbuild: 0.25.12
       fsevents: 2.3.3
       jiti: 2.6.1
       sass: 1.101.0
@@ -14490,10 +15060,10 @@ snapshots:
       tsx: 4.20.6
       yaml: 2.8.3
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -14510,7 +15080,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.4(@types/node@24.3.0)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 8.1.4(@types/node@24.3.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -14567,11 +15137,11 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
-  web-ext@8.10.0:
+  web-ext@8.10.0(body-parser@1.20.6)(express@4.22.2)(node-fetch@2.7.0):
     dependencies:
       '@babel/runtime': 7.28.4
       '@devicefarmer/adbkit': 3.3.8
-      addons-linter: 7.20.0
+      addons-linter: 7.20.0(body-parser@1.20.6)(express@4.22.2)(node-fetch@2.7.0)
       camelcase: 8.0.0
       chrome-launcher: 1.2.0
       debounce: 1.2.1
@@ -14617,7 +15187,9 @@ snapshots:
 
   webpack-sources@3.5.1: {}
 
-  webpack@5.104.1(postcss@8.5.23):
+  webpack-virtual-modules@0.6.2: {}
+
+  webpack@5.104.1(esbuild@0.25.12):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -14641,7 +15213,49 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(postcss@8.5.23)(webpack@5.104.1(postcss@8.5.23))
+      terser-webpack-plugin: 5.6.1(esbuild@0.25.12)(webpack@5.104.1(esbuild@0.25.12))
+      watchpack: 2.5.2
+      webpack-sources: 3.5.1
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+    optional: true
+
+  webpack@5.104.1(esbuild@0.25.12)(postcss@8.5.23):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.17.0
+      acorn-import-phases: 1.0.4(acorn@8.17.0)
+      browserslist: 4.28.5
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.24.2
+      es-module-lexer: 2.3.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.2
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.6.1(esbuild@0.25.12)(postcss@8.5.23)(webpack@5.104.1(esbuild@0.25.12)(postcss@8.5.23))
       watchpack: 2.5.2
       webpack-sources: 3.5.1
     transitivePeerDependencies:
@@ -14784,6 +15398,54 @@ snapshots:
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.1
+
+  wxt@0.21.4(esbuild@0.25.12)(eslint@8.57.1)(rolldown@1.1.5)(rollup@4.62.2)(typescript@5.9.2)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))(web-ext@8.10.0(body-parser@1.20.6)(express@4.22.2)(node-fetch@2.7.0))(webpack@5.104.1(esbuild@0.25.12)):
+    dependencies:
+      '@1natsu/wait-element': 4.2.0
+      '@aklinker1/rollup-plugin-visualizer': 5.12.0(rollup@4.62.2)
+      '@aklinker1/zero-zip': 1.0.1
+      '@topcli/prompts': 4.0.0
+      '@webext-core/fake-browser': 2.0.1
+      '@webext-core/isolated-element': 3.0.0
+      '@webext-core/match-patterns': 2.0.0
+      '@wxt-dev/browser': 0.2.5
+      '@wxt-dev/storage': 1.2.9
+      c12: 3.3.4(magicast@0.5.4)
+      cac: 7.0.0
+      chokidar: 5.0.0
+      consola: 3.4.2
+      defu: 6.1.7
+      dotenv-expand: 13.0.0
+      filesize: 11.0.22
+      giget: 2.0.0
+      hookable: 6.1.1
+      json5: 2.2.3
+      linkedom: 0.18.13
+      magicast: 0.5.4
+      nypm: 0.6.9
+      picomatch: 4.0.5
+      publish-browser-extension: 6.1.1
+      superlock: 1.3.5
+      tiny-open: 1.3.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      unimport: 6.4.0(esbuild@0.25.12)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.104.1(esbuild@0.25.12))
+      vite: 8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.3)
+    optionalDependencies:
+      eslint: 8.57.1
+      typescript: 5.9.2
+      web-ext: 8.10.0(body-parser@1.20.6)(express@4.22.2)(node-fetch@2.7.0)
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - canvas
+      - esbuild
+      - oxc-parser
+      - rolldown
+      - rollup
+      - unloader
+      - webpack
 
   xdg-basedir@4.0.0: {}
 


### PR DESCRIPTION
## P0 — scaffold + safety net (no source moves)

First phase of the WXT + React migration (owner directive; plan of record in the CTO prompt). The shipping build is untouched — `scripts/build-dist.mjs` still produces `dist/`; everything WXT lives side-by-side behind a gate.

### What's in here
- **WXT 0.21.4** (exact-pinned; current stable) + typescript 5.9.2, `wxt.config.ts` generating BOTH browser manifests from one config: `identity` + extension-pages CSP are Chrome-only, gecko id on both, Firefox forced to MV3 (`-b firefox --mv3` — WXT defaults FF to MV2).
- **Env-stamp doctrine carried over**: the vite `define` stamp is built from the SAME `ENVIRONMENTS` table in `build-dist.mjs` (imported, not copied — typed via a hand-written `.d.mts`). Production is the default mode; dev takes an explicit `--mode development`; an unknown mode throws.
- **Entrypoint stubs** (`entrypoints/content.ts`, `background.ts`, `popup/index.html`) with loud `TODO(WXT-P1/P2)` headers — the 11-file chain and popup are NOT ported yet.
- **Parity harness** (`pnpm test:parity`, wired into checks-extension.yml): per browser, semantic manifest diff of WXT output vs the committed golden manifests against a shrink-only expected-diffs allowlist (unlisted diff fails; stale entry fails), NEVER_SHIP file-inventory assertions over BOTH build systems, and env-stamp assertions (prod builds carry zero dev origins; dev build carries the dev stamp — the shipped Firefox/Safari dev-stamp incident, pinned against the new world). **Red-proofed**: removing a live allowlist entry and adding a bogus one each failed the run.
- CI also gains a strict `type-check` step for the WXT surfaces (`wxt prepare && tsc --noEmit`).

### Characterization pins (36 new tests — the P0 exit criterion before the P2 React rewrite)
A coverage-map pass graded every popup/OAuth behavior; what was already PINNED stays untouched. The gaps are now frozen:
- **Checkout-modal caller relay, both halves + round trip** (was: ZERO coverage, silent failure mode): `popup-caller-relay.test.mjs` (4 — exact `userLoggedInFromPopup_<id>` action, 150ms delayed close, dead-tab throw and rejection swallow, no-caller re-render branch) + `background-caller-relay.test.mjs` (4 — `openPopup` URL mint incl. senderless, numeric `parseInt` routing, and the mint→parse round trip that breaks if the action ever gains an underscore).
- **OAuth authorize REQUEST half** (response half was already pinned): `popup-oauth-authorize-request.test.mjs` (7 — exact authorize URL grammar with encoded `getRedirectURL()`, `interactive:true` with the backend-issued URL, authorize-hop failures, resolve-undefined cancel, session-write `lastError`, hidden-popup no-re-render gate).
- **Email-login failure copy** `popup-email-login.test.mjs` (8 — incl. two documented copy surprises pinned as-shipped: every failure carries the `Login failed:` prefix, and a reason-less rejection stutters `Login failed: Login failed`), **profile card** `popup-profile-card.test.mjs` (5 — first coverage of a whole view, incl. the `token && !url` routing and the `image?.length` default-avatar edge), **sign-in widgets** `popup-signin-widgets.test.mjs` (8 — a11y-complete password toggle, Back-button presence contract, gear hidden). Each suite was red-proofed against live behavior.

### Gates (local, this branch)
- vitest **780/780** (84 files; was 744 on main — +36 pins), guards **57/57**, smoke (production stamp) green, size-limit green (71.67/76 · 31.54/33 · 7.3/7.8 kB), parity **52/52**, tsc clean, eslint/prettier/knip green, app-side manifest-sync/repo-integrity/deps-pinned green (58/58). First CI run (scaffold commit) fully green including the extension e2e job.

Release gate reminder: Chrome + Edge **1.3.1 are in store review** — nothing here tags or ships; no 1.4.0 until the owner confirms both reviews landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)