### PR TITLE
fix(ext-probe): refuse to verdict without an extension, and seed carts beyond Shopify

### DIFF
--- a/apps/caramel-extension/tests/_ext-probe-fixtures.mjs
+++ b/apps/caramel-extension/tests/_ext-probe-fixtures.mjs
@@ -15,7 +15,13 @@ export function greenObservation(overrides = {}) {
             rejectedAdds: 0,
             adds: 1,
         },
-        platform: { productsJsonOk: true, cartJsOk: true },
+        platform: {
+            detected: 'shopify',
+            productFeedOk: true,
+            cartApiOk: true,
+            productsJsonOk: true,
+            cartJsOk: true,
+        },
         cartItemsAtArrival: 1,
         config: {
             servedFromApi: true,

--- a/apps/caramel-extension/tests/ext-probe-extension-required.test.mjs
+++ b/apps/caramel-extension/tests/ext-probe-extension-required.test.mjs
@@ -1,0 +1,131 @@
+// A probe that cannot load the extension must never produce a verdict.
+//
+// Chromium accepts `--load-extension=<dir>` at a directory with no manifest,
+// says nothing a caller can see, and runs an ordinary browser with nothing
+// installed. Every measurement taken that way reports the same thing — no
+// prompt, no coupons, nothing submitted — which is indistinguishable from a
+// genuinely broken store config. That is what happened after the WXT migration
+// moved the build to `.output/chrome-mv3` and left `apps/caramel-extension`
+// (the probe's own default) without a manifest: days of ext-QA verdicts were
+// measurements of an empty browser, and the only tell in the whole report was
+// `vnull` in the log header.
+//
+// So this suite spawns the REAL probe. Nothing is stubbed and no store is
+// touched: the refusal happens before Chromium is launched, which is the
+// property being pinned.
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import {
+    exitCodeFor,
+    PROBE_NO_EXTENSION,
+    SCHEMA,
+} from '../../../tools/ext-probe/verdict.mjs'
+
+const PROBE = join(
+    dirname(fileURLToPath(import.meta.url)),
+    '..',
+    '..',
+    '..',
+    'tools',
+    'ext-probe',
+    'probe.mjs',
+)
+
+// A URL that is never reached: the refusal is decided from the filesystem, so
+// a run that somehow got as far as the network would be the failure this suite
+// exists to catch.
+const UNREACHED = 'https://example.invalid/cart'
+
+function runProbe(extDir) {
+    const res = spawnSync(
+        process.execPath,
+        [PROBE, UNREACHED, '--tag', 'no-extension-pin'],
+        {
+            env: { ...process.env, EXT_DIR: extDir },
+            encoding: 'utf8',
+            timeout: 60000,
+        },
+    )
+    return res
+}
+
+function reportFrom(res) {
+    // The one-object contract holds on this path too, or a caller that parses
+    // stdout has to special-case the very outcome it most needs to see.
+    return JSON.parse(res.stdout)
+}
+
+describe('the probe refuses to run without a loadable extension', () => {
+    it('exits with the PROBE_NO_EXTENSION code when the directory has no manifest', () => {
+        const empty = mkdtempSync(join(tmpdir(), 'ext-probe-empty-'))
+        const res = runProbe(empty)
+
+        expect(res.status).toBe(exitCodeFor(PROBE_NO_EXTENSION))
+        expect(res.status).toBe(71)
+        const report = reportFrom(res)
+        expect(report.schema).toBe(SCHEMA)
+        expect(report.verdict).toBe(PROBE_NO_EXTENSION)
+        expect(report.exitCode).toBe(res.status)
+    })
+
+    it('names the directory it was given and where a build actually lands', () => {
+        const empty = mkdtempSync(join(tmpdir(), 'ext-probe-empty-'))
+        const reason = reportFrom(runProbe(empty)).reasons.join(' ')
+
+        expect(reason).toContain(empty)
+        expect(reason).toContain('.output/chrome-mv3')
+        // The consequence, spelled out — the number 71 alone would not tell
+        // the next reader why an empty browser is worse than a crash.
+        expect(reason).toMatch(/measurement of an empty browser/i)
+    })
+
+    it('refuses a manifest that exists but Chromium could not load either', () => {
+        const broken = mkdtempSync(join(tmpdir(), 'ext-probe-broken-'))
+        writeFileSync(join(broken, 'manifest.json'), '{ not json', 'utf8')
+        expect(runProbe(broken).status).toBe(71)
+
+        const versionless = mkdtempSync(join(tmpdir(), 'ext-probe-noversion-'))
+        writeFileSync(
+            join(versionless, 'manifest.json'),
+            JSON.stringify({ manifest_version: 3, name: 'x' }),
+            'utf8',
+        )
+        const res = runProbe(versionless)
+        expect(res.status).toBe(71)
+        expect(reportFrom(res).reasons.join(' ')).toMatch(/no version/i)
+    })
+
+    it('is not counted as a store verdict, and not confused with a crash', () => {
+        const empty = mkdtempSync(join(tmpdir(), 'ext-probe-empty-'))
+        const report = reportFrom(runProbe(empty))
+        // 70 is the generic harness crash; a caller that tolerates flaky
+        // crashes must still stop dead on "there was no extension".
+        expect(report.exitCode).not.toBe(70)
+        expect(report.observation).toBeNull()
+        expect(report.build).toBeNull()
+    })
+
+    it('RED-PROOF: the same probe reaches the launch path when a manifest IS present', () => {
+        // Without this, every assertion above would pass just as well against
+        // a probe that refused to run for some unrelated reason. A minimal
+        // manifest is enough to get past the gate — the run then fails on the
+        // unreachable URL, which is a DIFFERENT outcome and a different code.
+        const ok = mkdtempSync(join(tmpdir(), 'ext-probe-ok-'))
+        writeFileSync(
+            join(ok, 'manifest.json'),
+            JSON.stringify({
+                manifest_version: 3,
+                name: 'pin',
+                version: '0.0.1',
+            }),
+            'utf8',
+        )
+        const res = runProbe(ok)
+        expect(res.status).not.toBe(71)
+        expect(reportFrom(res).verdict).not.toBe(PROBE_NO_EXTENSION)
+    }, 120000)
+})

--- a/apps/caramel-extension/tests/ext-probe-safety.test.mjs
+++ b/apps/caramel-extension/tests/ext-probe-safety.test.mjs
@@ -21,9 +21,12 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
+    detectPlatformInPage,
     MAX_REJECTED_ADDS,
     readCartStateInPage,
+    seedBigCommerceCartInPage,
     seedShopifyCartInPage,
+    seedWooCommerceCartInPage,
 } from '../../../tools/ext-probe/seed.mjs'
 
 const TOOL_DIR = join(
@@ -161,7 +164,7 @@ describe('the seed stops before it can rate-limit a store', () => {
 describe('the cart is read before the wait window', () => {
     it('the cart read appears earlier in probe.mjs than the wait deadline', () => {
         const cartRead = probeSource.indexOf(
-            'page.evaluate(readCartStateInPage)',
+            'page.evaluate(readCartStateInPage, platform)',
         )
         const waitLoop = probeSource.indexOf(
             'const deadline = Date.now() + waitMs',
@@ -201,14 +204,16 @@ describe('the cart is read before the wait window', () => {
             status: 200,
             json: async () => ({ item_count: 3 }),
         })
-        await expect(readCartStateInPage()).resolves.toEqual({
+        await expect(readCartStateInPage('shopify')).resolves.toEqual({
+            cartApiOk: true,
             cartJsOk: true,
             itemCount: 3,
             detail: '',
         })
 
         globalThis.fetch = async () => ({ ok: false, status: 404 })
-        await expect(readCartStateInPage()).resolves.toEqual({
+        await expect(readCartStateInPage('shopify')).resolves.toEqual({
+            cartApiOk: false,
             cartJsOk: false,
             itemCount: null,
             detail: 'cart.js 404',
@@ -217,8 +222,8 @@ describe('the cart is read before the wait window', () => {
         globalThis.fetch = async () => {
             throw new Error('network down')
         }
-        const thrown = await readCartStateInPage()
-        expect(thrown.cartJsOk).toBe(false)
+        const thrown = await readCartStateInPage('shopify')
+        expect(thrown.cartApiOk).toBe(false)
         expect(thrown.itemCount).toBeNull()
     })
 })
@@ -247,19 +252,26 @@ describe('the probe is platform-portable', () => {
 
 describe('the page functions stay serialisable', () => {
     it.each([
+        ['detectPlatformInPage', detectPlatformInPage],
         ['seedShopifyCartInPage', seedShopifyCartInPage],
+        ['seedWooCommerceCartInPage', seedWooCommerceCartInPage],
+        ['seedBigCommerceCartInPage', seedBigCommerceCartInPage],
         ['readCartStateInPage', readCartStateInPage],
     ])('%s closes over nothing from module scope', (name, fn) => {
         // Playwright serialises a function by its source text, so anything
         // captured from this module would arrive `undefined` in the page. The
         // same property is what lets the tests above call them directly.
+        // SEEDABLE_PLATFORMS is the trap the widening added: it is exactly the
+        // kind of shared constant a new seeder wants to reference.
         const src = fn.toString()
         expect(src).not.toContain('MAX_REJECTED_ADDS')
         expect(src).not.toContain('DEFAULT_PRODUCT_LIMIT')
+        expect(src).not.toContain('SEEDABLE_PLATFORMS')
+        expect(src).not.toContain('seedersByPlatform')
         expect(src).not.toMatch(/\bimport\b/)
         // A plain named declaration — not a bound wrapper and not `[native
         // code]`, either of which would serialise into something the page
         // cannot run.
-        expect(src.startsWith(`async function ${name}`)).toBe(true)
+        expect(src).toMatch(new RegExp(`^(async )?function ${name}\\s*\\(`))
     })
 })

--- a/apps/caramel-extension/tests/ext-probe-seed-platforms.test.mjs
+++ b/apps/caramel-extension/tests/ext-probe-seed-platforms.test.mjs
@@ -1,0 +1,417 @@
+// The seeder speaks three platforms, and the store-safety cap holds in all of
+// them.
+//
+// The probe's first question on any store is "is there a cart?", and until
+// 2026-08-14 only Shopify could answer it: every WooCommerce and BigCommerce
+// store fell out at `INCONCLUSIVE_SEED`, so the repair loop behind ext-QA never
+// got a verdict to act on. Widening that path is only safe if two things stay
+// true — the platform is named from the store's OWN markup rather than from a
+// per-store list, and a platform that cannot be seeded abandons honestly
+// instead of inventing a cart.
+//
+// Everything here runs against a stubbed `globalThis.fetch`. No store is
+// touched, which is the same discipline as ext-probe-safety.test.mjs.
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+    detectPlatformInPage,
+    MAX_REJECTED_ADDS,
+    readCartStateInPage,
+    SEEDABLE_PLATFORMS,
+    seedBigCommerceCartInPage,
+    seedersByPlatform,
+    seedShopifyCartInPage,
+    seedWooCommerceCartInPage,
+} from '../../../tools/ext-probe/seed.mjs'
+
+const originalFetch = globalThis.fetch
+afterEach(() => {
+    globalThis.fetch = originalFetch
+    document.body.innerHTML = ''
+    document.body.className = ''
+    delete window.Shopify
+    delete window.BCData
+    delete window.wc_add_to_cart_params
+})
+
+describe('the platform is named from the store, never from a list of stores', () => {
+    it('reads Shopify from the global its own bundle sets', () => {
+        window.Shopify = { shop: 'x.myshopify.com' }
+        expect(detectPlatformInPage()).toEqual({
+            platform: 'shopify',
+            signal: 'window.Shopify.shop',
+        })
+    })
+
+    it('reads WooCommerce from the params WooCommerce core localises', () => {
+        window.wc_add_to_cart_params = { ajax_url: '/?wc-ajax=%%endpoint%%' }
+        expect(detectPlatformInPage().platform).toBe('woocommerce')
+    })
+
+    it('reads BigCommerce from the Stencil bootstrap object', () => {
+        window.BCData = { csrf_token: 'x' }
+        expect(detectPlatformInPage().platform).toBe('bigcommerce')
+    })
+
+    it('falls back to markup when no global is set', () => {
+        document.body.innerHTML =
+            '<script src="https://x.com/wp-content/plugins/woocommerce/assets/js/a.js"></script>'
+        expect(detectPlatformInPage().platform).toBe('woocommerce')
+    })
+
+    it('says "unknown" rather than guessing, and names why', () => {
+        const out = detectPlatformInPage()
+        expect(out.platform).toBe('unknown')
+        expect(SEEDABLE_PLATFORMS).not.toContain(out.platform)
+        expect(out.signal).toBe('no platform marker found')
+    })
+
+    it('a global outranks a stray CDN reference to another platform', () => {
+        // A Woo store embedding a Shopify buy-button script must still be
+        // seeded the Woo way; strongest-signal-first is what decides that.
+        window.wc_add_to_cart_params = {}
+        document.body.innerHTML =
+            '<script src="https://cdn.shopify.com/buy-button.js"></script>'
+        expect(detectPlatformInPage().platform).toBe('woocommerce')
+    })
+
+    it('every seedable platform has a seeder, and nothing else does', () => {
+        const seeders = seedersByPlatform()
+        expect(Object.keys(seeders).toSorted()).toEqual(
+            SEEDABLE_PLATFORMS.toSorted(),
+        )
+        expect(seeders.unknown).toBeUndefined()
+        expect(seeders.shopify).toBe(seedShopifyCartInPage)
+        expect(seeders.woocommerce).toBe(seedWooCommerceCartInPage)
+        expect(seeders.bigcommerce).toBe(seedBigCommerceCartInPage)
+    })
+})
+
+// ── WooCommerce ──────────────────────────────────────────────────────────────
+// Shape measured on alphaterritory.com, 2026-08-14: the Store API list is all
+// `variable` products, `add-item` answers 401 without a Nonce header, and the
+// nonce arrives on the cart GET the seeder already makes for its baseline.
+function stubWooStore({
+    products,
+    addStatus = 201,
+    nonce = 'abc123',
+    cartStatus = 200,
+} = {}) {
+    const counts = { adds: 0, cartReads: 0 }
+    let items = 0
+    globalThis.fetch = async (url, init) => {
+        const u = String(url)
+        if (u.startsWith('/wp-json/wc/store/v1/products'))
+            return { ok: true, status: 200, json: async () => products }
+        if (u === '/wp-json/wc/store/v1/cart') {
+            counts.cartReads++
+            return {
+                ok: cartStatus === 200,
+                status: cartStatus,
+                headers: { get: name => (name === 'nonce' ? nonce : null) },
+                json: async () => ({ items_count: items }),
+            }
+        }
+        if (u === '/wp-json/wc/store/v1/cart/add-item') {
+            counts.adds++
+            counts.lastNonce = init?.headers?.Nonce
+            counts.lastBody = JSON.parse(init.body)
+            const ok = addStatus >= 200 && addStatus < 300
+            if (ok) items++
+            return { ok, status: addStatus, json: async () => ({}) }
+        }
+        throw new Error(`unexpected request: ${u}`)
+    }
+    return counts
+}
+
+const wooVariable = (n = 10) =>
+    Array.from({ length: n }, (_, i) => ({
+        id: 1000 + i,
+        name: `Shorts ${i}`,
+        type: 'variable',
+        is_purchasable: true,
+        is_in_stock: true,
+        variations: [
+            { id: 2000 + i, attributes: [{ name: 'Size', value: 'M' }] },
+            { id: 3000 + i, attributes: [{ name: 'Size', value: 'L' }] },
+        ],
+    }))
+
+describe('WooCommerce is seeded through the Store API', () => {
+    it('adds a variable product by its PARENT id plus the chosen variation', async () => {
+        // The reason this path is general at all: a Woo catalogue is mostly
+        // variable products, which the classic `?add-to-cart=` handler cannot
+        // reach without reconstructing the theme's own attribute field names.
+        const counts = stubWooStore({ products: wooVariable() })
+        const out = await seedWooCommerceCartInPage()
+
+        expect(out.ok).toBe(true)
+        expect(counts.adds).toBe(1)
+        expect(counts.lastBody).toEqual({
+            id: 1000,
+            quantity: 1,
+            variation: [{ attribute: 'Size', value: 'M' }],
+        })
+        expect(out.detail).toContain('added Shorts 0')
+    })
+
+    it('sends the nonce the cart GET handed out — without it the endpoint 401s', async () => {
+        const counts = stubWooStore({ products: wooVariable(), nonce: 'n-42' })
+        await seedWooCommerceCartInPage()
+        expect(counts.lastNonce).toBe('n-42')
+    })
+
+    it('sends NO add at all when the cart served no nonce', async () => {
+        const counts = stubWooStore({ products: wooVariable(), nonce: null })
+        const out = await seedWooCommerceCartInPage()
+
+        expect(counts.adds).toBe(0)
+        expect(out.ok).toBe(false)
+        expect(out.detail).toMatch(/no Nonce header/i)
+    })
+
+    it('sends NO add when the cart cannot be read — an unverifiable add is not attempted', async () => {
+        const counts = stubWooStore({
+            products: wooVariable(),
+            cartStatus: 403,
+        })
+        const out = await seedWooCommerceCartInPage()
+
+        expect(counts.adds).toBe(0)
+        expect(out.detail).toMatch(/cannot verify an add/)
+    })
+
+    it('stops after 5 rejected adds, exactly like the Shopify path', async () => {
+        const counts = stubWooStore({
+            products: wooVariable(20),
+            addStatus: 429,
+        })
+        const out = await seedWooCommerceCartInPage({
+            maxRejectedAdds: MAX_REJECTED_ADDS,
+        })
+
+        expect(counts.adds).toBe(5)
+        expect(out.rejectedAdds).toBe(5)
+        expect(out.ok).toBe(false)
+        expect(out.detail).toContain('stopping before we rate-limit the store')
+    })
+
+    it('RED-PROOF: uncapped, the same fixture fires 40 adds', async () => {
+        const counts = stubWooStore({
+            products: wooVariable(20),
+            addStatus: 429,
+        })
+        await seedWooCommerceCartInPage({ maxRejectedAdds: Infinity })
+        expect(counts.adds).toBe(40)
+        expect(counts.adds).toBeGreaterThan(MAX_REJECTED_ADDS)
+    })
+
+    it('abandons honestly when the Store API is not there', async () => {
+        globalThis.fetch = async () => ({ ok: false, status: 404 })
+        const out = await seedWooCommerceCartInPage()
+        expect(out.ok).toBe(false)
+        expect(out.productFeedOk).toBe(false)
+        expect(out.detail).toBe('store-api products 404')
+    })
+
+    it('does not try a product the store says is unpurchasable or out of stock', async () => {
+        const counts = stubWooStore({
+            products: [
+                {
+                    id: 1,
+                    name: 'gone',
+                    type: 'simple',
+                    is_purchasable: true,
+                    is_in_stock: false,
+                    variations: [],
+                },
+                {
+                    id: 2,
+                    name: 'catalog only',
+                    type: 'simple',
+                    is_purchasable: false,
+                    is_in_stock: true,
+                    variations: [],
+                },
+            ],
+        })
+        const out = await seedWooCommerceCartInPage()
+
+        expect(counts.adds).toBe(0)
+        expect(out.candidates).toBe(0)
+        expect(out.detail).toMatch(/no purchasable in-stock product/)
+    })
+
+    it('reads the cart back rather than trusting the add status', async () => {
+        // A 201 whose item never appears is not a seeded cart. Counting it as
+        // one would put every downstream verdict on a cart that is not there.
+        globalThis.fetch = async (url, init) => {
+            const u = String(url)
+            if (u.startsWith('/wp-json/wc/store/v1/products'))
+                return {
+                    ok: true,
+                    status: 200,
+                    json: async () => wooVariable(1),
+                }
+            if (u === '/wp-json/wc/store/v1/cart')
+                return {
+                    ok: true,
+                    status: 200,
+                    headers: { get: () => 'n' },
+                    json: async () => ({ items_count: 0 }),
+                }
+            if (u === '/wp-json/wc/store/v1/cart/add-item' && init)
+                return { ok: true, status: 201, json: async () => ({}) }
+            throw new Error(`unexpected request: ${u}`)
+        }
+        const out = await seedWooCommerceCartInPage()
+        expect(out.ok).toBe(false)
+        expect(out.rejectedAdds).toBeGreaterThan(0)
+    })
+})
+
+// ── BigCommerce ──────────────────────────────────────────────────────────────
+// Shape measured on a1supplements.com, 2026-08-14: product ids come off the
+// storefront markup, and products carrying required options answer
+// `422 This product has options, variant ID is required`.
+function stubBigCommerceStore({ rejectUntil = 0, cartsStatus = 200 } = {}) {
+    const counts = { adds: 0 }
+    let items = 0
+    globalThis.fetch = async (url, init) => {
+        const u = String(url)
+        if (
+            u === '/api/storefront/carts' &&
+            (!init || init.method !== 'POST')
+        ) {
+            return {
+                ok: cartsStatus === 200,
+                status: cartsStatus,
+                json: async () =>
+                    items
+                        ? [
+                              {
+                                  id: 'cart-1',
+                                  lineItems: {
+                                      physicalItems: [{ quantity: items }],
+                                  },
+                              },
+                          ]
+                        : [],
+            }
+        }
+        if (u === '/api/storefront/carts' && init?.method === 'POST') {
+            counts.adds++
+            counts.lastBody = JSON.parse(init.body)
+            if (counts.adds <= rejectUntil)
+                return { ok: false, status: 422, json: async () => ({}) }
+            items++
+            return { ok: true, status: 201, json: async () => ({}) }
+        }
+        throw new Error(`unexpected request: ${u}`)
+    }
+    return counts
+}
+
+function paintProductCards(ids) {
+    document.body.innerHTML = ids
+        .map(id => `<article data-product-id="${id}"></article>`)
+        .join('')
+}
+
+describe('BigCommerce is seeded through the Storefront API', () => {
+    it('takes product ids off the storefront markup and adds the first the store accepts', async () => {
+        paintProductCards([2183, 1561, 6558])
+        const counts = stubBigCommerceStore({ rejectUntil: 2 })
+        const out = await seedBigCommerceCartInPage()
+
+        expect(out.ok).toBe(true)
+        expect(out.candidates).toBe(3)
+        // The two 422s are real rejections — "this product has options" — not
+        // a broken seeder, and they are reported as what they are.
+        expect(out.rejectedAdds).toBe(2)
+        expect(counts.lastBody).toEqual({
+            lineItems: [{ quantity: 1, productId: 6558 }],
+        })
+    })
+
+    it('abandons honestly when the markup carries no product id', async () => {
+        const counts = stubBigCommerceStore()
+        const out = await seedBigCommerceCartInPage()
+
+        expect(counts.adds).toBe(0)
+        expect(out.ok).toBe(false)
+        expect(out.productFeedOk).toBe(false)
+        expect(out.detail).toMatch(/no product id in the storefront markup/)
+    })
+
+    it('sends NO add when the cart endpoint cannot be read', async () => {
+        paintProductCards([1])
+        const counts = stubBigCommerceStore({ cartsStatus: 403 })
+        const out = await seedBigCommerceCartInPage()
+
+        expect(counts.adds).toBe(0)
+        expect(out.detail).toMatch(/cannot verify an add/)
+    })
+
+    it('stops after 5 rejected adds', async () => {
+        paintProductCards([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        const counts = stubBigCommerceStore({ rejectUntil: 99 })
+        const out = await seedBigCommerceCartInPage()
+
+        expect(counts.adds).toBe(MAX_REJECTED_ADDS)
+        expect(out.detail).toContain('stopping before we rate-limit the store')
+    })
+})
+
+describe('the cart is read through the endpoint the platform publishes', () => {
+    it('WooCommerce items_count', async () => {
+        globalThis.fetch = async url => {
+            expect(String(url)).toBe('/wp-json/wc/store/v1/cart')
+            return {
+                ok: true,
+                status: 200,
+                json: async () => ({ items_count: 2 }),
+            }
+        }
+        await expect(readCartStateInPage('woocommerce')).resolves.toEqual({
+            cartApiOk: true,
+            // Not `false`: there was no /cart.js in this run to have an opinion
+            // about, and "not observed" is never written as "did not happen".
+            cartJsOk: null,
+            itemCount: 2,
+            detail: '',
+        })
+    })
+
+    it('BigCommerce line-item quantities across every bucket', async () => {
+        globalThis.fetch = async () => ({
+            ok: true,
+            status: 200,
+            json: async () => [
+                {
+                    lineItems: {
+                        physicalItems: [{ quantity: 2 }],
+                        digitalItems: [{ quantity: 1 }],
+                        giftCertificates: [{}],
+                    },
+                },
+            ],
+        })
+        const out = await readCartStateInPage('bigcommerce')
+        expect(out.cartApiOk).toBe(true)
+        expect(out.itemCount).toBe(4)
+    })
+
+    it('a platform with no cart endpoint is reported, never assumed empty', async () => {
+        // `itemCount: 0` would be read one step later as "the cart was empty,
+        // so silence is correct" — a verdict about the store, invented out of
+        // the probe not knowing where to look.
+        globalThis.fetch = async () => {
+            throw new Error('should not be called')
+        }
+        const out = await readCartStateInPage('unknown')
+        expect(out.cartApiOk).toBe(false)
+        expect(out.itemCount).toBeNull()
+        expect(out.detail).toMatch(/no cart endpoint known/)
+    })
+})

--- a/apps/caramel-extension/tests/ext-probe-verdict.test.mjs
+++ b/apps/caramel-extension/tests/ext-probe-verdict.test.mjs
@@ -12,11 +12,13 @@
 // so the precedence cases at the bottom are as load-bearing as the ten
 // per-verdict cases above them.
 import { describe, expect, it } from 'vitest'
+import { SEEDABLE_PLATFORMS } from '../../../tools/ext-probe/seed.mjs'
 import {
     classify,
     EXIT_CODES,
     exitCodeFor,
     PROBE_ERROR,
+    PROBE_NO_EXTENSION,
     VERDICTS,
 } from '../../../tools/ext-probe/verdict.mjs'
 import { greenObservation } from './_ext-probe-fixtures.mjs'
@@ -44,12 +46,38 @@ describe('every verdict is reachable and carries its own exit code', () => {
         expect(r.reasons.join(' ')).toMatch(/correct behaviour/i)
     })
 
-    it('INCONCLUSIVE_PLATFORM when the store is not Shopify-shaped', () => {
+    it('INCONCLUSIVE_PLATFORM when no seeder speaks for the store platform', () => {
         const r = classify(
-            greenObservation({ platform: { productsJsonOk: false } }),
+            greenObservation({ platform: { detected: 'unknown' } }),
         )
         expect(r.verdict).toBe('INCONCLUSIVE_PLATFORM')
         expect(r.exitCode).toBe(31)
+        // The reason names what the seeder DOES speak, so the reader knows
+        // whether this is a gap to close or a store to leave alone.
+        for (const p of SEEDABLE_PLATFORMS)
+            expect(r.reasons.join(' ')).toContain(p)
+    })
+
+    it.each(SEEDABLE_PLATFORMS)(
+        'a seeded %s store gets past the platform gate',
+        platform => {
+            expect(
+                classify(greenObservation({ platform: { detected: platform } }))
+                    .verdict,
+            ).toBe('GREEN')
+        },
+    )
+
+    it('INCONCLUSIVE_PLATFORM when the platform is known but its endpoints did not answer', () => {
+        for (const patch of [{ productFeedOk: false }, { cartApiOk: false }]) {
+            const r = classify(
+                greenObservation({
+                    platform: { detected: 'woocommerce', ...patch },
+                }),
+            )
+            expect(r.verdict).toBe('INCONCLUSIVE_PLATFORM')
+            expect(r.reasons.join(' ')).toContain('woocommerce')
+        }
     })
 
     it('INCONCLUSIVE_CONFIG_STALE when the API log line never appeared', () => {
@@ -156,6 +184,22 @@ describe('every verdict is reachable and carries its own exit code', () => {
         expect(exitCodeFor(PROBE_ERROR)).toBe(70)
         // An unknown verdict string exits like a crash rather than like a red.
         expect(exitCodeFor('NOT_A_VERDICT')).toBe(EXIT_CODES[PROBE_ERROR])
+    })
+
+    it('"no extension was loaded" is not a verdict about the store either, and has its own code', () => {
+        // A browser with no extension answers every question with "nothing
+        // happened", which reads exactly like a broken config — so this must
+        // never be countable as a red, and must not collapse into the generic
+        // crash code a caller might already tolerate.
+        expect(VERDICTS).not.toContain(PROBE_NO_EXTENSION)
+        expect(exitCodeFor(PROBE_NO_EXTENSION)).toBe(71)
+        expect(exitCodeFor(PROBE_NO_EXTENSION)).not.toBe(
+            exitCodeFor(PROBE_ERROR),
+        )
+        for (const verdict of VERDICTS)
+            expect(exitCodeFor(verdict)).not.toBe(
+                exitCodeFor(PROBE_NO_EXTENSION),
+            )
     })
 })
 

--- a/tools/ext-probe/README.md
+++ b/tools/ext-probe/README.md
@@ -10,11 +10,11 @@ the vocabulary.
 
 ## Layout
 
-| File          | Role                                                                                             |
-| ------------- | ------------------------------------------------------------------------------------------------ |
-| `probe.mjs`   | The driver. Launches Chromium, seeds a cart, watches the run, emits the report. Needs a browser. |
-| `verdict.mjs` | The judgement. Pure — no browser, no filesystem. This is what the unit tests exercise.           |
-| `seed.mjs`    | The functions that run **inside** the page. Self-contained so Playwright can serialise them.     |
+| File          | Role                                                                                                                                                         |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `probe.mjs`   | The driver. Launches Chromium, seeds a cart, watches the run, emits the report. Needs a browser.                                                             |
+| `verdict.mjs` | The judgement. Pure — no browser, no filesystem. This is what the unit tests exercise.                                                                       |
+| `seed.mjs`    | The functions that run **inside** the page — platform detection, the per-platform seeders, the cart reader. Self-contained so Playwright can serialise them. |
 
 ## Usage
 
@@ -22,17 +22,17 @@ the vocabulary.
 node tools/ext-probe/probe.mjs <url> [width] [tag] [flags]
 ```
 
-| Flag / env         | Default                  | Meaning                                                                                                     |
-| ------------------ | ------------------------ | ----------------------------------------------------------------------------------------------------------- |
-| `EXT_DIR`          | `apps/caramel-extension` | Which build to load. Point it at `apps/caramel-extension/.output/chrome-mv3` to measure the packaged build. |
-| `PROBE_WAIT_MS`    | `30000`                  | How long a shopper waits before we call it a no-show.                                                       |
-| `PROBE_ALL_LOGS`   | unset                    | `1` keeps every console line, not just the Caramel-shaped ones.                                             |
-| `--out <path>`     | stdout                   | Write the JSON report to a file instead of stdout.                                                          |
-| `--out-dir <path>` | `.ext-probe/`            | Where the full log, screenshot and disposable profile live.                                                 |
-| `--expect-config`  | —                        | JSON file holding the config under test; enables the staleness compare.                                     |
-| `--good-code`      | —                        | A code expected to work — supplies GREEN evidence (6).                                                      |
-| `--invalid-code`   | —                        | A deliberately invalid code — the negative control, GREEN evidence (7).                                     |
-| `--width`/`--tag`  | `390` / `probe`          | Same as the positional forms.                                                                               |
+| Flag / env         | Default                  | Meaning                                                                                                                                                                                                                                              |
+| ------------------ | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `EXT_DIR`          | `apps/caramel-extension` | Which build to load. **Set it** — the WXT build lands in `apps/caramel-extension/.output/chrome-mv3`, and the default path no longer holds a manifest. A directory without a loadable `manifest.json` exits `71` before Chromium starts (see below). |
+| `PROBE_WAIT_MS`    | `30000`                  | How long a shopper waits before we call it a no-show.                                                                                                                                                                                                |
+| `PROBE_ALL_LOGS`   | unset                    | `1` keeps every console line, not just the Caramel-shaped ones.                                                                                                                                                                                      |
+| `--out <path>`     | stdout                   | Write the JSON report to a file instead of stdout.                                                                                                                                                                                                   |
+| `--out-dir <path>` | `.ext-probe/`            | Where the full log, screenshot and disposable profile live.                                                                                                                                                                                          |
+| `--expect-config`  | —                        | JSON file holding the config under test; enables the staleness compare.                                                                                                                                                                              |
+| `--good-code`      | —                        | A code expected to work — supplies GREEN evidence (6).                                                                                                                                                                                               |
+| `--invalid-code`   | —                        | A deliberately invalid code — the negative control, GREEN evidence (7).                                                                                                                                                                              |
+| `--width`/`--tag`  | `390` / `probe`          | Same as the positional forms.                                                                                                                                                                                                                        |
 
 Human prose goes to **stderr**; stdout carries the JSON object and nothing else.
 
@@ -42,19 +42,30 @@ The exit code carries the verdict. `0` means GREEN and nothing else. `1` and `2`
 deliberately — those are node's own uncaught-throw and bad-usage codes, and a caller must be able to
 tell "the config is broken" from "the probe never ran".
 
-| Code | Verdict                     | Meaning                                                            |
-| ---- | --------------------------- | ------------------------------------------------------------------ |
-| 0    | `GREEN`                     | Full chain proven — all seven evidence items below.                |
-| 10   | `AMBER_NO_INDICATORS`       | The flow works but cannot be **proved**.                           |
-| 20   | `RED_NOT_DETECTED`          | Real cart, extension never recognised the checkout.                |
-| 21   | `RED_NO_COUPONS`            | Detected, catalogue had nothing to try.                            |
-| 22   | `RED_NO_PROMPT`             | Coupons fetched, prompt never rendered.                            |
-| 23   | `RED_PROMPT_DEGENERATE`     | Rendered but unusable (zero size, invisible, fallback CSS).        |
-| 24   | `RED_APPLY_FAILED`          | Codes entered, nothing landed, no error fired.                     |
-| 30   | `INCONCLUSIVE_SEED`         | Cart never populated — "no prompt" is CORRECT here, not a failure. |
-| 31   | `INCONCLUSIVE_PLATFORM`     | Store is not Shopify-shaped; the seed path cannot apply.           |
-| 32   | `INCONCLUSIVE_CONFIG_STALE` | The served config is not the one under test.                       |
-| 70   | `PROBE_ERROR`               | The **probe** crashed. Not a statement about the store.            |
+| Code | Verdict                     | Meaning                                                                        |
+| ---- | --------------------------- | ------------------------------------------------------------------------------ |
+| 0    | `GREEN`                     | Full chain proven — all seven evidence items below.                            |
+| 10   | `AMBER_NO_INDICATORS`       | The flow works but cannot be **proved**.                                       |
+| 20   | `RED_NOT_DETECTED`          | Real cart, extension never recognised the checkout.                            |
+| 21   | `RED_NO_COUPONS`            | Detected, catalogue had nothing to try.                                        |
+| 22   | `RED_NO_PROMPT`             | Coupons fetched, prompt never rendered.                                        |
+| 23   | `RED_PROMPT_DEGENERATE`     | Rendered but unusable (zero size, invisible, fallback CSS).                    |
+| 24   | `RED_APPLY_FAILED`          | Codes entered, nothing landed, no error fired.                                 |
+| 30   | `INCONCLUSIVE_SEED`         | Cart never populated — "no prompt" is CORRECT here, not a failure.             |
+| 31   | `INCONCLUSIVE_PLATFORM`     | No seeder speaks for this store's platform, or its endpoints did not answer.   |
+| 32   | `INCONCLUSIVE_CONFIG_STALE` | The served config is not the one under test.                                   |
+| 70   | `PROBE_ERROR`               | The **probe** crashed. Not a statement about the store.                        |
+| 71   | `PROBE_NO_EXTENSION`        | `EXT_DIR` holds no loadable extension. Not a statement about the store either. |
+
+`PROBE_NO_EXTENSION` has its own code because the failure it names is silent by nature. Chromium
+accepts `--load-extension=<dir>` pointing at a directory with no manifest, logs nothing a caller can
+see, and runs a perfectly ordinary browser with nothing installed — and every measurement taken that
+way says the prompt never appeared, no coupons were fetched and nothing was submitted, which is
+indistinguishable from a genuinely broken store config. That is exactly what happened after the WXT
+migration moved the build to `.output/chrome-mv3`: days of ext-QA verdicts were measurements of an
+empty browser, and the only tell in the whole report was `vnull` in the log header. **A probe that
+cannot load the extension must never produce a verdict**, so the check runs before Chromium is
+launched and the report carries no observation at all.
 
 Verdicts are evaluated **first match wins**, in the order listed in `VERDICTS`. `INCONCLUSIVE_SEED`
 is checked before everything else on purpose: an empty cart is not a checkout, so the extension
@@ -88,7 +99,13 @@ the served config, the best available verdict is `AMBER_NO_INDICATORS` — never
     },
     "observation": {
         "seed": { "ok": null, "detail": "", "rejectedAdds": 0, "adds": 0 },
-        "platform": { "productsJsonOk": null, "cartJsOk": null },
+        "platform": {
+            "detected": null, // shopify | woocommerce | bigcommerce | unknown
+            "productFeedOk": null, // the platform's product source listed something addable
+            "cartApiOk": null, // the platform's cart endpoint answered
+            "productsJsonOk": null, // the Shopify legs, set only on a Shopify run
+            "cartJsOk": null,
+        },
         "cartItemsAtArrival": null, // read BEFORE the wait window
         "config": {
             "servedFromApi": null,
@@ -156,13 +173,49 @@ difference is _explainable_, which is not the same as _forgiven_.
 The timings live in extension storage and are readable **only** through the service-worker handle —
 page `evaluate` runs in the store's world and cannot see them.
 
+## Seeding a cart, per platform
+
+The probe's first question on any store is "is there a cart?". Until 2026-08-14 only Shopify could
+answer it, so every WooCommerce and BigCommerce store fell out at `INCONCLUSIVE_SEED` and the repair
+loop behind ext-QA never got a verdict to act on.
+
+The platform is named from markup the platform itself emits (`window.Shopify`,
+`wc_add_to_cart_params`, `window.BCData`, then CDN/asset URLs, then theme classes) — never from the
+hostname and never from a per-store list, which would rot the day a store replatformed. Detection
+runs **once** and the answer is passed to both the seeder and the cart reader, so the two can never
+disagree about what the store is.
+
+| Platform    | Products from                        | Added via                                                  | Cart read from              |
+| ----------- | ------------------------------------ | ---------------------------------------------------------- | --------------------------- |
+| Shopify     | `/products.json`                     | `POST /cart/add.js`                                        | `/cart.js`                  |
+| WooCommerce | `/wp-json/wc/store/v1/products`      | `POST /wp-json/wc/store/v1/cart/add-item` + `Nonce` header | `/wp-json/wc/store/v1/cart` |
+| BigCommerce | product ids in the storefront markup | `POST /api/storefront/carts`                               | `/api/storefront/carts`     |
+
+Two things about the WooCommerce path were measured on a live store (alphaterritory.com,
+2026-08-14) rather than assumed: `add-item` answers `401 woocommerce_rest_missing_nonce` without a
+`Nonce` header, and that nonce is handed out in the `Nonce` **response** header of the cart GET the
+seeder already makes for its baseline count — so it costs no extra request. The same endpoint takes
+a variable product as the parent id plus a `variation` list, which is what makes the path general:
+most Woo catalogues are variable products, and the classic `?add-to-cart=` form handler cannot reach
+them without reconstructing the theme's own `attribute_*` field names. On BigCommerce
+(a1supplements.com, same day) products carrying required options answer
+`422 This product has options, variant ID is required` — a real rejection, counted as one.
+
+A platform with no seeder reports `INCONCLUSIVE_PLATFORM` and the run stops there. **A cart is never
+faked**: on Shopify the add's own status is the signal, and on both new platforms success is
+confirmed by re-reading the cart, so a `201` whose item never appears is not a seeded cart.
+
 ## Store safety
 
 Two behaviours are non-negotiable and pinned by tests:
 
-- **The seed stops after 5 consecutive rejected adds.** An uncapped version of this loop once fired
-  154 POSTs into one store, drew 286 rate-limit 429s, and broke that store's own scripts — and the
-  breakage was then mis-diagnosed as an extension defect. The second-order damage is the lesson.
+- **Every seeder stops after 5 consecutive rejected adds.** An uncapped version of this loop once
+  fired 154 POSTs into one store, drew 286 rate-limit 429s, and broke that store's own scripts — and
+  the breakage was then mis-diagnosed as an extension defect. The second-order damage is the lesson.
+  Each platform's cap carries its own red-proof: uncapped, the same fixture fires 40 adds.
+- **An add that cannot be verified is never sent.** If the cart endpoint will not answer, or
+  WooCommerce served no nonce, the seeder abandons before the first POST rather than pushing writes
+  at a store it cannot check.
 - **The cart is read before the wait window, never after.** An empty cart at arrival makes silence
   the correct answer; reading the cart only after the wait cannot tell the two apart.
 

--- a/tools/ext-probe/probe.mjs
+++ b/tools/ext-probe/probe.mjs
@@ -12,6 +12,7 @@
 // Usage and the full exit-code table: see ./README.md
 import { createHash } from 'node:crypto'
 import {
+    existsSync,
     mkdirSync,
     readdirSync,
     readFileSync,
@@ -25,11 +26,17 @@ import { chromium } from 'playwright'
 import {
     countPromoInputsInPage,
     DEFAULT_PRODUCT_LIMIT,
+    detectPlatformInPage,
     MAX_REJECTED_ADDS,
     readCartStateInPage,
-    seedShopifyCartInPage,
+    seedersByPlatform,
 } from './seed.mjs'
-import { buildReport, diffWitnesses, emptyObservation } from './verdict.mjs'
+import {
+    buildReport,
+    diffWitnesses,
+    emptyObservation,
+    PROBE_NO_EXTENSION,
+} from './verdict.mjs'
 
 // fileURLToPath, not `new URL(...).pathname.slice(1)`: the slice trick strips
 // the leading slash of a Windows drive path and silently produces garbage
@@ -37,6 +44,12 @@ import { buildReport, diffWitnesses, emptyObservation } from './verdict.mjs'
 const HERE = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = resolve(HERE, '..', '..')
 const DEFAULT_EXT_DIR = join(REPO_ROOT, 'apps', 'caramel-extension')
+// Where a build actually lands. Only used to make the "you pointed me at a
+// directory with no manifest" message name a real path instead of a shrug.
+const BUILD_OUTPUT_HINTS = [
+    join(REPO_ROOT, 'apps', 'caramel-extension', '.output', 'chrome-mv3'),
+    join(REPO_ROOT, 'apps', 'caramel-extension', '.output', 'chrome-mv3-dev'),
+]
 
 // The extension's own cache key for the supported-domain list (store-detect.js).
 // Cleared before the run so the domain list is always fetched fresh: a verdict
@@ -107,6 +120,64 @@ function listFiles(dir, base = dir, out = []) {
         else out.push(relative(base, full).split(sep).join('/'))
     }
     return out
+}
+
+/**
+ * Carries the PROBE_NO_EXTENSION sentinel out to the one place that emits a
+ * report, so the "no extension" exit code is chosen where the verdict is
+ * built rather than by a second `process.exit` hiding in the middle of main().
+ */
+class NoExtensionError extends Error {
+    constructor(message) {
+        super(message)
+        this.name = 'NoExtensionError'
+        this.probeVerdict = PROBE_NO_EXTENSION
+    }
+}
+
+/**
+ * Refuse to launch without a loadable extension.
+ *
+ * Chromium accepts `--load-extension=<dir>` pointing at a directory with no
+ * manifest, logs nothing a caller can see, and runs a perfectly normal browser
+ * with no extension in it. Every measurement taken that way says the same
+ * thing — the prompt never appeared, no coupons were fetched, nothing was
+ * submitted — which is indistinguishable from a genuinely broken store config.
+ * That is exactly what happened after the WXT migration moved the build to
+ * `.output/chrome-mv3` and left `apps/caramel-extension` (this file's default)
+ * without a manifest: days of ext-QA verdicts were measurements of an empty
+ * browser, and the single tell was `vnull` in the log header.
+ */
+function assertLoadableExtension(extDir) {
+    const manifestPath = join(extDir, 'manifest.json')
+    let problem = null
+    if (!existsSync(manifestPath)) {
+        problem = `no manifest.json in ${extDir}`
+    } else {
+        // A manifest Chromium cannot parse loads exactly as well as no
+        // manifest at all, and produces the same empty browser.
+        try {
+            const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+            if (!manifest.version)
+                problem = `${manifestPath} carries no version — Chromium refuses a manifest without one`
+        } catch (e) {
+            problem = `${manifestPath} is not parseable JSON: ${e.message}`
+        }
+    }
+    if (!problem) return
+    const built = BUILD_OUTPUT_HINTS.filter(dir =>
+        existsSync(join(dir, 'manifest.json')),
+    )
+    throw new NoExtensionError(
+        [
+            `${problem} — Chromium would have launched with NO extension,`,
+            'and every verdict from that run would have been a measurement of an empty browser.',
+            'The WXT build lands in apps/caramel-extension/.output/chrome-mv3; point EXT_DIR (or --ext) at it.',
+            built.length
+                ? `Loadable build(s) found here now: ${built.join(', ')}`
+                : 'No built extension found either — run `pnpm --filter caramel-extension build` first.',
+        ].join(' '),
+    )
 }
 
 /**
@@ -202,6 +273,10 @@ async function main() {
             readFileSync(resolve(flags['expect-config']), 'utf8'),
         )
 
+    // Before anything else that costs time or touches a store: a probe that
+    // cannot load the extension must never produce a verdict.
+    assertLoadableExtension(extDir)
+
     const build = identifyBuild(extDir)
     const target = {
         url,
@@ -287,17 +362,44 @@ async function main() {
                     ),
                 )
 
-        const seeded = await page.evaluate(seedShopifyCartInPage, {
-            maxRejectedAdds: MAX_REJECTED_ADDS,
-            productLimit: DEFAULT_PRODUCT_LIMIT,
-        })
+        // Which cart mechanism this store speaks, named from markup the
+        // platform itself emits — detected ONCE and then passed to both the
+        // seeder and the cart reader, so the two can never disagree about what
+        // the store is.
+        const detected = await page.evaluate(detectPlatformInPage).catch(e => ({
+            platform: 'unknown',
+            signal: `detection failed: ${e.message}`,
+        }))
+        const platform = detected.platform
+        observation.platform.detected = platform
+        note(`platform: ${platform} (${detected.signal})`)
+
+        const seeder = seedersByPlatform()[platform]
+        // No seeder means no cart, and no cart means no evidence — reported as
+        // such rather than attempted with someone else's endpoints.
+        const seeded = seeder
+            ? await page.evaluate(seeder, {
+                  maxRejectedAdds: MAX_REJECTED_ADDS,
+                  productLimit: DEFAULT_PRODUCT_LIMIT,
+              })
+            : {
+                  ok: false,
+                  detail: `no seeder speaks for platform "${platform}" (${detected.signal})`,
+                  rejectedAdds: 0,
+                  adds: 0,
+                  productFeedOk: false,
+              }
         observation.seed = {
             ok: seeded.ok,
             detail: seeded.detail,
             rejectedAdds: seeded.rejectedAdds,
             adds: seeded.adds,
         }
-        observation.platform.productsJsonOk = seeded.productsJsonOk
+        observation.platform.productFeedOk = seeded.productFeedOk
+        // Only a Shopify run has a /products.json to speak about; on every
+        // other platform the field stays null, which is "not observed".
+        if (seeded.productsJsonOk !== undefined)
+            observation.platform.productsJsonOk = seeded.productsJsonOk
         note(`seed: ${seeded.detail}`)
 
         await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 })
@@ -305,8 +407,9 @@ async function main() {
         // The cart as it stands when the extension is about to look at it — an
         // empty cart here makes silence the CORRECT answer, and reading it only
         // after the wait cannot tell the two apart.
-        const cartState = await page.evaluate(readCartStateInPage)
+        const cartState = await page.evaluate(readCartStateInPage, platform)
         observation.cartItemsAtArrival = cartState.itemCount
+        observation.platform.cartApiOk = cartState.cartApiOk
         observation.platform.cartJsOk = cartState.cartJsOk
         note(`cart at arrival: ${cartState.itemCount ?? cartState.detail}`)
 
@@ -640,10 +743,20 @@ let code
 try {
     code = await main()
 } catch (e) {
-    // A harness crash is never reported as a store verdict.
-    const report = buildReport({ error: e?.stack || String(e) })
+    // A harness crash is never reported as a store verdict. Neither is a
+    // missing extension — that one carries its own sentinel and exit code, so
+    // a caller can tell "I was pointed at the wrong directory" from "the probe
+    // fell over" without reading English.
+    const report = buildReport({
+        error: e?.probeVerdict ? e.message : e?.stack || String(e),
+        errorVerdict: e?.probeVerdict || undefined,
+    })
     process.stdout.write(`${JSON.stringify(report, null, 2)}\n`)
-    note(`ext-probe crashed: ${e?.stack || e}`)
+    note(
+        e?.probeVerdict
+            ? `ext-probe refused to run: ${e.message}`
+            : `ext-probe crashed: ${e?.stack || e}`,
+    )
     code = report.exitCode
 }
 process.exit(code)

--- a/tools/ext-probe/seed.mjs
+++ b/tools/ext-probe/seed.mjs
@@ -1,14 +1,22 @@
-// The two functions the probe runs INSIDE the store page.
+// The functions the probe runs INSIDE the store page.
 //
-// Both are deliberately self-contained — no imports, no module-scope
-// references, no closures. Playwright serialises a function by its source
-// text, so anything captured from this module's scope would be `undefined` by
-// the time it runs in the page. The same property is what makes them testable:
-// with `globalThis.fetch` stubbed they run unchanged in Node, which is how the
-// seed cap below is pinned in CI without touching a real store.
+// Every one of them is deliberately self-contained — no imports, no
+// module-scope references, no closures. Playwright serialises a function by its
+// source text, so anything captured from this module's scope would be
+// `undefined` by the time it runs in the page. The same property is what makes
+// them testable: with `globalThis.fetch` stubbed they run unchanged in Node,
+// which is how the seed cap below is pinned in CI without touching a real
+// store.
+//
+// The seeder is per-PLATFORM, never per-store. A store-shaped special case
+// would be a config we could never verify — the platform's own documented
+// cart mechanism is a contract thousands of stores share, so a fix here is a
+// fix everywhere. A platform we cannot seed reports that honestly and the
+// probe abandons: a faked cart would turn every downstream verdict into
+// fiction.
 
 /**
- * How many consecutive rejected adds the seeder tolerates before it gives up.
+ * How many consecutive rejected adds any seeder tolerates before it gives up.
  * Exported so a caller can read the number, NOT so the page function can — see
  * the self-containment note above.
  */
@@ -18,11 +26,137 @@ export const MAX_REJECTED_ADDS = 5
 export const DEFAULT_PRODUCT_LIMIT = 30
 
 /**
+ * The platforms whose cart mechanism this file implements. `detectPlatformInPage`
+ * returns one of these or `'unknown'`; `unknown` is an honest abandon, never a
+ * reason to guess.
+ */
+export const SEEDABLE_PLATFORMS = Object.freeze([
+    'shopify',
+    'woocommerce',
+    'bigcommerce',
+])
+
+/**
+ * Which seeder speaks for which platform. The probe dispatches through this
+ * map so adding a platform is one entry plus one function — and so a platform
+ * with no seeder cannot silently fall through to a Shopify-shaped attempt.
+ *
+ * @returns {Record<string, (options: object) => Promise<object>>}
+ */
+export function seedersByPlatform() {
+    return {
+        shopify: seedShopifyCartInPage,
+        woocommerce: seedWooCommerceCartInPage,
+        bigcommerce: seedBigCommerceCartInPage,
+    }
+}
+
+/**
+ * Name the e-commerce platform from markup the platform itself emits — never
+ * from the hostname. A per-store list would rot the day a store replatformed,
+ * and would be wrong for the 2,700th store the moment it was written.
+ *
+ * Strongest signals first: a global the platform's own bundle sets outranks a
+ * CDN URL, which outranks a body class a theme could have copied.
+ *
+ * @returns {{platform: string, signal: string}}
+ */
+export function detectPlatformInPage() {
+    const has = sel => {
+        try {
+            return !!document.querySelector(sel)
+        } catch {
+            // An invalid selector here would be a bug in THIS list, not a
+            // property of the store; treat it as "no signal" and let the
+            // remaining probes speak.
+            return false
+        }
+    }
+    const bodyClass = (document.body && document.body.className) || ''
+    const probes = [
+        // Shopify
+        [
+            'shopify',
+            'window.Shopify.shop',
+            () =>
+                !!(
+                    window.Shopify &&
+                    (window.Shopify.shop || window.Shopify.routes)
+                ),
+        ],
+        // WooCommerce — these globals are localised by WooCommerce core itself.
+        [
+            'woocommerce',
+            'window.wc_add_to_cart_params',
+            () =>
+                !!(
+                    window.wc_add_to_cart_params ||
+                    window.woocommerce_params ||
+                    window.wc_cart_fragments_params
+                ),
+        ],
+        // BigCommerce — Stencil bootstraps this on every storefront page.
+        ['bigcommerce', 'window.BCData', () => !!window.BCData],
+        [
+            'shopify',
+            'cdn.shopify.com asset',
+            () =>
+                has(
+                    'script[src*="cdn.shopify.com"], link[href*="cdn.shopify.com"]',
+                ),
+        ],
+        [
+            'woocommerce',
+            'woocommerce plugin asset',
+            () =>
+                has(
+                    'script[src*="/plugins/woocommerce/"], link[href*="/plugins/woocommerce/"]',
+                ),
+        ],
+        [
+            'bigcommerce',
+            'bigcommerce cdn asset',
+            () =>
+                has(
+                    'script[src*="bigcommerce.com"], link[href*="bigcommerce.com"]',
+                ),
+        ],
+        [
+            'woocommerce',
+            'body.woocommerce class',
+            () => /(^|\s)woocommerce(-page)?(\s|$)/.test(String(bodyClass)),
+        ],
+        [
+            'bigcommerce',
+            'cart.php form action',
+            () => has('form[action*="/cart.php"]'),
+        ],
+    ]
+    for (const [platform, signal, test] of probes) {
+        let hit = false
+        try {
+            hit = test()
+        } catch (e) {
+            return {
+                platform: 'unknown',
+                signal: `detection threw on ${signal}: ${String(e).slice(0, 60)}`,
+            }
+        }
+        if (hit) return { platform, signal }
+    }
+    return { platform: 'unknown', signal: 'no platform marker found' }
+}
+
+/**
  * Seed a Shopify cart the way the platform itself would: read the public
  * product feed, then add the first available variant that the store accepts.
  *
+ * `productsJsonOk` is the literal Shopify leg and is reported alongside the
+ * platform-neutral `productFeedOk` so runs recorded before the seeder widened
+ * stay comparable field-for-field.
+ *
  * @param {{maxRejectedAdds?: number, productLimit?: number}} options
- * @returns {Promise<{ok: boolean, detail: string, rejectedAdds: number, adds: number, productsJsonOk: boolean}>}
+ * @returns {Promise<{ok: boolean, detail: string, rejectedAdds: number, adds: number, productFeedOk: boolean, productsJsonOk: boolean}>}
  */
 export async function seedShopifyCartInPage(options) {
     const maxRejectedAdds = (options && options.maxRejectedAdds) || 5
@@ -32,11 +166,13 @@ export async function seedShopifyCartInPage(options) {
         detail: '',
         rejectedAdds: 0,
         adds: 0,
+        productFeedOk: false,
         productsJsonOk: false,
     }
     try {
         const res = await fetch(`/products.json?limit=${productLimit}`)
         out.productsJsonOk = !!res.ok
+        out.productFeedOk = !!res.ok
         if (!res.ok) {
             out.detail = `products.json ${res.status}`
             return out
@@ -77,33 +213,350 @@ export async function seedShopifyCartInPage(options) {
 }
 
 /**
- * Read the cart as the store reports it. Kept separate from the seeder so the
- * probe can call it at the one moment that matters — see probe.mjs.
+ * Seed a WooCommerce cart through the Store API, the same interface the Blocks
+ * cart in WooCommerce core uses: `/wc/store/v1/products` to list what is
+ * purchasable, `/wc/store/v1/cart/add-item` to add it.
  *
- * @returns {Promise<{cartJsOk: boolean, itemCount: number|null, detail: string}>}
+ * Two things about that endpoint were measured, not assumed (alphaterritory.com,
+ * 2026-08-14). It answers `401 woocommerce_rest_missing_nonce` without a
+ * `Nonce` header, and the nonce is handed out in the `Nonce` RESPONSE header of
+ * the cart GET this function already makes for its baseline count — so the
+ * nonce costs no extra request. And it takes a variable product as the PARENT
+ * id plus a `variation` list, which is what makes this path general: most Woo
+ * catalogues are variable products, and the classic `?add-to-cart=` form handler
+ * needs the theme's own `attribute_*` field names reconstructed to reach them.
+ *
+ * Success is confirmed by re-reading the cart rather than trusting the add's
+ * status — the same independent-witness rule the rest of the probe lives by.
+ *
+ * @param {{maxRejectedAdds?: number, productLimit?: number}} options
+ * @returns {Promise<{ok: boolean, detail: string, rejectedAdds: number, adds: number, productFeedOk: boolean, candidates: number}>}
  */
-export async function readCartStateInPage() {
-    try {
-        const res = await fetch('/cart.js')
+export async function seedWooCommerceCartInPage(options) {
+    const maxRejectedAdds = (options && options.maxRejectedAdds) || 5
+    const productLimit = (options && options.productLimit) || 30
+    const out = {
+        ok: false,
+        detail: '',
+        rejectedAdds: 0,
+        adds: 0,
+        productFeedOk: false,
+        candidates: 0,
+    }
+    // Declared inside so the whole function survives serialisation into the
+    // page as one self-contained unit.
+    const readCart = async () => {
+        const res = await fetch('/wp-json/wc/store/v1/cart', {
+            headers: { accept: 'application/json' },
+        })
         if (!res.ok)
-            return {
-                cartJsOk: false,
-                itemCount: null,
-                detail: `cart.js ${res.status}`,
-            }
+            return { ok: false, count: null, nonce: null, status: res.status }
         const cart = await res.json()
         return {
-            cartJsOk: true,
-            itemCount:
-                typeof cart.item_count === 'number' ? cart.item_count : null,
-            detail: '',
+            ok: true,
+            count:
+                typeof cart.items_count === 'number' ? cart.items_count : null,
+            nonce: res.headers.get('nonce'),
+            status: res.status,
         }
+    }
+    try {
+        const feed = await fetch(
+            `/wp-json/wc/store/v1/products?per_page=${productLimit}`,
+            { headers: { accept: 'application/json' } },
+        )
+        out.productFeedOk = !!feed.ok
+        if (!feed.ok) {
+            out.detail = `store-api products ${feed.status}`
+            return out
+        }
+        const products = await feed.json()
+        // One entry per thing that can actually be added: a simple product is
+        // itself, a variable product is its parent id once per variation.
+        const candidates = []
+        for (const p of Array.isArray(products) ? products : []) {
+            if (!p || !p.is_purchasable || !p.is_in_stock) continue
+            if (typeof p.id !== 'number') continue
+            const name = String(p.name || p.id)
+            const variations = Array.isArray(p.variations) ? p.variations : []
+            if (!variations.length) {
+                candidates.push({ id: p.id, name, variation: null })
+                continue
+            }
+            for (const v of variations)
+                candidates.push({
+                    id: p.id,
+                    name: `${name} / ${v.id}`,
+                    variation: (v.attributes || []).map(a => ({
+                        attribute: a.name,
+                        value: a.value,
+                    })),
+                })
+        }
+        out.candidates = candidates.length
+        if (!candidates.length) {
+            out.detail = 'store-api listed no purchasable in-stock product'
+            return out
+        }
+
+        const before = await readCart()
+        if (!before.ok) {
+            out.detail = `store-api cart ${before.status} — cannot verify an add, so none was sent`
+            return out
+        }
+        if (!before.nonce) {
+            out.detail =
+                'store-api cart served no Nonce header — add-item would be rejected, so no add was sent'
+            return out
+        }
+        const baseline = before.count || 0
+
+        // Same cap, same reason as the Shopify path above: a store that
+        // rejects 5 adds in a row is not going to accept the 6th, and the
+        // damage from finding that out the hard way lands on the STORE.
+        let failed = 0
+        let lastStatus = null
+        for (const c of candidates) {
+            out.adds++
+            const body = { id: c.id, quantity: 1 }
+            if (c.variation) body.variation = c.variation
+            const add = await fetch('/wp-json/wc/store/v1/cart/add-item', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Nonce: before.nonce,
+                },
+                body: JSON.stringify(body),
+            })
+            lastStatus = add.status
+            if (add.ok) {
+                const after = await readCart()
+                if (after.ok && (after.count || 0) > baseline) {
+                    out.ok = true
+                    out.detail = `added ${c.name}`
+                    return out
+                }
+            }
+            out.rejectedAdds = ++failed
+            if (failed >= maxRejectedAdds) {
+                out.detail = `no add landed in the cart after ${failed} tries (last ${lastStatus}) — stopping before we rate-limit the store`
+                return out
+            }
+        }
+        out.detail = `no add landed in the cart across ${out.adds} candidate(s) (last ${lastStatus})`
+        return out
     } catch (e) {
+        out.detail = `seed failed: ${String(e).slice(0, 80)}`
+        return out
+    }
+}
+
+/**
+ * Seed a BigCommerce cart through the Storefront API the theme itself calls:
+ * `POST /api/storefront/carts` (or `/carts/{id}/items` when the session
+ * already holds one — checked, not guessed, because posting a second cart is
+ * an error rather than an add).
+ *
+ * BigCommerce publishes no product feed, so ids come from the storefront
+ * markup, where Stencil stamps them on every product card. Products carrying
+ * required options answer 422 and are counted as rejections like any other.
+ *
+ * @param {{maxRejectedAdds?: number, productLimit?: number}} options
+ * @returns {Promise<{ok: boolean, detail: string, rejectedAdds: number, adds: number, productFeedOk: boolean, candidates: number}>}
+ */
+export async function seedBigCommerceCartInPage(options) {
+    const maxRejectedAdds = (options && options.maxRejectedAdds) || 5
+    const productLimit = (options && options.productLimit) || 30
+    const out = {
+        ok: false,
+        detail: '',
+        rejectedAdds: 0,
+        adds: 0,
+        productFeedOk: false,
+        candidates: 0,
+    }
+    const readCarts = async () => {
+        const res = await fetch('/api/storefront/carts', {
+            headers: { accept: 'application/json' },
+        })
+        if (!res.ok) return { ok: false, carts: [], status: res.status }
+        const carts = await res.json()
         return {
-            cartJsOk: false,
-            itemCount: null,
-            detail: `err ${String(e).slice(0, 40)}`,
+            ok: true,
+            carts: Array.isArray(carts) ? carts : [],
+            status: res.status,
         }
+    }
+    const countItems = carts => {
+        let n = 0
+        for (const cart of carts || []) {
+            const line = cart.lineItems || {}
+            for (const bucket of [
+                line.physicalItems,
+                line.digitalItems,
+                line.giftCertificates,
+                line.customItems,
+            ])
+                for (const item of bucket || [])
+                    n += typeof item.quantity === 'number' ? item.quantity : 1
+        }
+        return n
+    }
+    try {
+        const ids = []
+        const seen = new Set()
+        for (const el of document.querySelectorAll(
+            '[data-product-id], [data-entity-id], input[name="product_id"]',
+        )) {
+            const raw =
+                el.getAttribute('data-product-id') ||
+                el.getAttribute('data-entity-id') ||
+                el.value
+            const id = Number(raw)
+            if (!Number.isInteger(id) || id <= 0 || seen.has(id)) continue
+            seen.add(id)
+            ids.push(id)
+            if (ids.length >= productLimit) break
+        }
+        out.productFeedOk = ids.length > 0
+        out.candidates = ids.length
+        if (!ids.length) {
+            out.detail =
+                'no product id in the storefront markup (data-product-id / data-entity-id)'
+            return out
+        }
+
+        const existing = await readCarts()
+        if (!existing.ok) {
+            out.detail = `storefront carts ${existing.status} — cannot verify an add, so none was sent`
+            return out
+        }
+        const baseline = countItems(existing.carts)
+        const cartId = existing.carts.length ? existing.carts[0].id : null
+
+        let failed = 0
+        for (const id of ids) {
+            out.adds++
+            const body = JSON.stringify({
+                lineItems: [{ quantity: 1, productId: id }],
+            })
+            const add = await fetch(
+                cartId
+                    ? `/api/storefront/carts/${cartId}/items`
+                    : '/api/storefront/carts',
+                {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body,
+                },
+            )
+            if (add.ok) {
+                const now = await readCarts()
+                if (now.ok && countItems(now.carts) > baseline) {
+                    out.ok = true
+                    out.detail = `added product ${id}`
+                    return out
+                }
+            }
+            out.rejectedAdds = ++failed
+            if (failed >= maxRejectedAdds) {
+                out.detail = `no add landed in the cart after ${failed} tries (last ${add.status}) — stopping before we rate-limit the store`
+                return out
+            }
+        }
+        out.detail = `no add landed in the cart across ${out.adds} candidate product(s)`
+        return out
+    } catch (e) {
+        out.detail = `seed failed: ${String(e).slice(0, 80)}`
+        return out
+    }
+}
+
+/**
+ * Read the cart as the store reports it, through the endpoint that platform
+ * publishes. Kept separate from the seeder so the probe can call it at the one
+ * moment that matters — see probe.mjs.
+ *
+ * The platform is passed IN rather than re-detected here: one detection per
+ * run means the reader and the seeder can never disagree about what the store
+ * is, and the answer is recorded in the report either way.
+ *
+ * `cartJsOk` is the Shopify leg under its original name; `cartApiOk` is the
+ * platform-neutral fact the classifier reads.
+ *
+ * @param {string} platform one of SEEDABLE_PLATFORMS
+ * @returns {Promise<{cartApiOk: boolean, cartJsOk: boolean|null, itemCount: number|null, detail: string}>}
+ */
+export async function readCartStateInPage(platform) {
+    const miss = (detail, isShopify) => ({
+        cartApiOk: false,
+        cartJsOk: isShopify ? false : null,
+        itemCount: null,
+        detail,
+    })
+    const shopify = platform === 'shopify'
+    try {
+        if (shopify) {
+            const res = await fetch('/cart.js')
+            if (!res.ok) return miss(`cart.js ${res.status}`, true)
+            const cart = await res.json()
+            return {
+                cartApiOk: true,
+                cartJsOk: true,
+                itemCount:
+                    typeof cart.item_count === 'number'
+                        ? cart.item_count
+                        : null,
+                detail: '',
+            }
+        }
+        if (platform === 'woocommerce') {
+            const res = await fetch('/wp-json/wc/store/v1/cart', {
+                headers: { accept: 'application/json' },
+            })
+            if (!res.ok) return miss(`store-api cart ${res.status}`, false)
+            const cart = await res.json()
+            return {
+                cartApiOk: true,
+                cartJsOk: null,
+                itemCount:
+                    typeof cart.items_count === 'number'
+                        ? cart.items_count
+                        : null,
+                detail: '',
+            }
+        }
+        if (platform === 'bigcommerce') {
+            const res = await fetch('/api/storefront/carts', {
+                headers: { accept: 'application/json' },
+            })
+            if (!res.ok) return miss(`storefront carts ${res.status}`, false)
+            const carts = await res.json()
+            let n = 0
+            for (const cart of Array.isArray(carts) ? carts : []) {
+                const line = cart.lineItems || {}
+                for (const bucket of [
+                    line.physicalItems,
+                    line.digitalItems,
+                    line.giftCertificates,
+                    line.customItems,
+                ])
+                    for (const item of bucket || [])
+                        n +=
+                            typeof item.quantity === 'number'
+                                ? item.quantity
+                                : 1
+            }
+            return {
+                cartApiOk: true,
+                cartJsOk: null,
+                itemCount: n,
+                detail: '',
+            }
+        }
+        return miss(`no cart endpoint known for platform ${platform}`, false)
+    } catch (e) {
+        return miss(`err ${String(e).slice(0, 40)}`, shopify)
     }
 }
 

--- a/tools/ext-probe/verdict.mjs
+++ b/tools/ext-probe/verdict.mjs
@@ -12,6 +12,14 @@
 // mistake here is reading "the prompt never appeared" as a defect when the cart
 // was empty the whole time and silence was the CORRECT behaviour.
 
+import { SEEDABLE_PLATFORMS } from './seed.mjs'
+
+// Still `ext-probe/1`. The widening of the seeder past Shopify only ADDED
+// fields to `observation.platform` (`detected`, `productFeedOk`, `cartApiOk`);
+// nothing was renamed or removed, so every consumer written against v1 keeps
+// reading exactly what it read before. The two Shopify-shaped fields it used
+// to carry alone are kept beside the new ones for the same reason — reports
+// recorded before the widening stay comparable field-for-field.
 export const SCHEMA = 'ext-probe/1'
 
 /**
@@ -39,6 +47,19 @@ export const VERDICTS = Object.freeze([
  */
 export const PROBE_ERROR = 'PROBE_ERROR'
 
+/**
+ * The probe was pointed at a directory that is not a loadable extension, so
+ * Chromium would have started with NOTHING installed. Its own sentinel rather
+ * than a flavour of PROBE_ERROR because the failure is silent by nature: a
+ * browser with no extension answers every question with "nothing happened",
+ * which reads exactly like a broken config. Days of ext-QA measurements were
+ * taken that way after the WXT migration moved the manifest to
+ * `.output/chrome-mv3` — the only tell in the whole report was `vnull` in the
+ * log header. A probe that cannot load the extension must never produce a
+ * verdict.
+ */
+export const PROBE_NO_EXTENSION = 'PROBE_NO_EXTENSION'
+
 // Exit codes are the machine contract for shell callers, so they are stable
 // numbers, not indexes into the array above. 0 is GREEN and nothing else.
 // 1 and 2 are avoided on purpose (node's own uncaught-throw / bad-usage codes),
@@ -56,6 +77,7 @@ export const EXIT_CODES = Object.freeze({
     INCONCLUSIVE_PLATFORM: 31,
     INCONCLUSIVE_CONFIG_STALE: 32,
     [PROBE_ERROR]: 70,
+    [PROBE_NO_EXTENSION]: 71,
 })
 
 export function exitCodeFor(verdict) {
@@ -92,7 +114,21 @@ export const TIMINGS_CAP = 50
 export function emptyObservation() {
     return {
         seed: { ok: null, detail: '', rejectedAdds: 0, adds: 0 },
-        platform: { productsJsonOk: null, cartJsOk: null },
+        platform: {
+            // Which platform's cart mechanism was used, named from markup the
+            // platform itself emits. `unknown` means no seeder speaks for this
+            // store — an honest abandon, never a Shopify-shaped guess.
+            detected: null,
+            // The platform-neutral facts the classifier reads: its product
+            // source listed something addable, and its cart endpoint answered.
+            productFeedOk: null,
+            cartApiOk: null,
+            // The literal Shopify legs, set only on a Shopify run. Kept beside
+            // the two above so reports recorded before the seeder widened past
+            // Shopify stay comparable field-for-field.
+            productsJsonOk: null,
+            cartJsOk: null,
+        },
         // Read BEFORE the wait window. See probe.mjs for why that ordering is
         // load-bearing rather than incidental.
         cartItemsAtArrival: null,
@@ -221,12 +257,22 @@ export function classify(partialObservation) {
             'cart held 0 items when the extension arrived — "no prompt" is the correct behaviour here, not a defect',
         )
 
-    // 2 — the Shopify-shaped seed path cannot speak for a store that is not
-    // Shopify-shaped.
-    if (o.platform.productsJsonOk !== true || o.platform.cartJsOk !== true)
+    // 2 — the seed path can only speak for a platform it implements. A store
+    // whose platform is unrecognised, or whose product/cart endpoints did not
+    // answer, produces no evidence about its config either way.
+    if (!SEEDABLE_PLATFORMS.includes(o.platform.detected))
         return done(
             'INCONCLUSIVE_PLATFORM',
-            `store is not Shopify-shaped (products.json ok=${o.platform.productsJsonOk}, cart.js ok=${o.platform.cartJsOk})`,
+            `store platform is ${
+                o.platform.detected === null
+                    ? 'unobserved'
+                    : `"${o.platform.detected}"`
+            } — the seeder speaks ${SEEDABLE_PLATFORMS.join('/')} and cannot seed a cart here`,
+        )
+    if (o.platform.productFeedOk !== true || o.platform.cartApiOk !== true)
+        return done(
+            'INCONCLUSIVE_PLATFORM',
+            `the ${o.platform.detected} endpoints did not answer (product feed ok=${o.platform.productFeedOk}, cart ok=${o.platform.cartApiOk})`,
         )
 
     // 3 — the config an agent edits is several hops from what the extension
@@ -397,12 +443,16 @@ export function buildReport({
     screenshot = null,
     durationMs = null,
     error = null,
+    // Which non-verdict sentinel the error is. Defaults to PROBE_ERROR so
+    // every existing caller keeps its behaviour; the probe passes
+    // PROBE_NO_EXTENSION when it never had an extension to measure.
+    errorVerdict = PROBE_ERROR,
 } = {}) {
     if (error) {
         return {
             schema: SCHEMA,
-            verdict: PROBE_ERROR,
-            exitCode: exitCodeFor(PROBE_ERROR),
+            verdict: errorVerdict,
+            exitCode: exitCodeFor(errorVerdict),
             reasons: [String(error)],
             target,
             build,


### PR DESCRIPTION
Two defects that made ext-QA measure the wrong thing, both in `tools/ext-probe/`.

## 1. A probe that cannot load the extension must never produce a verdict

`probe.mjs` defaults `EXT_DIR` to `apps/caramel-extension`, which lost its `manifest.json` in the WXT migration (builds land in `.output/chrome-mv3`). Chromium accepts `--load-extension=<dir>` at a directory with no manifest, logs nothing a caller can see, and runs an ordinary browser with **nothing installed** — and every measurement taken that way reports no prompt, no coupons, nothing submitted, which is indistinguishable from a genuinely broken store config. Days of ext-QA verdicts were measurements of an empty browser; the only tell in the whole report was `vnull` in the log header.

The probe now checks `join(extDir, 'manifest.json')` **before Chromium is launched** — exists, parses, carries a version (a manifest Chromium cannot parse loads exactly as well as none) — and refuses with its own sentinel `PROBE_NO_EXTENSION` / **exit 71**, kept out of `VERDICTS` beside `PROBE_ERROR` so a caller counting reds can never absorb it, and distinct from the generic crash code `70` a caller might already tolerate. The one-object stdout contract holds on this path too; the message names the directory it was given, the `.output/chrome-mv3` hint, and any loadable build it can find right now.

Proven, no `EXT_DIR`:

```
"verdict": "PROBE_NO_EXTENSION",
"exitCode": 71,
"reasons": ["no manifest.json in C:\\...\\apps\\caramel-extension — Chromium would have launched with NO extension, and every verdict from that run would have been a measurement of an empty browser. The WXT build lands in apps/caramel-extension/.output/chrome-mv3; point EXT_DIR (or --ext) at it. Loadable build(s) found here now: ...\\.output\\chrome-mv3, ...\\.output\\chrome-mv3-dev"]
EXIT=71
```

and with it:

```
ext-probe: Caramel - Trusted Honey Alternative v1.4.0 sha256:e40761b9...
```

## 2. The cart seeder speaks three platforms, not one

The seeder relied on Shopify's `/products.json`, so ebay/dsw/marcos-shaped stores abandoned at `INCONCLUSIVE_SEED` and the repair loop never got a verdict to act on. The platform is now named from markup the platform itself emits — `window.Shopify`, `wc_add_to_cart_params`, `window.BCData`, then CDN/asset URLs, then theme classes — never from the hostname and never from a per-store list. Detection runs **once** and is passed to both the seeder and the cart reader, so the two can never disagree about what the store is.

| Platform | Products from | Added via | Cart read from |
| --- | --- | --- | --- |
| Shopify | `/products.json` | `POST /cart/add.js` | `/cart.js` |
| WooCommerce | `/wp-json/wc/store/v1/products` | `POST /wp-json/wc/store/v1/cart/add-item` + `Nonce` | `/wp-json/wc/store/v1/cart` |
| BigCommerce | product ids in the storefront markup | `POST /api/storefront/carts` | `/api/storefront/carts` |

Two facts about the WooCommerce path were **measured** on a live store, not assumed: `add-item` answers `401 woocommerce_rest_missing_nonce` without a `Nonce` header, and that nonce arrives in the `Nonce` **response** header of the cart GET the seeder already makes for its baseline count — so it costs no extra request. The same endpoint takes a variable product as the parent id plus a `variation` list, which is what makes the path general: the catalogue measured was 100% `variable`, and the classic `?add-to-cart=` handler cannot reach those without reconstructing the theme's own `attribute_*` field names.

Store safety is unchanged and now uniform: every seeder stops after 5 consecutive rejected adds (each with its own red-proof — uncapped, the same fixture fires 40), and **an add that cannot be verified is never sent** (cart endpoint silent, or no nonce, and the seeder abandons before the first POST). Success on both new platforms is confirmed by re-reading the cart, so a `201` whose item never appears is not a seeded cart. A platform with no seeder still reports `INCONCLUSIVE_SEED` / `INCONCLUSIVE_PLATFORM` — no cart is ever faked.

Live proof, WooCommerce (alphaterritory.com):

```
platform: woocommerce (window.wc_add_to_cart_params)
seed: added Haze Olive ALPHA Men’s Shorts / 36899
cart at arrival: 1
```

Live proof, BigCommerce (a1supplements.com/cart.php) — the full chain, previously unreachable:

```
platform: bigcommerce (window.BCData)
seed: added product 6558
cart at arrival: 3
prompt appeared after: 2411ms
clicked the prompt CTA
apply attempts observed: 1
```

The two 422s that preceded the accepted add are `This product has options, variant ID is required` — real rejections, counted as such.

A read-only platform sweep over the first 500 of the 2,705 supported domains (alphabetical, stopping at "bon") found 6 WooCommerce and 8 BigCommerce stores, so this is a meaningful slice of the catalogue rather than two lucky examples.

## Contract

Still `ext-probe/1`. The change to `observation.platform` is purely **additive** — `detected`, `productFeedOk`, `cartApiOk` join `productsJsonOk`/`cartJsOk`, which are kept (set only on a Shopify run) so reports recorded before the widening stay comparable field-for-field. Nothing was renamed or removed, so the caramel-coupons consumer, which reads `verdict`/`exitCode`/`reasons`/`observation.seed`, is unaffected. It does not yet know `PROBE_NO_EXTENSION` and will raise a loud `ProbeContractError` on it — strictly better than today's silent empty-browser verdicts, and a one-line follow-up in that repo.

## Tests

`apps/caramel-extension/tests/` (the probe's own suites, per the README) — 808 pass, 0 fail.

- `ext-probe-extension-required.test.mjs` (new) — spawns the **real** probe: exit 71 on a manifest-less dir, on unparseable JSON, on a version-less manifest; the reason names the path and the hint; not 70 and no observation; plus a RED-PROOF that a minimal valid manifest gets past the gate, so the suite cannot pass against a probe that refuses for some unrelated reason.
- `ext-probe-seed-platforms.test.mjs` (new) — detection per platform incl. strongest-signal-first (a Woo store embedding a Shopify buy-button is still seeded the Woo way), the seeder map covering exactly `SEEDABLE_PLATFORMS`, both new caps + red-proofs, the no-nonce / unreadable-cart no-send paths, the re-read that refuses to trust a `201`, and the platform cart readers (incl. `unknown` reporting rather than returning `itemCount: 0`, which one step later would read as "the cart was empty, so silence is correct").
- Existing suites updated for the new call shape; the serialisation gate now covers all five page functions and additionally bans `SEEDABLE_PLATFORMS`/`seedersByPlatform` — exactly the shared constants a new seeder would want to reference and which would arrive `undefined` in the page.

## Out of scope, worth knowing

Both live runs ended `INCONCLUSIVE_CONFIG_STALE` (exit 32) for a reason that has nothing to do with either fix: `config.servedFromApi` is derived from the console line `Loaded supported domains from API`, and `log` in `caramel-base.js` is gated on `CARAMEL_ENV.verbose` — so a **production-stamped build never emits it** and can never reach GREEN. The BigCommerce run's storage witness shows the flow worked (`FETCHCOUPONS_END {count: 20}`, one `ATTEMPT_END`) while the console witness was silent. Either ext-QA should run `.output/chrome-mv3-dev`, or the staleness gate should read the cached record's timestamp instead of a log line.
