### PR TITLE
fix(ext-probe): QA at the desktop viewport discovery derives configs at, and prove freshness from storage

### DIFF
--- a/apps/caramel-extension/tests/_ext-probe-fixtures.mjs
+++ b/apps/caramel-extension/tests/_ext-probe-fixtures.mjs
@@ -25,6 +25,7 @@ export function greenObservation(overrides = {}) {
         cartItemsAtArrival: 1,
         config: {
             servedFromApi: true,
+            cacheClearedBeforeRun: true,
             expected: { couponInput: '#code' },
             served: { couponInput: '#code' },
             matches: true,

--- a/apps/caramel-extension/tests/ext-probe-extension-required.test.mjs
+++ b/apps/caramel-extension/tests/ext-probe-extension-required.test.mjs
@@ -37,8 +37,10 @@ const PROBE = join(
 
 // A URL that is never reached: the refusal is decided from the filesystem, so
 // a run that somehow got as far as the network would be the failure this suite
-// exists to catch.
-const UNREACHED = 'https://example.invalid/cart'
+// exists to catch. A closed local port rather than an unresolvable host —
+// connection-refused is immediate, where a bogus TLD spends ~50s in the DNS
+// resolver and made the red-proof below race its own timeout.
+const UNREACHED = 'http://127.0.0.1:1/cart'
 
 function runProbe(extDir) {
     const res = spawnSync(
@@ -127,5 +129,11 @@ describe('the probe refuses to run without a loadable extension', () => {
         const res = runProbe(ok)
         expect(res.status).not.toBe(71)
         expect(reportFrom(res).verdict).not.toBe(PROBE_NO_EXTENSION)
+        // The header resolved a real version instead of the `vnull` that was
+        // the only tell for days...
+        expect(res.stderr).toContain('v0.0.1')
+        // ...and the launch really happened at the desktop viewport, which is
+        // the one place that default can be observed end to end.
+        expect(res.stderr).toContain('viewport 1920x1080')
     }, 120000)
 })

--- a/apps/caramel-extension/tests/ext-probe-report.test.mjs
+++ b/apps/caramel-extension/tests/ext-probe-report.test.mjs
@@ -57,6 +57,9 @@ const TOP_LEVEL_KEYS = [
     'observation',
     'witnesses',
     'logFile',
+    // Where the probe persisted this same object. The report is an artifact,
+    // not just something a caller may or may not have piped somewhere.
+    'reportFile',
     'screenshot',
     'durationMs',
 ]

--- a/apps/caramel-extension/tests/ext-probe-safety.test.mjs
+++ b/apps/caramel-extension/tests/ext-probe-safety.test.mjs
@@ -48,6 +48,21 @@ const probeCode = probeSource
     .map(l => l.replace(/(^|[^:])\/\/.*$/, '$1'))
     .join('\n')
 
+describe('the comment-stripped view still contains the code', () => {
+    it('keeps most of the source, so the bans below are not testing an empty string', () => {
+        // The stripper opens a block comment at any `/*`, including one that
+        // occurs INSIDE a line comment — writing the literal match pattern
+        // `https:` + `//*` + `/*` in a prose comment once swallowed 25K of the
+        // 34K file, and every source assertion in this suite silently passed
+        // against the remains. A hollow view is a suite that tests nothing.
+        expect(probeCode.length).toBeGreaterThan(probeSource.length * 0.6)
+        // Spot-check both ends: truncation from a runaway open-comment shows up
+        // as a missing tail long before the ratio does.
+        expect(probeCode).toContain('async function main()')
+        expect(probeCode).toContain('process.exit(code)')
+    })
+})
+
 const originalFetch = globalThis.fetch
 afterEach(() => {
     globalThis.fetch = originalFetch
@@ -240,6 +255,31 @@ describe('the probe is platform-portable', () => {
     it('keeps the three documented env knobs', () => {
         for (const knob of ['EXT_DIR', 'PROBE_WAIT_MS', 'PROBE_ALL_LOGS'])
             expect(probeSource).toContain(knob)
+    })
+
+    it('persists the report beside the log, whatever the caller does with stdout', () => {
+        // `observation.config.served` — the served config, the exact datum a
+        // staleness diagnosis needs — existed only on stdout and was discarded
+        // by every caller that did not ask for it. A diagnosis a week later
+        // cannot ask a pipe what it saw.
+        expect(probeCode).toMatch(
+            /const reportFile = join\(\s*outDir,\s*`ext-probe-\$\{tag\}-\$\{width\}\.json`/,
+        )
+        expect(probeCode).toContain('writeFileSync(reportFile, json,')
+        // Unconditional: not inside the `if (flags.out)` branch that decides
+        // where the caller's copy goes.
+        const persist = probeCode.indexOf('writeFileSync(reportFile, json,')
+        const stdoutBranch = probeCode.indexOf('if (flags.out)')
+        expect(persist).toBeGreaterThan(-1)
+        expect(persist).toBeLessThan(stdoutBranch)
+    })
+
+    it('takes the FRESHEST service worker, as its own comment has always claimed', () => {
+        // `[0]` is the oldest handle. After a worker restart every storage
+        // read went to the dead one the timeout exists to survive, and the
+        // witness came back empty.
+        expect(probeCode).toContain('ctx.serviceWorkers().at(-1)')
+        expect(probeCode).not.toContain('ctx.serviceWorkers()[0]')
     })
 
     it('sends the report to stdout and every word of prose to stderr', () => {

--- a/apps/caramel-extension/tests/ext-probe-served-from-api.test.mjs
+++ b/apps/caramel-extension/tests/ext-probe-served-from-api.test.mjs
@@ -1,0 +1,141 @@
+// The witness that proves the config under test is the config that was served.
+//
+// `config.servedFromApi` used to be `consoleTrail.some(l => l.includes('Loaded
+// supported domains from API'))`. That line comes from `log` in
+// caramel-base.js, which is `CARAMEL_ENV.verbose ? console.log : noop`, and
+// the production stamp sets `verbose: false` on purpose — content scripts run
+// on every https origin, so a shipped build must never write into a shopper's
+// store console.
+//
+// So on the build ext-QA actually measures the line can never appear, silence
+// was recorded as `false`, and classify's FIRST config gate fired on every
+// single run: 10/10 probe artifacts over 36 hours came back
+// INCONCLUSIVE_CONFIG_STALE, and the served-vs-expected comparison behind that
+// gate had never once executed. Verified in the built artifacts on 2026-08-14:
+// `.output/chrome-mv3` carries `verbose:!1`, `.output/chrome-mv3-dev` carries
+// `verbose:!0`.
+//
+// The fix reads the extension's own STORAGE instead, which is stamped in both
+// builds. These pins are about that asymmetry: storage can prove or disprove,
+// the console can only ever confirm.
+import { describe, expect, it } from 'vitest'
+import {
+    classify,
+    deriveServedFromApi,
+} from '../../../tools/ext-probe/verdict.mjs'
+import { greenObservation } from './_ext-probe-fixtures.mjs'
+
+describe('served-from-API is read from storage, not from a log line', () => {
+    it('a cleared cache that came back holding data proves the fetch', () => {
+        // The probe removes the key before the run and the extension rewrites
+        // it only on the branch that just fetched from the API.
+        expect(
+            deriveServedFromApi({
+                cacheCleared: true,
+                cacheReadOk: true,
+                cacheHasData: true,
+            }),
+        ).toBe(true)
+    })
+
+    it('a cleared cache that stayed empty DISPROVES it', () => {
+        expect(
+            deriveServedFromApi({
+                cacheCleared: true,
+                cacheReadOk: true,
+                cacheHasData: false,
+            }),
+        ).toBe(false)
+    })
+
+    it('works with a completely silent console — the production build case', () => {
+        // The whole point: no log line anywhere, and the answer is still true.
+        expect(
+            deriveServedFromApi({
+                cacheCleared: true,
+                cacheReadOk: true,
+                cacheHasData: true,
+                loggedApiLoad: false,
+            }),
+        ).toBe(true)
+    })
+
+    it('RED-PROOF: the OLD rule calls that same run stale', () => {
+        // The superseded derivation, spelled out against the same facts. If
+        // someone restores it, this is the number that changes.
+        const oldRule = ({ loggedApiLoad }) => loggedApiLoad
+        const productionRun = {
+            cacheCleared: true,
+            cacheReadOk: true,
+            cacheHasData: true,
+            loggedApiLoad: false,
+        }
+        expect(oldRule(productionRun)).toBe(false)
+        expect(deriveServedFromApi(productionRun)).toBe(true)
+    })
+
+    it('the console line still CONFIRMS when storage could not be read', () => {
+        // Independent witnesses are the probe's design; the console one is
+        // kept, just demoted to something that can only say yes.
+        expect(
+            deriveServedFromApi({
+                cacheCleared: false,
+                loggedApiLoad: true,
+            }),
+        ).toBe(true)
+    })
+
+    it('neither witness available is null — never false', () => {
+        // "We did not see it" and "it did not happen" lead to different
+        // verdicts, and collapsing them is how a harness starts lying.
+        expect(deriveServedFromApi({})).toBeNull()
+        expect(
+            deriveServedFromApi({ cacheCleared: true, cacheReadOk: false }),
+        ).toBeNull()
+    })
+
+    it('an uncleared cache holding data is NOT proof — it could be yesterday', () => {
+        expect(
+            deriveServedFromApi({
+                cacheCleared: false,
+                cacheReadOk: true,
+                cacheHasData: true,
+            }),
+        ).toBeNull()
+    })
+})
+
+describe('the stale gate says which of the two situations it is in', () => {
+    it('names the cleared-and-never-refilled case', () => {
+        const r = classify(
+            greenObservation({
+                config: { servedFromApi: false, cacheClearedBeforeRun: true },
+            }),
+        )
+        expect(r.verdict).toBe('INCONCLUSIVE_CONFIG_STALE')
+        expect(r.reasons.join(' ')).toMatch(/never came back/)
+    })
+
+    it('names the could-not-clear case differently — a different fix', () => {
+        const r = classify(
+            greenObservation({
+                config: { servedFromApi: null, cacheClearedBeforeRun: false },
+            }),
+        )
+        expect(r.verdict).toBe('INCONCLUSIVE_CONFIG_STALE')
+        expect(r.reasons.join(' ')).toMatch(/could not be cleared/)
+    })
+
+    it('a proven fresh fetch gets past the gate to the real comparison', () => {
+        expect(
+            classify(
+                greenObservation({
+                    config: {
+                        servedFromApi: true,
+                        cacheClearedBeforeRun: true,
+                    },
+                }),
+            ).verdict,
+        ).toBe('GREEN')
+    })
+})

--- a/apps/caramel-extension/tests/ext-probe-viewport.test.mjs
+++ b/apps/caramel-extension/tests/ext-probe-viewport.test.mjs
@@ -1,0 +1,86 @@
+// QA must run at the viewport the config was DERIVED at.
+//
+// `agent_discovery` drives its browser at `--viewport 1920x1080` and writes
+// selectors against that DOM. The probe defaulted to 390x844, so every config
+// was proven on a desktop layout and then graded on a phone one — a different
+// DOM, frequently a different checkout, and a source of reds that were never
+// about the config. Every ext-QA run before 2026-08-14 was measured that way.
+//
+// The default is therefore pinned here, not left to a literal in the middle of
+// a 700-line driver where the next refactor can quietly restore a phone.
+import { describe, expect, it } from 'vitest'
+import {
+    DESKTOP_VIEWPORT,
+    MOBILE_HEIGHT,
+    resolveViewport,
+} from '../../../tools/ext-probe/viewport.mjs'
+
+describe('the probe measures at the viewport discovery derived the config at', () => {
+    it('defaults to 1920x1080 — the same pair agent_discovery passes', () => {
+        expect(resolveViewport({})).toEqual({ width: 1920, height: 1080 })
+        expect(DESKTOP_VIEWPORT).toEqual({ width: 1920, height: 1080 })
+    })
+
+    it('is NOT the old 390x844 phone default', () => {
+        // The regression this pin exists for. A probe that silently goes back
+        // to a phone viewport grades desktop-derived selectors against a DOM
+        // that may not contain them at all.
+        const v = resolveViewport({})
+        expect(v.width).not.toBe(390)
+        expect(v.height).not.toBe(MOBILE_HEIGHT)
+    })
+
+    it('takes --viewport WxH verbatim, in agent_discovery spelling', () => {
+        expect(resolveViewport({ viewport: '1440x900' })).toEqual({
+            width: 1440,
+            height: 900,
+        })
+        // Whitespace and the unicode multiplication sign, because both turn up
+        // in hand-typed invocations.
+        expect(resolveViewport({ viewport: '1280 x 720' })).toEqual({
+            width: 1280,
+            height: 720,
+        })
+        expect(resolveViewport({ viewport: '1280×720' }).width).toBe(1280)
+    })
+
+    it('--width alone opts into a REAL phone, not a 390x1080 sliver', () => {
+        expect(resolveViewport({ width: '390' })).toEqual({
+            width: 390,
+            height: MOBILE_HEIGHT,
+        })
+        // ...and the positional form the probe has always accepted behaves the
+        // same, so the documented mobile pass is one argument either way.
+        expect(resolveViewport({}, '390')).toEqual({
+            width: 390,
+            height: MOBILE_HEIGHT,
+        })
+    })
+
+    it('a desktop-class width keeps the desktop height', () => {
+        expect(resolveViewport({ width: '1440' }).height).toBe(1080)
+    })
+
+    it('--height overrides the class rule in both directions', () => {
+        expect(resolveViewport({ width: '390', height: '1200' })).toEqual({
+            width: 390,
+            height: 1200,
+        })
+        expect(resolveViewport({ width: '1920', height: '600' }).height).toBe(
+            600,
+        )
+    })
+
+    it('--viewport outranks --width/--height, so one flag fully decides', () => {
+        expect(
+            resolveViewport({ viewport: '800x600', width: '390', height: '9' }),
+        ).toEqual({ width: 800, height: 600 })
+    })
+
+    it('a malformed --viewport falls through to the desktop default rather than NaN', () => {
+        // A NaN viewport reaches Playwright and fails deep inside the launch,
+        // long after the useful error could have been printed.
+        for (const bad of ['wide', '1920', '1920x', 'x1080', ''])
+            expect(resolveViewport({ viewport: bad })).toEqual(DESKTOP_VIEWPORT)
+    })
+})

--- a/tools/ext-probe/README.md
+++ b/tools/ext-probe/README.md
@@ -10,11 +10,12 @@ the vocabulary.
 
 ## Layout
 
-| File          | Role                                                                                                                                                         |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `probe.mjs`   | The driver. Launches Chromium, seeds a cart, watches the run, emits the report. Needs a browser.                                                             |
-| `verdict.mjs` | The judgement. Pure — no browser, no filesystem. This is what the unit tests exercise.                                                                       |
-| `seed.mjs`    | The functions that run **inside** the page — platform detection, the per-platform seeders, the cart reader. Self-contained so Playwright can serialise them. |
+| File           | Role                                                                                                                                                         |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `probe.mjs`    | The driver. Launches Chromium, seeds a cart, watches the run, emits the report. Needs a browser.                                                             |
+| `verdict.mjs`  | The judgement. Pure — no browser, no filesystem. This is what the unit tests exercise.                                                                       |
+| `seed.mjs`     | The functions that run **inside** the page — platform detection, the per-platform seeders, the cart reader. Self-contained so Playwright can serialise them. |
+| `viewport.mjs` | Which viewport to measure at. Its own module because it is a policy, not a detail — see below.                                                               |
 
 ## Usage
 
@@ -22,19 +23,33 @@ the vocabulary.
 node tools/ext-probe/probe.mjs <url> [width] [tag] [flags]
 ```
 
-| Flag / env         | Default                  | Meaning                                                                                                                                                                                                                                              |
-| ------------------ | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `EXT_DIR`          | `apps/caramel-extension` | Which build to load. **Set it** — the WXT build lands in `apps/caramel-extension/.output/chrome-mv3`, and the default path no longer holds a manifest. A directory without a loadable `manifest.json` exits `71` before Chromium starts (see below). |
-| `PROBE_WAIT_MS`    | `30000`                  | How long a shopper waits before we call it a no-show.                                                                                                                                                                                                |
-| `PROBE_ALL_LOGS`   | unset                    | `1` keeps every console line, not just the Caramel-shaped ones.                                                                                                                                                                                      |
-| `--out <path>`     | stdout                   | Write the JSON report to a file instead of stdout.                                                                                                                                                                                                   |
-| `--out-dir <path>` | `.ext-probe/`            | Where the full log, screenshot and disposable profile live.                                                                                                                                                                                          |
-| `--expect-config`  | —                        | JSON file holding the config under test; enables the staleness compare.                                                                                                                                                                              |
-| `--good-code`      | —                        | A code expected to work — supplies GREEN evidence (6).                                                                                                                                                                                               |
-| `--invalid-code`   | —                        | A deliberately invalid code — the negative control, GREEN evidence (7).                                                                                                                                                                              |
-| `--width`/`--tag`  | `390` / `probe`          | Same as the positional forms.                                                                                                                                                                                                                        |
+| Flag / env           | Default                  | Meaning                                                                                                                                                                                                                                              |
+| -------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `EXT_DIR`            | `apps/caramel-extension` | Which build to load. **Set it** — the WXT build lands in `apps/caramel-extension/.output/chrome-mv3`, and the default path no longer holds a manifest. A directory without a loadable `manifest.json` exits `71` before Chromium starts (see below). |
+| `PROBE_WAIT_MS`      | `30000`                  | How long a shopper waits before we call it a no-show.                                                                                                                                                                                                |
+| `PROBE_ALL_LOGS`     | unset                    | `1` keeps every console line, not just the Caramel-shaped ones.                                                                                                                                                                                      |
+| `--out <path>`       | stdout                   | Write the JSON report to a file instead of stdout. The report is persisted to `--out-dir` regardless.                                                                                                                                                |
+| `--out-dir <path>`   | `.ext-probe/`            | Where the full log, the JSON report, the screenshot and the disposable profile live.                                                                                                                                                                 |
+| `--expect-config`    | —                        | JSON file holding the config under test; enables the staleness compare.                                                                                                                                                                              |
+| `--good-code`        | —                        | A code expected to work — supplies GREEN evidence (6).                                                                                                                                                                                               |
+| `--invalid-code`     | —                        | A deliberately invalid code — the negative control, GREEN evidence (7).                                                                                                                                                                              |
+| `--viewport WxH`     | `1920x1080`              | The viewport to measure at, in the spelling `agent_discovery` uses. Authoritative when given.                                                                                                                                                        |
+| `--width`/`--height` | `1920` / class default   | Set individually. A width alone picks the conventional height for its class (`--width 390` → 390x844), so a mobile pass is one flag.                                                                                                                 |
+| `--tag`              | `probe`                  | Same as the positional form.                                                                                                                                                                                                                         |
 
-Human prose goes to **stderr**; stdout carries the JSON object and nothing else.
+Human prose goes to **stderr**; stdout carries the JSON object and nothing else. Three artifacts always
+land in `--out-dir`: `ext-probe-<tag>-<width>.log`, `.json` and `.png`. The **report is an artifact,
+not just something a caller may have piped somewhere** — `observation.config.served` is the exact
+datum a staleness diagnosis needs, and a diagnosis a week later cannot ask a pipe what it saw.
+
+## Viewport
+
+**Default `1920x1080` — the same pair `agent_discovery` passes.** QA must run at the viewport the
+config was DERIVED at. Discovery writes selectors against a desktop DOM; this probe defaulted to
+`390x844`, so every config was proven on a desktop layout and then graded on a phone one. A phone is
+a different DOM and frequently a different checkout, which produced reds that were never about the
+config — every ext-QA run before 2026-08-14 was measured that way. A mobile pass is still available
+and still approximates iOS Safari; it is simply no longer the silent default (`--width 390`).
 
 ## Exit codes
 
@@ -108,7 +123,8 @@ the served config, the best available verdict is `AMBER_NO_INDICATORS` — never
         },
         "cartItemsAtArrival": null, // read BEFORE the wait window
         "config": {
-            "servedFromApi": null,
+            "servedFromApi": null, // from storage, not from a log line — see below
+            "cacheClearedBeforeRun": null, // without which the above is not proof
             "expected": null,
             "served": null,
             "matches": null,
@@ -154,6 +170,7 @@ the served config, the best available verdict is `AMBER_NO_INDICATORS` — never
         },
     },
     "logFile": "", // full, untruncated
+    "reportFile": "", // where this object was persisted
     "screenshot": null,
     "durationMs": 0,
 }
@@ -161,6 +178,32 @@ the served config, the best available verdict is `AMBER_NO_INDICATORS` — never
 
 `null` means **not observed** and is never written as `false`. "We did not see it" and "it did not
 happen" lead to different verdicts, and collapsing them is how a harness starts lying.
+
+## The console cannot deny, only confirm
+
+The build ext-QA measures is **silent by design**. `log` in `caramel-base.js` is
+`CARAMEL_ENV.verbose ? console.log : noop`, and the production stamp sets `verbose: false` on
+purpose — content scripts run on every https origin, so a shipped build must never write into a
+shopper's store console. Verified in the artifacts on 2026-08-14: `.output/chrome-mv3` carries
+`verbose:!1`, `.output/chrome-mv3-dev` carries `verbose:!0`.
+
+So an empty console/service-worker trail is **correct** for a production build, and anything
+concluded from that silence is a conclusion about the build stamp rather than about the store.
+`config.servedFromApi` used to be exactly such a conclusion — `consoleTrail.some(l => l.includes('Loaded
+supported domains from API'))` — which meant classify's first config gate fired on every single
+production run and the served-vs-expected comparison behind it never once executed.
+
+It is now read from the extension's own **storage**, which is stamped in both builds: the probe
+removes the supported-stores cache key before the run, and the extension rewrites that key only on
+the branch that just fetched the list from the API, so a key that comes back holding data **is** the
+fetch. `observation.config.cacheClearedBeforeRun` records whether the removal actually happened,
+because without it a repopulated key could just be yesterday's cache. The console line is kept as a
+genuinely independent witness, but it can only ever say **yes** — never no. If neither witness can
+speak the answer is `null`, never `false`.
+
+Switching ext-QA to the dev build is **not** the fix: `.output/chrome-mv3-dev` is verbose but points
+at `https://dev.grabcaramel.com`, so it would QA the dev configs rather than the ones production
+serves.
 
 ## Two independent witnesses
 

--- a/tools/ext-probe/probe.mjs
+++ b/tools/ext-probe/probe.mjs
@@ -33,10 +33,12 @@ import {
 } from './seed.mjs'
 import {
     buildReport,
+    deriveServedFromApi,
     diffWitnesses,
     emptyObservation,
     PROBE_NO_EXTENSION,
 } from './verdict.mjs'
+import { resolveViewport } from './viewport.mjs'
 
 // fileURLToPath, not `new URL(...).pathname.slice(1)`: the slice trick strips
 // the leading slash of a Windows drive path and silently produces garbage
@@ -70,7 +72,11 @@ const note = (...args) => console.error(...args)
 // context knows about and races a hard timeout around the call.
 const SW_EVAL_TIMEOUT_MS = 8000
 async function swEval(ctx, fallbackSw, pageFunction, arg, label) {
-    const sw = ctx.serviceWorkers()[0] || fallbackSw
+    // `.at(-1)`, not `[0]`: the comment above has always said "the freshest
+    // worker the context knows about" while the code took the OLDEST one, so
+    // after a worker restart every storage read went to the dead handle the
+    // timeout exists to survive — and the witness came back empty.
+    const sw = ctx.serviceWorkers().at(-1) || fallbackSw
     if (!sw) return { ok: false, value: null }
     try {
         const value = await Promise.race([
@@ -252,7 +258,7 @@ async function main() {
         // one-object contract holds only on the happy path.
         throw new Error('no target url given')
     }
-    const width = Number(flags.width || widthArg || 390)
+    const { width, height } = resolveViewport(flags, widthArg)
     const tag = flags.tag || tagArg || 'probe'
     const extDir = resolve(process.env.EXT_DIR || flags.ext || DEFAULT_EXT_DIR)
     const waitMs = Number(process.env.PROBE_WAIT_MS || flags.wait || 30000)
@@ -266,6 +272,11 @@ async function main() {
     mkdirSync(outDir, { recursive: true })
     const logFile = join(outDir, `ext-probe-${tag}-${width}.log`)
     const screenshotFile = join(outDir, `ext-probe-${tag}-${width}.png`)
+    // The report is an ARTIFACT, not just something a caller may or may not
+    // have piped somewhere. `observation.config.served` — the served config,
+    // the exact datum a staleness diagnosis needs — used to exist only on
+    // stdout and was discarded by every caller that did not ask for it.
+    const reportFile = join(outDir, `ext-probe-${tag}-${width}.json`)
 
     let expectedConfig = null
     if (flags['expect-config'])
@@ -282,12 +293,14 @@ async function main() {
         url,
         origin: new URL(url).origin,
         viewportWidth: width,
+        viewportHeight: height,
         tag,
     }
     note(
         `ext-probe: ${build.manifestName || 'extension'} v${build.manifestVersion} ${build.contentHash}`,
     )
     note(`ext-probe: ${extDir}`)
+    note(`ext-probe: viewport ${width}x${height}`)
 
     const observation = emptyObservation()
     const consoleTrail = []
@@ -300,7 +313,7 @@ async function main() {
 
     const ctx = await chromium.launchPersistentContext(profile, {
         headless: false,
-        viewport: { width, height: 844 },
+        viewport: { width, height },
         args: [
             `--disable-extensions-except=${extDir}`,
             `--load-extension=${extDir}`,
@@ -319,11 +332,21 @@ async function main() {
                 consoleTrail.push(`[${m.type()}] ${t}`)
         })
         page.on('pageerror', e => consoleTrail.push(`[pageerror] ${String(e)}`))
-        // The background service worker is where the API calls are made and
-        // logged on a dev install, so it says whether the content script ever
-        // asked — and it is the ONLY context that can read the extension's own
-        // chrome.storage.local. Page `evaluate` runs in the store's world and
-        // cannot see it at all.
+        // The background service worker is the ONLY context that can read the
+        // extension's own chrome.storage.local — page `evaluate` runs in the
+        // store's world and cannot see it at all.
+        //
+        // Its CONSOLE, however, says nothing in the build ext-QA actually
+        // measures. `log` in caramel-base.js is `CARAMEL_ENV.verbose ?
+        // console.log : noop`, and the production stamp sets `verbose: false`
+        // deliberately — content scripts run on every https origin, so a
+        // shipped build must never write into a shopper's console. Verified in
+        // the built artifacts: `.output/chrome-mv3` carries `verbose:!1`,
+        // `.output/chrome-mv3-dev` carries `verbose:!0` (2026-08-14). So an
+        // empty console trail is CORRECT for a production build, and anything
+        // this probe concludes from silence is a conclusion about the build
+        // stamp, not about the store. The storage witness below is what
+        // carries the evidence.
         let sw = null
         const attachSW = worker => {
             if (!sw) sw = worker
@@ -344,11 +367,17 @@ async function main() {
             sw = await ctx
                 .waitForEvent('serviceworker', { timeout: 15000 })
                 .catch(() => null)
-        // Force the API path. The extension caches the supported-domain list in
-        // chrome.storage.local, and staleness must be ruled out by evidence
-        // (the API log line below), not by hoping a fixed sleep was long enough.
+        // Force the API path, and make the clear itself the evidence. The
+        // extension writes `{data, ts}` to this key ONLY on the branch that
+        // just fetched the list from the API (store-detect.js), so a key that
+        // was removed here and holds data at the end of the run was fetched
+        // fresh DURING this run. That is the same fact the log line used to
+        // stand for, established from state instead of from a message a
+        // production build never prints — and it is only a proof if the clear
+        // succeeded, which is why the outcome is recorded rather than assumed.
+        let storeCacheCleared = false
         if (sw)
-            await sw
+            storeCacheCleared = await sw
                 .evaluate(
                     key =>
                         new Promise(r =>
@@ -356,11 +385,12 @@ async function main() {
                         ),
                     STORE_CACHE_KEY,
                 )
-                .catch(e =>
-                    note(
-                        `  (could not clear ${STORE_CACHE_KEY}: ${e.message})`,
-                    ),
-                )
+                .then(() => true)
+                .catch(e => {
+                    note(`  (could not clear ${STORE_CACHE_KEY}: ${e.message})`)
+                    return false
+                })
+        observation.config.cacheClearedBeforeRun = storeCacheCleared
 
         // Which cart mechanism this store speaks, named from markup the
         // platform itself emits — detected ONCE and then passed to both the
@@ -528,6 +558,8 @@ async function main() {
         let timings = []
         let timingsReadOk = false
         let servedRecord = null
+        let cacheReadOk = false
+        let cachedList = null
         if (sw || ctx.serviceWorkers().length) {
             const timingsRead = await swEval(
                 ctx,
@@ -551,10 +583,11 @@ async function main() {
                 STORE_CACHE_KEY,
                 STORE_CACHE_KEY,
             )
-            const cached = cachedRead.value
+            cacheReadOk = cachedRead.ok
+            cachedList = cachedRead.value
             const host = new URL(url).hostname
             servedRecord =
-                (cached?.data || []).find(rec =>
+                (cachedList?.data || []).find(rec =>
                     hostMatches(rec.domain, host),
                 ) || null
         } else {
@@ -574,9 +607,26 @@ async function main() {
         }
 
         // ── derive the observation from what the witnesses saw ────────────
-        observation.config.servedFromApi = wholeTrail.some(l =>
-            l.includes(API_LOAD_LINE),
-        )
+        // Two independent witnesses to one fact: "the domain list under test
+        // was fetched from the API during THIS run".
+        //
+        // The storage witness is the load-bearing one. The key was removed
+        // before the run and the extension rewrites it only on the branch that
+        // just fetched from the API, so a repopulated key IS the fetch. It
+        // works on a production build, which is the build ext-QA measures.
+        //
+        // The console witness is kept because it is genuinely independent —
+        // but it can only ever CONFIRM, never deny: `log` is compiled out when
+        // `CARAMEL_ENV.verbose` is false, so its absence in a production build
+        // says nothing at all. Reading that silence as `false` is what pinned
+        // every production run at INCONCLUSIVE_CONFIG_STALE and meant the
+        // served-vs-expected comparison below never once ran.
+        observation.config.servedFromApi = deriveServedFromApi({
+            cacheCleared: storeCacheCleared,
+            cacheReadOk,
+            cacheHasData: !!cachedList?.data?.length,
+            loggedApiLoad: wholeTrail.some(l => l.includes(API_LOAD_LINE)),
+        })
         observation.config.served = servedRecord
         observation.config.expected = expectedConfig
         Object.assign(
@@ -719,11 +769,17 @@ async function main() {
             observation,
             witnesses,
             logFile,
+            reportFile,
             screenshot,
             durationMs: Date.now() - started,
         })
-        // The ONE machine-readable object, alone on stdout.
         const json = JSON.stringify(report, null, 2)
+        // Always persisted beside the log, whatever the caller does with
+        // stdout — the report is the only place `observation.config.served`
+        // survives, and a diagnosis a week later cannot ask a pipe what it saw.
+        writeFileSync(reportFile, json, 'utf8')
+        note(`full report: ${reportFile}`)
+        // The ONE machine-readable object, alone on stdout.
         if (flags.out) writeFileSync(resolve(flags.out), json, 'utf8')
         else process.stdout.write(`${json}\n`)
         note(`verdict: ${report.verdict} (exit ${report.exitCode})`)

--- a/tools/ext-probe/verdict.mjs
+++ b/tools/ext-probe/verdict.mjs
@@ -133,7 +133,16 @@ export function emptyObservation() {
         // load-bearing rather than incidental.
         cartItemsAtArrival: null,
         config: {
+            // "the domain list under test was fetched from the API during
+            // THIS run". Established from the extension's own storage — the
+            // cache key the probe removed coming back — because the console
+            // line it used to be read from is compiled out of a production
+            // build and its silence therefore proves nothing.
             servedFromApi: null,
+            // Whether that removal actually happened. Without it a repopulated
+            // key could just be yesterday's cache, so the proof above is only
+            // a proof when this is true.
+            cacheClearedBeforeRun: null,
             expected: null,
             served: null,
             matches: null,
@@ -186,6 +195,41 @@ export function normalizeObservation(partial) {
                 : incoming
     }
     return base
+}
+
+/**
+ * Did the extension fetch the domain list from the API during THIS run?
+ *
+ * Two independent witnesses to one fact, and they are not interchangeable.
+ *
+ * The STORAGE witness is load-bearing. The probe removes the extension's
+ * supported-stores cache key before the run, and the extension rewrites that
+ * key only on the branch that just fetched from the API — so a key that comes
+ * back holding data IS the fetch. It works on the production build, which is
+ * the build ext-QA measures.
+ *
+ * The CONSOLE witness can only CONFIRM, never deny. `log` in caramel-base.js
+ * is `CARAMEL_ENV.verbose ? console.log : noop` and the production stamp sets
+ * `verbose: false` on purpose — content scripts run on every https origin, so
+ * a shipped build must never write into a shopper's store console (verified in
+ * the artifacts: `.output/chrome-mv3` carries `verbose:!1`, the dev build
+ * `verbose:!0`, 2026-08-14). Its absence therefore says nothing at all, and
+ * reading that silence as `false` is what pinned every production run at
+ * INCONCLUSIVE_CONFIG_STALE and meant the served-vs-expected comparison never
+ * once ran.
+ *
+ * @returns {boolean|null} `null` when neither witness could speak — not
+ *   observed, which is not the same as "it did not happen".
+ */
+export function deriveServedFromApi({
+    cacheCleared = false,
+    cacheReadOk = false,
+    cacheHasData = false,
+    loggedApiLoad = false,
+} = {}) {
+    if (cacheCleared && cacheReadOk) return cacheHasData
+    if (loggedApiLoad) return true
+    return null
 }
 
 const SELECTOR_FIELDS = ['priceContainer', 'successIndicator', 'errorIndicator']
@@ -283,7 +327,9 @@ export function classify(partialObservation) {
     if (o.config.servedFromApi !== true)
         return done(
             'INCONCLUSIVE_CONFIG_STALE',
-            'the "Loaded supported domains from API" line never appeared — the run may have been served a cached domain list',
+            o.config.cacheClearedBeforeRun === true
+                ? 'the supported-domain cache was cleared before the run and never came back — the extension did not fetch the domain list from the API'
+                : 'the supported-domain cache could not be cleared and no API load was observed — the run may have been served a stale domain list',
         )
     if (o.config.matches === false)
         return done(
@@ -440,6 +486,7 @@ export function buildReport({
     observation = null,
     witnesses = null,
     logFile = null,
+    reportFile = null,
     screenshot = null,
     durationMs = null,
     error = null,
@@ -459,6 +506,7 @@ export function buildReport({
             observation: observation ? normalizeObservation(observation) : null,
             witnesses,
             logFile,
+            reportFile,
             screenshot,
             durationMs,
         }
@@ -475,6 +523,7 @@ export function buildReport({
         observation: normalized,
         witnesses,
         logFile,
+        reportFile,
         screenshot,
         durationMs,
     }

--- a/tools/ext-probe/viewport.mjs
+++ b/tools/ext-probe/viewport.mjs
@@ -1,0 +1,45 @@
+// Which viewport the probe measures at.
+//
+// Its own module because it is a POLICY, not a detail: QA must run at the
+// viewport the config was DERIVED at. `agent_discovery` drives its browser at
+// `--viewport 1920x1080` and writes selectors against that DOM, while this
+// probe defaulted to 390x844 — so every config was proven on a desktop layout
+// and then graded on a phone one. A phone is a different DOM and frequently a
+// different checkout, which made reds that were never about the config.
+// Desktop is the default; a mobile pass is opt-in and explicit (owner call,
+// 2026-08-14).
+//
+// Browser-free, like verdict.mjs, so the rule is pinned in CI rather than
+// rediscovered on a live store.
+
+/** Matches `agent_discovery`'s `--viewport 1920x1080`. */
+export const DESKTOP_VIEWPORT = Object.freeze({ width: 1920, height: 1080 })
+
+/**
+ * The conventional height for a phone-class width, so `--width 390` yields a
+ * real phone rather than a 390x1080 sliver. `--height` overrides either way.
+ */
+export const MOBILE_HEIGHT = 844
+export const DESKTOP_MIN_WIDTH = 1024
+
+/**
+ * `--viewport 1920x1080` (the spelling agent_discovery uses) is authoritative
+ * when given; otherwise width and height are taken individually, and a width
+ * alone picks the conventional height for its class.
+ *
+ * @param {{viewport?: string, width?: string|number, height?: string|number}} flags
+ * @param {string|number} [widthArg] the positional width, kept for the old call shape
+ * @returns {{width: number, height: number}}
+ */
+export function resolveViewport(flags = {}, widthArg = undefined) {
+    const pair = String(flags.viewport || '').match(/^(\d+)\s*[x×]\s*(\d+)$/i)
+    if (pair) return { width: Number(pair[1]), height: Number(pair[2]) }
+    const width = Number(flags.width || widthArg || DESKTOP_VIEWPORT.width)
+    const height = Number(
+        flags.height ||
+            (width >= DESKTOP_MIN_WIDTH
+                ? DESKTOP_VIEWPORT.height
+                : MOBILE_HEIGHT),
+    )
+    return { width, height }
+}


### PR DESCRIPTION
Follow-up to #200, same scope (`tools/ext-probe/`). Four items, in the owner's priority order.

## 1. Desktop viewport is the default (owner requirement)

`agent_discovery` drives its browser at `--viewport 1920x1080` and writes selectors against that DOM. This probe defaulted to **390x844**, so every config was proven on a desktop layout and then graded on a phone one — a different DOM, frequently a different checkout, and a source of reds that were never about the config. Every ext-QA run before today was measured that way.

The default is now `1920x1080`. A mobile pass stays available and is now explicit. The rule is small and documented rather than magic: `--viewport WxH` (the spelling discovery uses) is authoritative when given; otherwise `--width`/`--height` are taken individually, and **a width alone picks the conventional height for its class**, so `--width 390` yields a real 390x844 phone rather than a 390x1080 sliver.

This lives in its own module (`tools/ext-probe/viewport.mjs`) because it is a policy, not a detail — it is browser-free, so the default is pinned in CI instead of being a literal in the middle of a 700-line driver.

## 2. Silent extension: diagnosed, and it is not a broken tap

**The extension did not stop emitting and the probe's tap is not broken. The build ext-QA measures is silent by design.**

`log` in `caramel-base.js` is `CARAMEL_ENV.verbose ? console.log : noop`, and `scripts/environments.mjs` sets `verbose: false` for the production stamp, with the reason written down at the definition: *"Content scripts run on https://\*/\*, so a console call lands in a STORE's console on a shopper's machine. Never in a shipped build."*

Verified in the built artifacts rather than inferred from source:

```
chrome-mv3      verbose tokens: [ 'verbose:!1', 'verbose:!1' ]   baseUrl: https://grabcaramel.com
chrome-mv3-dev  verbose tokens: [ 'verbose:!0', 'verbose:!0' ]   baseUrl: https://dev.grabcaramel.com
```

Both builds still contain the string `Loaded supported domains from API` — it is the `log` call around it that is compiled to a no-op. So the console witness could never fire, `servedFromApi` was recorded as `false`, and classify's **first** config gate fired on every run: the observed-vs-expected comparison behind it had indeed never once executed.

Note the trap in the obvious workaround: switching ext-QA to `chrome-mv3-dev` would make it verbose **and** point it at `https://dev.grabcaramel.com`, so it would QA the dev configs instead of the ones production serves. Not a fix.

The fix is in the probe. `config.servedFromApi` is now read from the extension's own **storage**, which is stamped in both builds: the probe removes the supported-stores cache key before the run, and the extension rewrites that key only on the branch that just fetched from the API — so a key that comes back holding data **is** the fetch. `observation.config.cacheClearedBeforeRun` records whether the removal actually happened, because without it a repopulated key could just be yesterday's cache. The console line is kept as a genuinely independent witness but demoted to something that can only say **yes**, never no; when neither witness can speak the answer is `null`, never `false`.

One real bug found alongside it: `swEval` took `ctx.serviceWorkers()[0]` — the **oldest** handle — while its own comment has always claimed it takes "the freshest worker the context knows about". After a worker restart every storage read went to the dead handle the timeout exists to survive, and the witness came back empty. Now `.at(-1)`.

## 3. The report is persisted

`ext-probe-<tag>-<width>.json` is now always written beside the `.log`, whatever the caller does with stdout, and `reportFile` is a top-level field. `observation.config.served` — the served config, the exact datum a staleness diagnosis needs — existed only on stdout and was discarded by every caller that did not ask for it. A diagnosis a week later cannot ask a pipe what it saw.

## Live proof — one run, all three

`a1supplements.com/cart.php`, production build, no `--width`:

```
ext-probe: Caramel - Trusted Honey Alternative v1.4.0 sha256:e40761b9...
ext-probe: viewport 1920x1080
platform: bigcommerce (window.BCData)
seed: added product 6558
cart at arrival: 3
prompt appeared after: 2560ms
clicked the prompt CTA
apply attempts observed: 1
full report: ...\ext-probe-desktop-a1-1920.json
verdict: RED_APPLY_FAILED (exit 24)
```

Artifacts, read back from disk:

```
viewport 1920x1080          png dims 1920x1080
servedFromApi true | cacheCleared true
served domain a1supplements.com | couponInput #couponcode
indicators {"priceContainer":".cart-total-grandTotal span", "successIndicator":"a[href*=\"removecoupon\"]...", "errorIndicator":".alertBox--info .alertBox-message"}
consoleTrail 2  swTrail 0  timings 5
```

`swTrail 0` with `servedFromApi true` is the whole point: the console is silent, and the run is still proven fresh. **This is the first probe run to get past the config gates** — the verdict is now a real statement about the store (`RED_APPLY_FAILED`: one code submitted, no indicator fired, total did not move) instead of `INCONCLUSIVE_CONFIG_STALE`.

## Tests — 829 pass, 0 fail

- `ext-probe-viewport.test.mjs` (new) — the 1920x1080 default, an explicit pin that it is **not** 390x844, `--viewport` in all three spellings, the width-alone phone rule, `--height` overriding in both directions, `--viewport` outranking the pair, and a malformed `--viewport` falling back to the default rather than reaching Playwright as `NaN`.
- `ext-probe-served-from-api.test.mjs` (new) — storage proves and disproves; a silent console still yields `true`; a **RED-PROOF** running the superseded rule against the same facts (it returns `false` where the new one returns `true`); the console confirming when storage is unreadable; `null` when neither witness can speak; an uncleared cache holding data is not proof.
- `ext-probe-safety.test.mjs` — new pins that the report is persisted unconditionally (before the `flags.out` branch) and that the freshest worker is taken.

**A test-integrity bug fixed while here.** This suite asserts against a comment-stripped view of `probe.mjs`, and the stripper opens a block comment at any `/*` — including one inside a *line* comment. Writing the literal content-script match pattern in prose swallowed 25K of the 34K file, and every source assertion in the suite silently passed against the remains. The prose is reworded, and a standing pin now fails the build if that view ever drops below 60% of the source or loses its head/tail.

Also fixed: the `#200` red-proof pointed at an unresolvable host, which spends ~50s in the Windows DNS resolver and raced its own 60s timeout. It now uses a closed local port (8s, deterministic) and additionally asserts the stderr header shows a resolved version and `viewport 1920x1080` — the one place the new default is observable end to end.

## Contract

Still `ext-probe/1`, still purely additive: `observation.config.cacheClearedBeforeRun`, `target.viewportHeight`, and the top-level `reportFile` are new fields; nothing renamed or removed.

## Answer to the attribution question

**No — I did not rebuild `.output/chrome-mv3`.** Its mtime is `2026-08-13 23:08:28 +0100` (22:08 UTC) and `chrome-mv3-dev` is `23:08:32`, four seconds later: one `wxt build` producing both modes. My task was assigned `2026-08-14T02:37Z`, four and a half hours after that build, and I have run no build in this session — only `vitest`, `oxlint`, `prettier`, `knip` and `wxt prepare` (type-check). The artifact changing mid-run came from somewhere else.
