### PR TITLE
fix(safari): the MV3 deployment floor, and the in-popup OAuth the WXT migration dropped

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -846,6 +846,12 @@ jobs:
       ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       RELEASE_VERSION: ${{ needs.guard.outputs.version }}
+      # The MV3 floor, in one place: read by both archive steps as a build
+      # setting and by the post-archive assertion. See the comment above
+      # "Build & archive (macOS)" for why these numbers and not the
+      # converter's iOS 15.0 / macOS 10.14 defaults.
+      IOS_DEPLOYMENT_FLOOR: '16.4'
+      MACOS_DEPLOYMENT_FLOOR: '13.0'
     timeout-minutes: 30
     defaults:
       run:
@@ -1008,6 +1014,16 @@ jobs:
             /usr/libexec/PlistBuddy -c "Set :LSApplicationCategoryType ${MAC_CATEGORY}" "$plist"
           done
 
+      # MV3 deployment floor. safari-web-extension-converter stamps its own
+      # defaults (iOS 15.0 / macOS 10.14) onto the generated project, and both
+      # are below what this extension can actually run on: MV3 web extensions
+      # need Safari 15.4, and the service-worker background only became usable
+      # at Safari 16.4 (background ES modules, storage.session, the
+      # importScripts fix). macOS 10.14 Mojave tops out at Safari 14.1 and has
+      # no MV3 at all — that default would ship an app whose extension Safari
+      # can never load. Floors below are the 16.4 era: iOS 16.4, and macOS 13.0
+      # (Ventura, which bundles 16.1 and auto-updates past 16.4).
+      # Asserted after archive by "Assert MV3 deployment floor".
       - name: Build & archive (macOS)
         run: |
           xcodebuild archive \
@@ -1019,6 +1035,7 @@ jobs:
             DEVELOPMENT_TEAM="${{ secrets.APPLE_TEAM_ID }}" \
             MARKETING_VERSION="${RELEASE_VERSION}" \
             CURRENT_PROJECT_VERSION="${{ env.MACOS_BUILD_NUM }}" \
+            MACOSX_DEPLOYMENT_TARGET="${MACOS_DEPLOYMENT_FLOOR}" \
             ARCHS="arm64 x86_64" \
             VALID_ARCHS="arm64 x86_64" \
             ONLY_ACTIVE_ARCH=NO \
@@ -1040,11 +1057,67 @@ jobs:
             DEVELOPMENT_TEAM="${{ secrets.APPLE_TEAM_ID }}" \
             MARKETING_VERSION="${RELEASE_VERSION}" \
             CURRENT_PROJECT_VERSION="${{ env.IOS_BUILD_NUM }}" \
+            IPHONEOS_DEPLOYMENT_TARGET="${IOS_DEPLOYMENT_FLOOR}" \
             ENABLE_HARDENED_RUNTIME=YES \
             -allowProvisioningUpdates \
             -authenticationKeyPath "/tmp/AuthKey_${ASC_KEY_ID}.p8" \
             -authenticationKeyID "${ASC_KEY_ID}" \
             -authenticationKeyIssuerID "${ASC_ISSUER_ID}"
+
+      # The floor is a build SETTING on the two archive commands above, which is
+      # only worth anything if it actually landed in the shipped bundles — and
+      # the one that matters most is the .appex, since the extension is what
+      # Safari refuses to load below 16.4. Command-line settings apply to every
+      # target in the build, so this reads the archives back and proves it,
+      # rather than trusting that they did. A missing key or a path change that
+      # finds nothing is a failure too: a gate that inspects zero files passes
+      # forever and tells you nothing.
+      - name: Assert MV3 deployment floor
+        run: |
+          set -euo pipefail
+
+          # true when A < B, comparing version components numerically.
+          ver_lt() {
+            awk -v a="$1" -v b="$2" 'BEGIN {
+              split(a, x, "."); split(b, y, ".")
+              for (i = 1; i <= 3; i++) {
+                xi = (x[i] == "" ? 0 : x[i] + 0); yi = (y[i] == "" ? 0 : y[i] + 0)
+                if (xi < yi) exit 0
+                if (xi > yi) exit 1
+              }
+              exit 1
+            }'
+          }
+
+          fail=0
+          checked=0
+          check_archive() {
+            archive="$1"; key="$2"; floor="$3"
+            while IFS= read -r -d '' plist; do
+              value=$(/usr/libexec/PlistBuddy -c "Print :${key}" "$plist" 2>/dev/null || true)
+              [ -n "$value" ] || continue
+              checked=$((checked + 1))
+              bundle=${plist#"${archive}/Products/"}
+              if ver_lt "$value" "$floor"; then
+                echo "::error::${bundle} declares ${key} ${value}, below the MV3 floor ${floor}"
+                fail=1
+              else
+                echo "ok: ${bundle} ${key}=${value} (floor ${floor})"
+              fi
+            done < <(find "${archive}/Products" -name Info.plist -print0)
+          }
+
+          check_archive "SafariExtProject/${{ env.APP_NAME }}-ios.xcarchive" \
+            MinimumOSVersion "${IOS_DEPLOYMENT_FLOOR}"
+          check_archive "SafariExtProject/${{ env.APP_NAME }}-macos.xcarchive" \
+            LSMinimumSystemVersion "${MACOS_DEPLOYMENT_FLOOR}"
+
+          if [ "$checked" -eq 0 ]; then
+            echo "::error::No archived Info.plist declared a deployment target — the floor gate inspected nothing."
+            exit 1
+          fi
+          echo "Checked ${checked} bundle(s) against the MV3 deployment floor."
+          exit "$fail"
 
       - name: Write exportOptions (macOS)
         run: |

--- a/apps/caramel-extension/.size-limit.js
+++ b/apps/caramel-extension/.size-limit.js
@@ -49,7 +49,12 @@ module.exports = [
         // popup-core.js and every render moved to the React popup (its own
         // budget below) — what remains is the pinned logic, measured 5.67 kB.
         // A ratchet locks wins in, not just losses out.
-        limit: '6.5 KB',
+        // 2026-08-14, raised 6.5 -> 9.6 kB: the Safari OAuth poll client came
+        // back (tab + nonce flow, the poll loop, the pending-nonce resume —
+        // Safari has no launchWebAuthFlow, so this is the only in-popup
+        // sign-in it has). Real behaviour, measured 8.71 kB. This is the raise
+        // the header sanctions: a whole flow arrived, not prose.
+        limit: '9.6 KB',
         brotli: false,
     },
     {

--- a/apps/caramel-extension/entrypoints/popup/App.tsx
+++ b/apps/caramel-extension/entrypoints/popup/App.tsx
@@ -1,6 +1,10 @@
 import { Spinner } from 'caramel-ui'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { resolvePopupState, setAfterLoginRerender } from '../../popup-core.js'
+import {
+    resolvePopupState,
+    resumeSafariOauthIfPending,
+    setAfterLoginRerender,
+} from '../../popup-core.js'
 import { ToastProvider } from './components/toast'
 import type { AppApi, ResolvedState } from './types'
 import { CouponsView } from './views/CouponsView'
@@ -66,6 +70,15 @@ export function App() {
             if (runSeq.current === seq) setResolved(next)
         })
         void Promise.all([first, minDisplay]).then(() => setBooted(true))
+
+        // Safari finishes OAuth in a TAB, which closes this popup mid-flow —
+        // the token is waiting server-side under the stored nonce when the user
+        // reopens us. Deliberately NOT awaited into the boot gate: it can poll
+        // for up to 30s, and the popup must paint immediately. Resolves to
+        // 'idle' in every other runtime, so no other boot path changes.
+        void resumeSafariOauthIfPending().then(result => {
+            if (result.status === 'ok') refreshRef.current()
+        })
     }, [])
 
     const api: AppApi = {

--- a/apps/caramel-extension/entrypoints/popup/views/SignInView.tsx
+++ b/apps/caramel-extension/entrypoints/popup/views/SignInView.tsx
@@ -4,8 +4,9 @@ import {
     afterLoginSuccess,
     caramelUrl,
     openWebsiteSignIn,
-    popupOAuthSupported,
+    runSafariSocialSignIn,
     runSocialSignIn,
+    signInStrategy,
 } from '../../../popup-core.js'
 import type { AppApi } from '../types'
 
@@ -13,11 +14,17 @@ import type { AppApi } from '../types'
  * The sign-in prompt (P2 React successor to popup.js renderSignInPrompt):
  * social providers, then email/password, then the sign-up and back links.
  *
- * The OAuth WIRE lives in popup-core's runSocialSignIn — every URL, body and
- * message string there is pinned. This view owns only the UI half of that
- * contract: both providers disable together (only one launchWebAuthFlow can be
- * in flight, so the other really is unavailable), the clicked one reads
- * 'Redirecting...', and onError restores both.
+ * The OAuth WIRE lives in popup-core — every URL, body and message string there
+ * is pinned. This view owns only the UI half of that contract: both providers
+ * disable together (only one sign-in can be in flight, so the other really is
+ * unavailable), the clicked one reads 'Redirecting...', and onError restores
+ * both.
+ *
+ * WHICH wire runs is popup-core's signInStrategy(), and all three branches are
+ * live: 'identity' (Chrome/Edge, launchWebAuthFlow in-popup), 'safari-poll'
+ * (Safari, the tab + nonce poll shim — Safari has no launchWebAuthFlow), and
+ * 'website' (Firefox, which ships no identity permission by design). Collapsing
+ * Safari back into 'website' is the regression popup-oauth-safari-poll guards.
  *
  * Email login has no popup-core seam on purpose — it is a plain form POST with
  * no browser-API choreography to extract. Its copy is frozen by
@@ -38,26 +45,39 @@ export function SignInView({ api }: { api: AppApi }) {
     const [revealed, setRevealed] = useState(false)
     const [email, setEmail] = useState('')
     const [password, setPassword] = useState('')
+    // Safari's flow continues in another tab, so it has something to SAY while
+    // it waits. The other two strategies never set this.
+    const [notice, setNotice] = useState('')
 
     // Read at paint AND again at click: the note explains the fallback the
     // buttons will actually take.
-    const oauthSupported = popupOAuthSupported()
+    const strategy = signInStrategy()
 
     const signInWith = (provider: Provider) => {
-        if (!popupOAuthSupported()) {
+        // Firefox: no in-popup OAuth at all, and no poll shim either — the
+        // website relay is the whole flow, so there is no wire to run.
+        if (signInStrategy() === 'website') {
             openWebsiteSignIn()
             return
         }
-        void runSocialSignIn(provider, {
+        const ui = {
             onPending: () => {
                 setPending(provider)
                 setError('')
+                setNotice('')
             },
             onError: (message: string) => {
                 setPending(null)
                 setError(message)
+                setNotice('')
             },
-        })
+            onNotice: (message: string) => setNotice(message),
+        }
+        // Safari cannot capture an OAuth redirect (no launchWebAuthFlow), so it
+        // takes the tab + nonce poll shim instead of the identity wire.
+        void (signInStrategy() === 'safari-poll'
+            ? runSafariSocialSignIn(provider, ui)
+            : runSocialSignIn(provider, ui))
     }
 
     const handleEmailLogin = async (event: FormEvent<HTMLFormElement>) => {
@@ -166,10 +186,18 @@ export function SignInView({ api }: { api: AppApi }) {
                 </button>
             </div>
 
-            {!oauthSupported && (
+            {strategy === 'website' && (
                 <p className="oauth-note">
                     Sign-in opens grabcaramel.com; the extension picks it up
                     automatically.
+                </p>
+            )}
+
+            {/* Safari's flow leaves the popup; role=status so a screen reader
+                hears where the sign-in went. */}
+            {notice && (
+                <p className="oauth-note" role="status">
+                    {notice}
                 </p>
             )}
 

--- a/apps/caramel-extension/popup-core.js
+++ b/apps/caramel-extension/popup-core.js
@@ -561,6 +561,238 @@ export function openWebsiteSignIn() {
 }
 
 /* ------------------------------------------------------------ */
+/*  Safari OAuth: tab + nonce polling                           */
+/* ------------------------------------------------------------ */
+/* Safari ships no identity.launchWebAuthFlow, so it cannot capture an OAuth
+ * redirect the way Chrome does. The shipped 1.3.x Safari build compensated with
+ * a poll shim: hand /authorize a one-shot nonce, let the provider come back to
+ * OUR /redirect, which finishes the exchange server-side and stashes the result
+ * under that nonce, and poll /poll until the session token appears.
+ *
+ * The server half of that shim is live and PINNED by the app suite
+ * (apps/caramel-app/tests/unit/extension-oauth-safari-poll-shim.test.ts, whose
+ * header is the wire contract). The client half was lost in the pre-WXT popup
+ * rewrite, which is how in-popup OAuth silently disappeared from Safari with
+ * every gate green — this is that client, ported from popup.js at d86c244 (the
+ * 2026-04-29 store build) rather than reinvented, so the two halves still
+ * describe the same protocol. It keeps the shipped codes and timings:
+ *   204                -> pending, keep polling
+ *   2xx + {token}      -> done
+ *   2xx without token  -> 'Empty response from poll'
+ *   anything else      -> the error body's `.error`
+ *
+ * Two deliberate departures from the shipped client, both because the tree
+ * moved under it: the session lands via caramelSetSession (sessions migrated
+ * from storage.sync to storage.local), and a hard failure falls back to
+ * openWebsiteSignIn() instead of leaving the user at an error with no route
+ * out.
+ */
+const SAFARI_OAUTH_TTL_MS = 5 * 60 * 1000 // the server's own nonce TTL
+const SAFARI_OAUTH_POLL_INTERVAL_MS = 2000
+/* A popup that reopens mid-flow polls in the foreground for this long before
+ * telling the user to come back. Not the TTL: the popup must not hang. */
+const SAFARI_OAUTH_RESUME_BUDGET_MS = 30 * 1000
+const SAFARI_OAUTH_PENDING_KEYS = [
+    'pendingOauthNonce',
+    'pendingOauthExpiresAt',
+    'pendingOauthProvider',
+]
+
+/* Which sign-in route this runtime can actually take. Safari is identified by
+ * the scheme of its OWN extension origin, not by the user agent and not at
+ * build time: the Safari artifact IS the chrome-mv3 build put through
+ * safari-web-extension-converter (see release-extension.yml publish_safari), so
+ * every build-time stamp in it still reads "chrome". */
+export function isSafariExtensionRuntime() {
+    const url = currentBrowser.runtime?.getURL?.('')
+    return typeof url === 'string' && url.startsWith('safari-web-extension://')
+}
+
+/**
+ * 'identity'    — Chrome/Edge: launchWebAuthFlow, in-popup, unchanged.
+ * 'safari-poll' — Safari: the tab + nonce poll shim below.
+ * 'website'     — Firefox: no identity permission BY DESIGN (issue #139), and
+ *                 no poll shim either; the website relay stays its route.
+ */
+export function signInStrategy() {
+    if (popupOAuthSupported()) return 'identity'
+    if (isSafariExtensionRuntime()) return 'safari-poll'
+    return 'website'
+}
+
+function safariPendingGet() {
+    return new Promise(resolve => {
+        currentBrowser.storage.local.get(SAFARI_OAUTH_PENDING_KEYS, res =>
+            resolve(res || {}),
+        )
+    })
+}
+
+function safariPendingSet(pending) {
+    return new Promise(resolve => {
+        currentBrowser.storage.local.set(pending, () => resolve())
+    })
+}
+
+function safariPendingClear() {
+    return new Promise(resolve => {
+        currentBrowser.storage.local.remove(SAFARI_OAUTH_PENDING_KEYS, () =>
+            resolve(),
+        )
+    })
+}
+
+/** One /poll hop. A thrown fetch is 'pending', never an error: Safari drops
+ * connections while a tab takes focus, and treating that blip as a failure
+ * would abandon a sign-in that is still perfectly alive server-side. */
+async function pollSafariOauthOnce(nonce) {
+    const pollUrl = `${CARAMEL_ENV.baseUrl}/api/extension/oauth/poll?nonce=${encodeURIComponent(nonce)}`
+    try {
+        const resp = await fetch(pollUrl, { method: 'GET' })
+        if (resp.status === 204) return { status: 'pending' }
+        if (resp.ok) {
+            const data = await resp.json().catch(() => ({}))
+            if (data && data.token) return { status: 'ok', data }
+            return { status: 'error', error: 'Empty response from poll' }
+        }
+        const errorData = await resp.json().catch(() => ({}))
+        return {
+            status: 'error',
+            error: errorData?.error || `Poll failed (${resp.status})`,
+        }
+    } catch {
+        return { status: 'pending' }
+    }
+}
+
+async function pollSafariOauthUntilDone(nonce, deadlineMs) {
+    while (Date.now() < deadlineMs) {
+        const result = await pollSafariOauthOnce(nonce)
+        if (result.status !== 'pending') return result
+        await new Promise(resolve =>
+            setTimeout(resolve, SAFARI_OAUTH_POLL_INTERVAL_MS),
+        )
+    }
+    return { status: 'timeout', error: 'Sign-in timed out. Please try again.' }
+}
+
+function applySafariOauthResult(data) {
+    return new Promise(resolve => {
+        caramelSetSession(
+            {
+                token: data.token,
+                user: { username: data.username, image: data.image },
+            },
+            () => resolve(),
+        )
+    })
+}
+
+/**
+ * The Safari sign-in the provider buttons take. Returns the terminal outcome
+ * so callers and tests can read it; the UI half goes through `ui`.
+ */
+export async function runSafariSocialSignIn(provider, ui = {}) {
+    ui.onPending?.()
+
+    const nonce = crypto.randomUUID()
+    const expiresAt = Date.now() + SAFARI_OAUTH_TTL_MS
+
+    try {
+        const authorizeUrl = `${CARAMEL_ENV.baseUrl}/api/extension/oauth/authorize?provider=${provider}&redirect_uri=${encodeURIComponent(
+            `${CARAMEL_ENV.baseUrl}/api/extension/oauth/redirect`,
+        )}&nonce=${encodeURIComponent(nonce)}`
+
+        const authorizeResponse = await fetch(authorizeUrl, { method: 'GET' })
+        if (!authorizeResponse.ok) {
+            const errorData = await authorizeResponse.json().catch(() => ({}))
+            throw new Error(
+                errorData.error ||
+                    `HTTP ${authorizeResponse.status}: Failed to get OAuth authorization URL`,
+            )
+        }
+        const responseData = await authorizeResponse.json().catch(() => ({}))
+        if (!responseData.authorizationUrl) {
+            throw new Error('Failed to get OAuth authorization URL')
+        }
+
+        /* Persist BEFORE opening the tab. Safari closes the popup when the new
+         * tab takes focus, killing the poll loop below mid-flight — without the
+         * stored nonce the user lands on "You're signed in" and the extension
+         * never learns the token. resumeSafariOauthIfPending() picks it up on
+         * the next popup open. */
+        await safariPendingSet({
+            pendingOauthNonce: nonce,
+            pendingOauthExpiresAt: expiresAt,
+            pendingOauthProvider: provider,
+        })
+
+        currentBrowser.tabs.create({ url: responseData.authorizationUrl })
+        ui.onNotice?.(
+            'Complete sign-in in the new tab. You can close this popup — it picks up the result when you reopen it.',
+        )
+
+        const result = await pollSafariOauthUntilDone(nonce, expiresAt)
+
+        if (result.status === 'ok') {
+            await applySafariOauthResult(result.data)
+            await safariPendingClear()
+            if (CARAMEL_CALLER_ID || document.visibilityState === 'visible') {
+                afterLoginSuccess()
+            }
+            return { status: 'ok' }
+        }
+
+        throw new Error(result.error)
+    } catch (err) {
+        console.error('Safari OAuth error:', err)
+        /* Nothing left to resume: the nonce is spent or dead, so clear it
+         * rather than let the next popup open poll a corpse. */
+        await safariPendingClear()
+        ui.onError?.(`OAuth sign-in failed: ${err.message}`)
+        // Never a dead end — the website relay still signs this user in.
+        openWebsiteSignIn()
+        return { status: 'error', error: err.message }
+    }
+}
+
+/**
+ * Called at popup boot. Resolves the sign-in the user finished in a tab while
+ * this popup was closed. A no-op with nothing pending, which is every runtime
+ * but Safari — only runSafariSocialSignIn ever writes these keys.
+ *
+ * 'pending' deliberately KEEPS the stored nonce: the flow is still alive
+ * server-side until the TTL, and the next popup open resumes it.
+ */
+export async function resumeSafariOauthIfPending() {
+    const stored = await safariPendingGet()
+    const nonce = stored.pendingOauthNonce
+    const expiresAt = stored.pendingOauthExpiresAt
+    if (!nonce) return { status: 'idle' }
+
+    if (!expiresAt || Date.now() > expiresAt) {
+        await safariPendingClear()
+        return { status: 'expired' }
+    }
+
+    const deadline = Math.min(
+        expiresAt,
+        Date.now() + SAFARI_OAUTH_RESUME_BUDGET_MS,
+    )
+    const result = await pollSafariOauthUntilDone(nonce, deadline)
+
+    if (result.status === 'ok') {
+        await applySafariOauthResult(result.data)
+        await safariPendingClear()
+        return { status: 'ok' }
+    }
+    if (result.status === 'timeout') return { status: 'pending' }
+
+    await safariPendingClear()
+    return { status: 'error', error: result.error }
+}
+
+/* ------------------------------------------------------------ */
 /*  Coupon list constants (data half — the views render them)   */
 /* ------------------------------------------------------------ */
 /* Identity of a coupon ACROSS requests, for the append dedupe.

--- a/apps/caramel-extension/tests/popup-oauth-safari-poll.test.mjs
+++ b/apps/caramel-extension/tests/popup-oauth-safari-poll.test.mjs
@@ -1,0 +1,507 @@
+import { readFileSync } from 'node:fs'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { caramelGetSession, initCaramelBase } from '../caramel-base.js'
+import { initCouponConstants } from '../coupon-constants.generated.js'
+import { initCouponRunner } from '../coupon-runner.js'
+import {
+    isSafariExtensionRuntime,
+    resumeSafariOauthIfPending,
+    runSafariSocialSignIn,
+    setAfterLoginRerender,
+    signInStrategy,
+} from '../popup-core.js'
+
+// Pins the Safari in-popup OAuth client (restored 2026-08-14).
+//
+// Safari has no identity.launchWebAuthFlow, so it cannot capture an OAuth
+// redirect. The shipped 1.3.x build compensated with a poll shim — nonce to
+// /authorize, provider returns to OUR /redirect, poll /poll for the minted
+// session — whose SERVER half is live and pinned by the app suite
+// (apps/caramel-app/tests/unit/extension-oauth-safari-poll-shim.test.ts). The
+// client half was lost in the pre-WXT popup rewrite, and 1.4.0 Safari silently
+// fell back to openWebsiteSignIn(): a capability disappeared with every gate
+// green, which is the regression class this suite exists to close.
+//
+// So it pins two different things. The BEHAVIOR (a Safari-shaped runtime takes
+// the poll route, a success signs the popup in, a failure still leaves a way
+// in) and, in the last describe, the STRUCTURE — a standing guard that fails if
+// the client is deleted or unwired again, because behavior tests only catch a
+// deletion if something still calls the deleted thing.
+
+/* Realm stub, lifted from popup-oauth-fallback.test.mjs — permissive Proxy,
+ * storage callbacks invoked, lastError undefined outside a failing callback.
+ * The difference here: storage.local really STORES, because the pending nonce
+ * surviving a closed popup is the whole point of the flow. */
+let storageLocal = {}
+
+function installChromeStub() {
+    const cache = new WeakMap()
+    const wrap = target => {
+        if (cache.has(target)) return cache.get(target)
+        const proxy = new Proxy(target, {
+            get(obj, prop) {
+                if (prop === 'then' || typeof prop === 'symbol')
+                    return undefined
+                if (!(prop in obj)) obj[prop] = wrap(function () {})
+                return obj[prop]
+            },
+            apply: () => undefined,
+        })
+        cache.set(target, proxy)
+        return proxy
+    }
+    const stub = wrap(function chromeStubRoot() {})
+    for (const area of ['sync', 'session']) {
+        stub.storage[area].get = (_keys, cb) => {
+            if (typeof cb === 'function') cb({})
+        }
+        stub.storage[area].set = (_items, cb) => {
+            if (typeof cb === 'function') cb()
+        }
+        stub.storage[area].remove = (_keys, cb) => {
+            if (typeof cb === 'function') cb()
+        }
+    }
+    const keyList = keys =>
+        Array.isArray(keys)
+            ? keys
+            : typeof keys === 'string'
+              ? [keys]
+              : Object.keys(keys || {})
+    stub.storage.local.get = (keys, cb) => {
+        const out = {}
+        for (const key of keyList(keys))
+            if (key in storageLocal) out[key] = storageLocal[key]
+        if (typeof cb === 'function') cb(out)
+    }
+    stub.storage.local.set = (items, cb) => {
+        Object.assign(storageLocal, items)
+        if (typeof cb === 'function') cb()
+    }
+    stub.storage.local.remove = (keys, cb) => {
+        for (const key of keyList(keys)) delete storageLocal[key]
+        if (typeof cb === 'function') cb()
+    }
+    stub.runtime.lastError = undefined
+    globalThis.chrome = stub
+    globalThis.browser = undefined
+    window.chrome = stub
+    window.browser = undefined
+    return stub
+}
+
+let createdTabs = []
+
+beforeAll(() => {
+    installChromeStub()
+    initCouponConstants()
+    initCaramelBase()
+    initCouponRunner()
+})
+
+/** Safari: no identity API, and the extension origin carries Safari's scheme —
+ * the only honest tell, since the Safari artifact IS the chrome-mv3 build put
+ * through the converter and every build-time stamp in it still says "chrome". */
+const safariShape = () => {
+    globalThis.currentBrowser.identity = undefined
+    globalThis.currentBrowser.chrome = undefined
+    globalThis.currentBrowser.runtime.getURL = path =>
+        `safari-web-extension://ABCD-1234/${path}`
+    globalThis.currentBrowser.tabs.create = opts => {
+        createdTabs.push(opts)
+    }
+}
+
+/** Firefox: no identity API either, but a moz-extension origin — it must keep
+ * the website route, NOT inherit Safari's. */
+const firefoxShape = () => {
+    globalThis.currentBrowser.identity = undefined
+    globalThis.currentBrowser.chrome = undefined
+    globalThis.currentBrowser.runtime.getURL = path =>
+        `moz-extension://abcd-1234/${path}`
+    globalThis.currentBrowser.tabs.create = opts => {
+        createdTabs.push(opts)
+    }
+}
+
+/** Chrome: identity present, so nothing about it may change. */
+const chromeShape = () => {
+    globalThis.currentBrowser.identity = {
+        launchWebAuthFlow: async () => undefined,
+        getRedirectURL: () => 'https://ext-id.chromiumapp.org/',
+    }
+    globalThis.currentBrowser.chrome = undefined
+    globalThis.currentBrowser.runtime.getURL = path =>
+        `chrome-extension://abcd-1234/${path}`
+    globalThis.currentBrowser.tabs.create = opts => {
+        createdTabs.push(opts)
+    }
+}
+
+const AUTHORIZATION_URL = 'https://accounts.google.com/o/oauth2/auth?x=1'
+
+/** The session /poll hands back, shaped as the app's poll route returns it. */
+const POLL_SESSION = {
+    token: 'safari-session-token',
+    username: 'Safari Shopper',
+    image: 'https://example.com/avatar.png',
+}
+
+/**
+ * A fetch that answers /authorize once and then walks /poll through a scripted
+ * sequence of responses, repeating the last one forever (a poll loop asks more
+ * times than a script can enumerate).
+ */
+function installFetch(pollScript, { authorize = { ok: true } } = {}) {
+    const calls = []
+    let pollIndex = 0
+    globalThis.fetch = vi.fn(async url => {
+        const href = String(url)
+        calls.push(href)
+        if (href.includes('/api/extension/oauth/authorize')) {
+            if (!authorize.ok) {
+                return {
+                    ok: false,
+                    status: authorize.status ?? 500,
+                    json: async () => ({ error: authorize.error }),
+                }
+            }
+            return {
+                ok: true,
+                status: 200,
+                json: async () => ({ authorizationUrl: AUTHORIZATION_URL }),
+            }
+        }
+        if (href.includes('/api/extension/oauth/poll')) {
+            const step = pollScript[Math.min(pollIndex, pollScript.length - 1)]
+            pollIndex += 1
+            return step
+        }
+        throw new Error(`unexpected fetch to ${href}`)
+    })
+    return { calls, pollCount: () => pollIndex }
+}
+
+/** 204 — the code that keeps the client polling. */
+const PENDING = { ok: false, status: 204, json: async () => ({}) }
+/** 200 + a minted session. */
+const DONE = { ok: true, status: 200, json: async () => POLL_SESSION }
+/** 400 — the sentinel /redirect stores when the provider refuses. */
+const REFUSED = {
+    ok: false,
+    status: 400,
+    json: async () => ({ error: 'OAuth sign-in failed' }),
+}
+
+const noopUi = () => ({
+    onPending: vi.fn(),
+    onError: vi.fn(),
+    onNotice: vi.fn(),
+})
+
+beforeEach(() => {
+    createdTabs = []
+    storageLocal = {}
+    window.close = vi.fn()
+    setAfterLoginRerender(() => {})
+    vi.useRealTimers()
+})
+
+describe('the sign-in strategy each runtime takes', () => {
+    it('routes Safari to the poll shim — NOT to the website redirect', () => {
+        // The 1.4.0 regression in one assertion: Safari and Firefox both lack
+        // launchWebAuthFlow, so a capability check alone collapses them onto
+        // the website fallback and in-popup OAuth quietly disappears.
+        safariShape()
+        expect(isSafariExtensionRuntime()).toBe(true)
+        expect(signInStrategy()).toBe('safari-poll')
+        expect(signInStrategy()).not.toBe('website')
+    })
+
+    it('leaves Firefox on the website route and Chrome on the identity route', () => {
+        firefoxShape()
+        expect(isSafariExtensionRuntime()).toBe(false)
+        expect(signInStrategy()).toBe('website')
+
+        chromeShape()
+        expect(isSafariExtensionRuntime()).toBe(false)
+        expect(signInStrategy()).toBe('identity')
+    })
+})
+
+describe('the Safari sign-in, from click to session', () => {
+    it('carries a nonce to authorize, opens the provider in a TAB, and stores the nonce first', async () => {
+        safariShape()
+        const { calls } = installFetch([DONE])
+        const ui = noopUi()
+
+        await runSafariSocialSignIn('google', ui)
+
+        const authorize = new URL(calls.find(c => c.includes('/authorize')))
+        expect(authorize.searchParams.get('provider')).toBe('google')
+        // redirect_uri is OURS — Safari cannot receive an extension callback.
+        expect(authorize.searchParams.get('redirect_uri')).toBe(
+            'https://grabcaramel.com/api/extension/oauth/redirect',
+        )
+        const nonce = authorize.searchParams.get('nonce')
+        // 36 chars: the crypto.randomUUID() shape /poll validates.
+        expect(nonce).toHaveLength(36)
+
+        // The provider opens in a real tab, not launchWebAuthFlow.
+        expect(createdTabs).toHaveLength(1)
+        expect(createdTabs[0].url).toBe(AUTHORIZATION_URL)
+
+        // The same nonce goes to /poll.
+        const polled = new URL(calls.find(c => c.includes('/poll')))
+        expect(polled.searchParams.get('nonce')).toBe(nonce)
+
+        expect(ui.onNotice).toHaveBeenCalledWith(
+            expect.stringContaining('new tab'),
+        )
+    })
+
+    it('signs the popup in when poll returns the token, and re-renders', async () => {
+        safariShape()
+        installFetch([PENDING, DONE])
+        const rerender = vi.fn()
+        setAfterLoginRerender(rerender)
+        const ui = noopUi()
+
+        vi.useFakeTimers()
+        const run = runSafariSocialSignIn('google', ui)
+        // One 204, one 2s gap, then the token.
+        await vi.advanceTimersByTimeAsync(2500)
+        const result = await run
+        vi.useRealTimers()
+
+        expect(result.status).toBe('ok')
+        const session = await caramelGetSession()
+        expect(session.token).toBe(POLL_SESSION.token)
+        expect(session.user).toEqual({
+            username: POLL_SESSION.username,
+            image: POLL_SESSION.image,
+        })
+        expect(rerender).toHaveBeenCalled()
+        expect(ui.onError).not.toHaveBeenCalled()
+
+        // The spent nonce is gone — nothing left for a later boot to resume.
+        expect(storageLocal.pendingOauthNonce).toBeUndefined()
+    })
+
+    it('persists the pending nonce BEFORE opening the tab, so a popup Safari closes can resume', async () => {
+        safariShape()
+        // Never completes while the popup is open: the real Safari case, where
+        // the tab takes focus and the popup dies mid-poll.
+        installFetch([PENDING])
+        const ui = noopUi()
+
+        vi.useFakeTimers()
+        void runSafariSocialSignIn('apple', ui)
+        await vi.advanceTimersByTimeAsync(3000)
+
+        expect(storageLocal.pendingOauthNonce).toHaveLength(36)
+        expect(storageLocal.pendingOauthProvider).toBe('apple')
+        expect(storageLocal.pendingOauthExpiresAt).toBeGreaterThan(Date.now())
+        vi.useRealTimers()
+    })
+})
+
+describe('a Safari sign-in that fails is never a dead end', () => {
+    it('falls back to the website sign-in when the provider refuses', async () => {
+        safariShape()
+        installFetch([REFUSED])
+        const ui = noopUi()
+
+        const result = await runSafariSocialSignIn('google', ui)
+
+        expect(result.status).toBe('error')
+        expect(ui.onError).toHaveBeenCalledWith(
+            expect.stringContaining('OAuth sign-in failed'),
+        )
+        // The user still gets a route in: the website login tab.
+        const login = createdTabs.find(t => t.url.includes('/login'))
+        expect(login).toBeDefined()
+        expect(window.close).toHaveBeenCalled()
+        // A dead nonce is not left behind for the next boot to poll.
+        expect(storageLocal.pendingOauthNonce).toBeUndefined()
+    })
+
+    it('falls back when authorize itself fails, without opening a provider tab', async () => {
+        safariShape()
+        installFetch([], {
+            authorize: { ok: false, status: 500, error: 'authorize exploded' },
+        })
+        const ui = noopUi()
+
+        const result = await runSafariSocialSignIn('google', ui)
+
+        expect(result.status).toBe('error')
+        expect(createdTabs.map(t => t.url)).not.toContain(AUTHORIZATION_URL)
+        expect(createdTabs.some(t => t.url.includes('/login'))).toBe(true)
+    })
+
+    it('falls back when the whole nonce TTL elapses with no answer', async () => {
+        safariShape()
+        installFetch([PENDING])
+        const ui = noopUi()
+
+        vi.useFakeTimers()
+        const run = runSafariSocialSignIn('google', ui)
+        await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 5000)
+        const result = await run
+        vi.useRealTimers()
+
+        expect(result.status).toBe('error')
+        expect(ui.onError).toHaveBeenCalled()
+        expect(createdTabs.some(t => t.url.includes('/login'))).toBe(true)
+        expect(storageLocal.pendingOauthNonce).toBeUndefined()
+    })
+
+    it('treats a thrown fetch as pending, not as a failure', async () => {
+        // Safari drops connections while a tab takes focus. Reading that blip
+        // as an error would abandon a sign-in that is still alive server-side.
+        safariShape()
+        let first = true
+        globalThis.fetch = vi.fn(async url => {
+            const href = String(url)
+            if (href.includes('/authorize'))
+                return {
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ authorizationUrl: AUTHORIZATION_URL }),
+                }
+            if (first) {
+                first = false
+                throw new TypeError('Load failed')
+            }
+            return DONE
+        })
+        const ui = noopUi()
+
+        vi.useFakeTimers()
+        const run = runSafariSocialSignIn('google', ui)
+        await vi.advanceTimersByTimeAsync(2500)
+        const result = await run
+        vi.useRealTimers()
+
+        expect(result.status).toBe('ok')
+        expect(ui.onError).not.toHaveBeenCalled()
+    })
+})
+
+describe('resuming a sign-in the user finished while the popup was closed', () => {
+    it('is a silent no-op with nothing pending — every non-Safari boot', async () => {
+        chromeShape()
+        globalThis.fetch = vi.fn()
+
+        expect(await resumeSafariOauthIfPending()).toEqual({ status: 'idle' })
+        expect(globalThis.fetch).not.toHaveBeenCalled()
+    })
+
+    it('collects the token stashed while the popup was gone', async () => {
+        safariShape()
+        storageLocal = {
+            pendingOauthNonce: '3f2b1c7a-9d41-4e2f-8a55-0b6c9d1e2f30',
+            pendingOauthExpiresAt: Date.now() + 4 * 60 * 1000,
+            pendingOauthProvider: 'google',
+        }
+        const { calls } = installFetch([DONE])
+
+        const result = await resumeSafariOauthIfPending()
+
+        expect(result.status).toBe('ok')
+        expect(calls[0]).toContain('3f2b1c7a-9d41-4e2f-8a55-0b6c9d1e2f30')
+        expect((await caramelGetSession()).token).toBe(POLL_SESSION.token)
+        expect(storageLocal.pendingOauthNonce).toBeUndefined()
+    })
+
+    it('KEEPS the nonce when the flow is still running, so the next open resumes it', async () => {
+        // The resume budget (30s) is shorter than the TTL (5min) on purpose:
+        // the popup must not hang. Clearing here would strand a live sign-in.
+        safariShape()
+        storageLocal = {
+            pendingOauthNonce: '3f2b1c7a-9d41-4e2f-8a55-0b6c9d1e2f30',
+            pendingOauthExpiresAt: Date.now() + 4 * 60 * 1000,
+            pendingOauthProvider: 'google',
+        }
+        installFetch([PENDING])
+
+        vi.useFakeTimers()
+        const run = resumeSafariOauthIfPending()
+        await vi.advanceTimersByTimeAsync(35 * 1000)
+        const result = await run
+        vi.useRealTimers()
+
+        expect(result.status).toBe('pending')
+        expect(storageLocal.pendingOauthNonce).toBe(
+            '3f2b1c7a-9d41-4e2f-8a55-0b6c9d1e2f30',
+        )
+    })
+
+    it('drops an expired nonce without polling a corpse', async () => {
+        safariShape()
+        storageLocal = {
+            pendingOauthNonce: '3f2b1c7a-9d41-4e2f-8a55-0b6c9d1e2f30',
+            pendingOauthExpiresAt: Date.now() - 1,
+            pendingOauthProvider: 'google',
+        }
+        globalThis.fetch = vi.fn()
+
+        expect(await resumeSafariOauthIfPending()).toEqual({
+            status: 'expired',
+        })
+        expect(globalThis.fetch).not.toHaveBeenCalled()
+        expect(storageLocal.pendingOauthNonce).toBeUndefined()
+    })
+})
+
+describe('SAFARI-AWARENESS GUARD — the client cannot vanish silently again', () => {
+    // Behavior suites only catch a deletion if something still calls the
+    // deleted code. This capability was lost precisely because nothing did:
+    // the popup rewrite dropped the client, every gate stayed green, and
+    // Safari degraded to the website redirect for a full release. These
+    // assertions fail on the DELETION itself.
+    const read = relative =>
+        readFileSync(new URL(relative, import.meta.url), 'utf8')
+
+    it('popup-core still speaks the poll protocol the app server half pins', () => {
+        const source = read('../popup-core.js')
+        expect(source).toContain('/api/extension/oauth/poll')
+        expect(source).toContain('/api/extension/oauth/authorize')
+        expect(source).toContain('/api/extension/oauth/redirect')
+        // The two exports the popup consumes.
+        expect(source).toContain('export async function runSafariSocialSignIn')
+        expect(source).toContain(
+            'export async function resumeSafariOauthIfPending',
+        )
+    })
+
+    it('the sign-in view still ROUTES Safari to it', () => {
+        // Wiring, not just existence: an unreferenced client is the same
+        // outage with extra code.
+        const source = read('../entrypoints/popup/views/SignInView.tsx')
+        expect(source).toContain('runSafariSocialSignIn')
+        expect(source).toContain('signInStrategy')
+    })
+
+    it('the popup still resumes a pending sign-in at boot', () => {
+        const source = read('../entrypoints/popup/App.tsx')
+        expect(source).toContain('resumeSafariOauthIfPending')
+    })
+
+    it('every strategy the router can return has a live branch in the view', () => {
+        // Three strategies, three routes. A fourth added without wiring it —
+        // or a branch quietly deleted — fails here.
+        const core = read('../popup-core.js')
+        const view = read('../entrypoints/popup/views/SignInView.tsx')
+        const returned = [...core.matchAll(/return '([a-z-]+)'/g)]
+            .map(m => m[1])
+            .filter(s => ['identity', 'safari-poll', 'website'].includes(s))
+        expect(new Set(returned)).toEqual(
+            new Set(['identity', 'safari-poll', 'website']),
+        )
+        expect(view).toContain("=== 'website'")
+        expect(view).toContain("=== 'safari-poll'")
+        expect(view).toContain('runSocialSignIn')
+    })
+})


### PR DESCRIPTION
Two Safari fixes, both code-only. **No release**: no tag, no version bump, no store submission — the in-review 1.4.0 is untouched. This lands ready for whatever ships next.

## 1. The Safari builds were archived against pre-MV3 deployment targets

`publish_safari` converts `.output/chrome-mv3` with `safari-web-extension-converter`, which stamps its own defaults onto the generated project: **iOS 15.0 / macOS 10.14**. Both are below what this extension can actually run on.

- MV3 web extensions need **Safari 15.4**; the service-worker background only became usable at **Safari 16.4** (background ES modules, `storage.session`, the `importScripts` fix).
- **macOS 10.14 Mojave tops out at Safari 14.1 and has no MV3 at all** — that default shipped an app whose extension Safari can never load.

Both `xcodebuild archive` invocations now pass the floor as a build setting, from one pair of job-level env vars: **`IPHONEOS_DEPLOYMENT_TARGET=16.4`**, **`MACOSX_DEPLOYMENT_TARGET=13.0`** (Ventura bundles 16.1 and auto-updates well past 16.4). The generated pbxproj is not patched by hand — command-line build settings apply to every target in the build, including the appex.

**Rules become checks:** a new `Assert MV3 deployment floor` step reads the two archives back and fails loudly if any bundle's `MinimumOSVersion` / `LSMinimumSystemVersion` is below the floor — the appex especially, since the extension is what Safari refuses to load. Inspecting zero files is also a failure: a gate that finds nothing passes forever and tells you nothing. The version comparison was exercised against the exact defaults it exists to catch (15.0 vs 16.4, 10.14 vs 13.0 → both rejected; 13 vs 13.0 → accepted).

## 2. Safari's in-popup OAuth was silently gone

Safari ships no `identity.launchWebAuthFlow`, so it cannot capture an OAuth redirect. The shipped 1.3.x build compensated with a **poll shim**: hand `/authorize` a one-shot nonce, let the provider return to *our* `/redirect`, which finishes the exchange server-side and stashes the result under that nonce, then poll `/poll` until the session token appears.

The **server half is live and pinned** (`apps/caramel-app/tests/unit/extension-oauth-safari-poll-shim.test.ts`). The **client half was lost in the pre-WXT popup rewrite** — so on 1.4.0, Safari fell through `popupOAuthSupported() === false` into `openWebsiteSignIn()`. That fallback works, which is exactly why nobody noticed: a capability disappeared with every gate green.

The client is **ported from `popup.js` at `d86c244`** (the 2026-04-29 store build), not reinvented, so both halves still describe the same protocol — same codes, same timings (204 = pending · 2xx+`{token}` = done · 2xx without token = `Empty response from poll` · else the error body's `.error`; 2s interval, 5-minute TTL).

**Safari is detected at runtime, by the scheme of its own extension origin** (`safari-web-extension://`) — not by user agent, and not at build time: the Safari artifact *is* the chrome-mv3 build put through the converter, so every build-time stamp in it still reads `chrome`.

`signInStrategy()` now has three live branches, and **Chrome and Firefox are untouched**:

| runtime | strategy | flow |
|---|---|---|
| Chrome/Edge | `identity` | `launchWebAuthFlow`, in-popup — unchanged |
| Safari | `safari-poll` | **restored**: tab + nonce poll |
| Firefox | `website` | no identity permission *by design* (#139) — website relay, unchanged |

Three deliberate departures from the 1.3.x client, because the tree moved under it:
- the session lands via `caramelSetSession` (sessions migrated `storage.sync` → `storage.local`);
- a hard failure **falls back to `openWebsiteSignIn()`** rather than leaving the user at an error with no route out;
- the resume runs from `App.tsx` at mount, not `DOMContentLoaded`.

The pending nonce is persisted **before** the tab opens — Safari closes the popup when the new tab takes focus, killing the poll loop mid-flight, and `resumeSafariOauthIfPending()` picks it up on the next open (30s foreground budget, then it keeps the nonce and asks the user to come back).

### Tests — `tests/popup-oauth-safari-poll.test.mjs` (17)

Behaviour: Safari routes to the poll shim and **not** the website redirect · Firefox stays `website`, Chrome stays `identity` · the nonce reaches `/authorize` with *our* `redirect_uri` and the provider opens in a tab · poll success signs the popup in and re-renders · the nonce is stored before the tab opens · a thrown fetch is *pending*, not a failure (Safari drops connections when a tab takes focus) · provider refusal, authorize failure and full-TTL timeout each fall back to the website sign-in and leave no dead nonce · resume collects a token stashed while the popup was gone, keeps a still-running nonce, drops an expired one, and is a silent no-op everywhere else.

**And a standing SAFARI-AWARENESS GUARD**, which is the actual point: behaviour tests only catch a deletion if something still *calls* the deleted code, and this capability was lost precisely because nothing did. Four assertions fail on the deletion itself — popup-core still speaks the poll protocol, the view still routes Safari to it, the popup still resumes at boot, and every strategy the router returns has a live branch in the view.

Red-proofed both ways: breaking Safari detection reds the routing pin; unwiring the view reds two guard pins.

### Gates

`test` 846/846 (88 files) · `test:guards` 57/57 · `test:parity` 71/71 · `type-check` · `build` · `knip` · `prettier-check` · `lint` (unchanged from `main`: the 2 errors / 5 warnings are pre-existing, in files this PR does not touch) · `size`.

`size` **caught this change** — popup-core minified went 5.67 → 8.71 kB against a 6.5 kB ceiling. Raised to **9.6 kB** with a dated reason beside it, per that config's own rule ("raising a number is allowed; raising it silently is not") and its ~10% headroom convention. A whole flow arrived, not prose.

`apps/caramel-app` is unchanged — the server routes exist and are already pinned.