### PR TITLE
The E2E workflow no longer dies uploading to the retired Argos account

### DIFF
--- a/.github/workflows/checks-app.yml
+++ b/.github/workflows/checks-app.yml
@@ -319,10 +319,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-    env:
-      ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
-      ARGOS_API_BASE_URL: ${{ vars.ARGOS_API_BASE_URL }}
-
     steps:
       - uses: actions/checkout@v4
 
@@ -400,8 +396,6 @@ jobs:
     # was queue latency, not a defect.
     timeout-minutes: 35
     env:
-      ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
-      ARGOS_API_BASE_URL: ${{ vars.ARGOS_API_BASE_URL }}
       NEXT_PUBLIC_BASE_URL: ${{ github.ref == 'refs/heads/dev' && 'https://dev.grabcaramel.com' || 'https://grabcaramel.com' }}
 
     steps:

--- a/apps/caramel-app/playwright.config.ts
+++ b/apps/caramel-app/playwright.config.ts
@@ -37,10 +37,14 @@ export default defineConfig({
         [
             '@argos-ci/playwright/reporter',
             createArgosReporterOptions({
-                uploadToArgos: !!process.env.CI,
+                // Upload permanently OFF (2026-08-13, issue #194): the Argos
+                // account is retired and the end-of-run upload threw APIError
+                // AFTER a green 108-test suite, keeping the whole workflow
+                // red on every main push. Snapvisor owns visual diffs now;
+                // the argosScreenshot specs stay as deterministic render
+                // smoke + local screenshot artifacts.
+                uploadToArgos: false,
                 buildName: 'caramel-app',
-                token: process.env.ARGOS_TOKEN,
-                apiBaseUrl: process.env.ARGOS_API_BASE_URL,
             }),
         ],
     ],


### PR DESCRIPTION
Closes #194.

The `@argos-ci` reporter's end-of-run upload threw `APIError` against the retired Argos account AFTER a green test suite (108 passed on the PR #193 run), keeping "E2E & Visual Regression" red on every main push — a workflow that cries wolf on schedule trains everyone to ignore the one channel that would catch a real regression.

- `uploadToArgos` is now hard `false` (dated comment explains why). Snapvisor owns visual diffs; the `argosScreenshot` specs stay as deterministic render smoke + local screenshot artifacts.
- The now-dead `ARGOS_TOKEN` / `ARGOS_API_BASE_URL` env plumbing is removed from both jobs in `checks-app.yml`.

Proof is this PR's own E2E run finishing green end-to-end instead of red-after-green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)