### PR TITLE
The smoke default and two parity labels stop pointing at the retired build

### DIFF
--- a/apps/caramel-extension/scripts/parity-expected-diffs.json
+++ b/apps/caramel-extension/scripts/parity-expected-diffs.json
@@ -12,8 +12,8 @@
         {
             "browser": "chrome",
             "path": "/action/default_title",
-            "reason": "WXT derives default_title from the popup <title>; harmless addition, golden adopts it at P2",
-            "retiredBy": "P2",
+            "reason": "WXT derives default_title from the popup <title>; harmless addition the shipped 1.3.1 manifest does not have. Relabelled 2026-08-13: P2 shipped without adopting it, and back-dating a frozen 1.3.1 snapshot would falsify the golden — it retires when the goldens are re-frozen from 1.4.0",
+            "retiredBy": "golden-rebaseline(1.4.0)",
             "added": "2026-08-12"
         },
         {
@@ -40,8 +40,8 @@
         {
             "browser": "firefox",
             "path": "/action/default_title",
-            "reason": "WXT derives default_title from the popup <title>; harmless addition, golden adopts it at P2",
-            "retiredBy": "P2",
+            "reason": "WXT derives default_title from the popup <title>; harmless addition the shipped 1.3.1 manifest does not have. Relabelled 2026-08-13: P2 shipped without adopting it, and back-dating a frozen 1.3.1 snapshot would falsify the golden — it retires when the goldens are re-frozen from 1.4.0",
+            "retiredBy": "golden-rebaseline(1.4.0)",
             "added": "2026-08-12"
         },
         {

--- a/apps/caramel-extension/scripts/smoke-package.mjs
+++ b/apps/caramel-extension/scripts/smoke-package.mjs
@@ -31,7 +31,14 @@ import { chromium } from 'playwright'
 import { ENVIRONMENTS } from './environments.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const PACKAGE_DIR = path.resolve(__dirname, '..', process.argv[2] || 'dist')
+// Default is the WXT production build. It used to be `dist` — the hand-rolled
+// build's output, deleted in P1 (2026-08-12) — so a bare invocation pointed at
+// a directory that no longer exists and reported that as a package problem.
+const PACKAGE_DIR = path.resolve(
+    __dirname,
+    '..',
+    process.argv[2] || '.output/chrome-mv3',
+)
 const ENVIRONMENT = process.argv[3] || 'production'
 
 const expected = ENVIRONMENTS[ENVIRONMENT]


### PR DESCRIPTION
Two fossils the migration left behind — found while sweeping for whether anything was actually left.

**1. `smoke-package.mjs` defaulted to `dist`** — the hand-rolled build's output, deleted in P1. `pnpm test:smoke` always passes the path explicitly so CI was never affected, but a bare `node scripts/smoke-package.mjs` pointed at a directory that no longer exists and reported that as a package problem. Now defaults to `.output/chrome-mv3`; proven by running it bare — all checks pass, exit 0.

**2. Two `retiredBy: "P2"` rows outlived P2.** Their reason said "golden adopts it at P2"; P2 shipped without adopting it, so the label was simply untrue. The fix is *not* to add `default_title` to the goldens: those are frozen snapshots of the shipped 1.3.1 manifests, which genuinely do not have that key, and back-dating them would falsify the baseline the whole harness rests on. Relabelled to `golden-rebaseline(1.4.0)` — the re-freeze that legitimately sweeps them — with the reasoning in the row.

This matters beyond tidiness: the 1.4.0 release PR must delete every `golden-rebaseline(1.4.0)` row in the same commit as the re-freeze, and a mislabelled row would have been missed and then failed the harness as a stale entry.

Gates: 71/71 parity · smoke (bare invocation) · prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)