### PR TITLE
Firefox manifest declares data collection per Mozilla's consent framework

### DIFF
--- a/apps/caramel-extension/scripts/parity-expected-diffs.json
+++ b/apps/caramel-extension/scripts/parity-expected-diffs.json
@@ -67,6 +67,13 @@
         },
         {
             "browser": "firefox",
+            "path": "/browser_specific_settings/gecko/data_collection_permissions",
+            "reason": "Mozilla data-collection consent declaration added 2026-08-13 (mandatory for AMO; audit-backed mapping in wxt.config.ts) — the 1.3.1 golden predates the framework",
+            "retiredBy": "golden-rebaseline(1.4.0)",
+            "added": "2026-08-13"
+        },
+        {
+            "browser": "firefox",
             "path": "/background/scripts",
             "reason": "the env stamp is BUNDLED into background.js instead of a separate manifest entry — the stamp-first guarantee moves from manifest order into the module graph (P1 pins it there)",
             "retiredBy": "golden-rebaseline(1.4.0)",

--- a/apps/caramel-extension/wxt.config.ts
+++ b/apps/caramel-extension/wxt.config.ts
@@ -69,7 +69,49 @@ export default defineConfig({
             default_icon: ICONS,
         },
         browser_specific_settings: {
-            gecko: { id: 'caramel@devino.ca' },
+            gecko: {
+                id: 'caramel@devino.ca',
+                // Mozilla's data-collection consent framework (mandatory for
+                // new AMO submissions since 2025-11-03, extending to updates
+                // of existing listings during 2026 — declared now so the
+                // 1.4.0 submission cannot bounce on it). Firefox-only: Chrome
+                // ignores the key and the chrome parity golden stays exact.
+                //
+                // Evidence-based mapping (full outbound audit 2026-08-13; the
+                // ONLY server origin is the build-time baseUrl — no Sentry,
+                // no analytics, nothing third-party):
+                //   required.browsingActivity — the toolbar badge sends every
+                //     visited https domain to /api/coupons on tab switch,
+                //     guests included, no off switch.
+                //   required.websiteContent — /api/classify-cart sends page
+                //     title/meta/product names; coupon outcome reports carry
+                //     the store's own rejection text. Both automatic.
+                //   optional.authenticationInfo + personallyIdentifyingInfo —
+                //     email/password (and OAuth codes on non-Firefox) travel
+                //     only when the user signs in; guests never send them.
+                //   optional.financialAndPaymentInfo — savings sync uploads
+                //     per-win {store, code, amountCents} records, and is
+                //     double-gated: sign-in AND an off-by-default toggle.
+                // Deliberately ABSENT: technicalAndInteraction (timings and
+                // error buffers live in chrome.storage.local with no reader
+                // that transmits them — declaring it would disclose
+                // collection that doesn't happen), websiteActivity (we click
+                // checkout buttons, we never transmit interaction data),
+                // searchTerms (the key_words API param is '' at all call
+                // sites).
+                ...(browser === 'firefox'
+                    ? {
+                          data_collection_permissions: {
+                              required: ['browsingActivity', 'websiteContent'],
+                              optional: [
+                                  'authenticationInfo',
+                                  'personallyIdentifyingInfo',
+                                  'financialAndPaymentInfo',
+                              ],
+                          },
+                      }
+                    : {}),
+            },
         },
         // `identity` (launchWebAuthFlow) exists on Chrome/Edge/Safari builds
         // only; its absence on Firefox is what routes popup sign-in through


### PR DESCRIPTION
Mozilla's data-collection consent framework (mandatory for new AMO submissions since 2025-11-03, extending to updates of existing listings during 2026) requires `browser_specific_settings.gecko.data_collection_permissions`. Declared now so the 1.4.0 submission cannot bounce on it.

## The declaration (evidence-based — full outbound audit of every call site, 2026-08-13)

The only server origin in the shipped extension is the build-time baseUrl (grabcaramel.com). No Sentry, no analytics, no third-party endpoint exists in the tree.

- **required: browsingActivity** — the toolbar badge sends every visited https domain to `/api/coupons` on tab switch, guests included, no off switch.
- **required: websiteContent** — `/api/classify-cart` sends page title/meta/product names; outcome reports carry the store's own rejection text. Both automatic, guests included.
- **optional: authenticationInfo, personallyIdentifyingInfo** — email/password travel only on user-initiated sign-in.
- **optional: financialAndPaymentInfo** — savings sync uploads per-win `{store, code, amountCents}`, double-gated (sign-in AND an off-by-default toggle).

Deliberately absent: `technicalAndInteraction` (the `caramel_timings`/error buffers in `chrome.storage.local` have **no reader that transmits them** — declaring it would disclose collection that doesn't happen), `websiteActivity` (we click checkout buttons; we never transmit interaction data), `searchTerms` (the `key_words` API param is `''` at all four call sites).

Firefox-only: Chrome ignores the key, so the chrome build and its parity golden stay byte-exact.

## Enforcement

The parity harness pins this two-sided: the new allowlist row in `parity-expected-diffs.json` fails the build if the key disappears, and an unlisted manifest diff fails it if the shape drifts. Row retires at the 1.4.0 golden re-freeze.

## Gates

71/71 parity · 772 vitest · 57 guards · knip · prettier · tsc · `web-ext lint` **0 errors** on the built firefox-mv3 (8 pre-existing innerHTML warnings from minified React vendor chunks, non-blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)