### PR TITLE
fix(support): the support notification email is a real template, not plain text dropped into the html body

### DIFF
--- a/apps/caramel-app/emails/EmailLayout.tsx
+++ b/apps/caramel-app/emails/EmailLayout.tsx
@@ -25,11 +25,18 @@ export const brand = {
 interface EmailLayoutProps {
     children: React.ReactNode
     previewText?: string
+    /** Replaces the default "do not reply" footer line.
+     *
+     * The default is correct for the automated mail this layout was built for,
+     * but the support notification sets `replyTo` to the CUSTOMER — telling the
+     * operator not to reply would be the opposite of what they should do. */
+    footerNote?: string
 }
 
 export default function EmailLayout({
     children,
     previewText,
+    footerNote,
 }: EmailLayoutProps) {
     return (
         <div
@@ -213,14 +220,21 @@ export default function EmailLayout({
                                                                         '18px',
                                                                 }}
                                                             >
-                                                                This is an
-                                                                automated
-                                                                message from{' '}
-                                                                <strong>
-                                                                    no_reply@grabcaramel.com
-                                                                </strong>
-                                                                . Please do not
-                                                                reply.
+                                                                {footerNote ?? (
+                                                                    <>
+                                                                        This is
+                                                                        an
+                                                                        automated
+                                                                        message
+                                                                        from{' '}
+                                                                        <strong>
+                                                                            no_reply@grabcaramel.com
+                                                                        </strong>
+                                                                        . Please
+                                                                        do not
+                                                                        reply.
+                                                                    </>
+                                                                )}
                                                             </p>
                                                             <p
                                                                 style={{

--- a/apps/caramel-app/emails/SupportNotificationTemplate.tsx
+++ b/apps/caramel-app/emails/SupportNotificationTemplate.tsx
@@ -1,0 +1,236 @@
+import EmailLayout, { brand, EmailNotice, text } from './EmailLayout'
+
+/**
+ * The operator-facing notification for a support-form submission.
+ *
+ * This email used to be plain text dropped straight into the HTML body (see
+ * `src/lib/email.ts`), so every line break collapsed and the whole report
+ * arrived as one unstyled run-on paragraph. The fields are structured here
+ * instead, and the plain-text version travels alongside as the real text part.
+ *
+ * Everything interpolated is USER INPUT or user-influenced. It is rendered as
+ * JSX text children, never as `dangerouslySetInnerHTML`, so React escapes it —
+ * a report whose message contains `<script>` or `<img onerror=…>` arrives as
+ * the literal characters the user typed. `renderMessage` preserves newlines
+ * with real <br/> elements rather than by injecting markup.
+ */
+
+export interface SupportNotificationProps {
+    feedbackId: string
+    feedbackType: string
+    wantsReply: boolean
+    message: string
+    expectedOutcome?: string
+    appLabel: string
+    environment: string
+    platform: string
+    route: string
+    userLabel: string
+    posthogSessionId?: string
+    posthogDistinctId?: string
+    sentryEventId?: string
+    sentryUrl?: string
+}
+
+/** Preserve the author's line breaks as <br/> — never by injecting markup. */
+function renderMessage(value: string) {
+    const lines = value.split('\n')
+    return lines.map((line, index) => (
+        <span key={index}>
+            {line}
+            {index < lines.length - 1 ? <br /> : null}
+        </span>
+    ))
+}
+
+const panel = {
+    backgroundColor: brand.bg,
+    border: `1px solid ${brand.border}`,
+    borderRadius: '10px',
+    padding: '16px 18px',
+    fontSize: '15px',
+    lineHeight: '25px',
+    color: brand.textPrimary,
+    margin: '0 0 24px',
+    whiteSpace: 'pre-wrap' as const,
+    wordBreak: 'break-word' as const,
+}
+
+const sectionLabel = {
+    color: brand.textMuted,
+    fontSize: '12px',
+    fontWeight: 700 as const,
+    letterSpacing: '0.7px',
+    lineHeight: '18px',
+    margin: '0 0 8px',
+    textTransform: 'uppercase' as const,
+}
+
+const contextCell = {
+    fontSize: '13px',
+    lineHeight: '20px',
+    padding: '5px 0',
+    color: brand.textSecondary,
+    verticalAlign: 'top' as const,
+}
+
+/** One label/value row in the context block. Values wrap rather than overflow. */
+function ContextRow({ label, value }: { label: string; value: string }) {
+    return (
+        <tr>
+            <td style={{ ...contextCell, width: '38%', fontWeight: 600 }}>
+                {label}
+            </td>
+            <td
+                style={{
+                    ...contextCell,
+                    color: brand.textPrimary,
+                    wordBreak: 'break-word',
+                }}
+            >
+                {value}
+            </td>
+        </tr>
+    )
+}
+
+export default function SupportNotificationTemplate(
+    props: SupportNotificationProps,
+) {
+    const {
+        feedbackId,
+        feedbackType,
+        wantsReply,
+        message,
+        expectedOutcome,
+        appLabel,
+        environment,
+        platform,
+        route,
+        userLabel,
+        posthogSessionId,
+        posthogDistinctId,
+        sentryEventId,
+        sentryUrl,
+    } = props
+
+    // The inbox preview line: the type plus the opening of what they wrote,
+    // so a triage decision is possible without opening the mail.
+    const preview = `${feedbackType} — ${message.slice(0, 90)}`
+
+    return (
+        <EmailLayout
+            previewText={preview}
+            footerNote={
+                wantsReply
+                    ? 'Reply to this email and your response goes straight to the customer.'
+                    : undefined
+            }
+        >
+            <h1 style={text.heading}>New support request</h1>
+
+            <table
+                role="presentation"
+                width="100%"
+                cellPadding={0}
+                cellSpacing={0}
+                style={{ margin: '0 0 24px' }}
+            >
+                <tbody>
+                    <tr>
+                        <td>
+                            <span
+                                style={{
+                                    backgroundColor: brand.orangeSoft,
+                                    border: `1px solid ${brand.orangeGlow}`,
+                                    borderRadius: '999px',
+                                    color: brand.orangeDark,
+                                    display: 'inline-block',
+                                    fontSize: '12px',
+                                    fontWeight: 700,
+                                    letterSpacing: '0.4px',
+                                    padding: '5px 14px',
+                                    textTransform: 'uppercase',
+                                }}
+                            >
+                                {feedbackType}
+                            </span>
+                            <span
+                                style={{
+                                    color: brand.textMuted,
+                                    fontSize: '13px',
+                                    paddingLeft: '10px',
+                                }}
+                            >
+                                {wantsReply
+                                    ? 'Wants a reply'
+                                    : 'No reply requested'}
+                            </span>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+
+            {wantsReply ? (
+                <EmailNotice>
+                    This customer asked for a reply. Replying to this email
+                    reaches them directly.
+                </EmailNotice>
+            ) : null}
+
+            <div style={{ height: wantsReply ? '24px' : '0' }} />
+
+            <p style={sectionLabel}>Message</p>
+            <div style={panel}>{renderMessage(message)}</div>
+
+            {expectedOutcome ? (
+                <>
+                    <p style={sectionLabel}>Expected outcome</p>
+                    <div style={panel}>{renderMessage(expectedOutcome)}</div>
+                </>
+            ) : null}
+
+            {sentryUrl && sentryEventId ? (
+                <>
+                    <p style={sectionLabel}>Error report</p>
+                    <p style={{ ...text.body, margin: '0 0 24px' }}>
+                        <a href={sentryUrl} style={text.link}>
+                            Open Sentry event {sentryEventId}
+                        </a>
+                    </p>
+                </>
+            ) : null}
+
+            <div style={text.divider} />
+
+            <p style={sectionLabel}>Context</p>
+            <table
+                role="presentation"
+                width="100%"
+                cellPadding={0}
+                cellSpacing={0}
+            >
+                <tbody>
+                    <ContextRow label="Feedback ID" value={feedbackId} />
+                    <ContextRow label="App" value={appLabel} />
+                    <ContextRow label="Environment" value={environment} />
+                    <ContextRow label="Platform" value={platform} />
+                    <ContextRow label="Route" value={route} />
+                    <ContextRow label="User" value={userLabel} />
+                    {posthogSessionId ? (
+                        <ContextRow
+                            label="PostHog session"
+                            value={posthogSessionId}
+                        />
+                    ) : null}
+                    {posthogDistinctId ? (
+                        <ContextRow
+                            label="PostHog distinct id"
+                            value={posthogDistinctId}
+                        />
+                    ) : null}
+                </tbody>
+            </table>
+        </EmailLayout>
+    )
+}

--- a/apps/caramel-app/scripts/render-support-email-preview.mts
+++ b/apps/caramel-app/scripts/render-support-email-preview.mts
@@ -1,0 +1,58 @@
+/**
+ * Render the support-notification email to a file for visual inspection.
+ *
+ * Not part of the build or the test suite — a developer tool for eyeballing the
+ * template the way a mail client will, which is the only way this class of bug
+ * (a body that renders fine in code review and arrives as a wall of text) gets
+ * caught before an operator sees it.
+ *
+ *   pnpm --filter caramel-app exec tsx scripts/render-support-email-preview.mts <out.html>
+ */
+import { render } from '@react-email/render'
+import { writeFileSync } from 'node:fs'
+import * as TemplateModule from '../emails/SupportNotificationTemplate'
+
+// tsx loads this .tsx through CJS interop, which wraps the default export one
+// or two levels deep (`default`, then `default.default`) depending on the
+// resolver; under vitest it is the plain function. Unwrap until it is callable
+// rather than guessing a fixed depth.
+function unwrapDefault(mod: unknown): typeof TemplateModule.default {
+    let candidate: unknown = mod
+    for (let depth = 0; depth < 4; depth += 1) {
+        if (typeof candidate === 'function') {
+            return candidate as typeof TemplateModule.default
+        }
+        candidate = (candidate as { default?: unknown })?.default
+    }
+    throw new Error(
+        'SupportNotificationTemplate default export is not callable',
+    )
+}
+
+const SupportNotificationTemplate = unwrapDefault(TemplateModule)
+
+// The real 2026-08-14 production submission (feedback id 0610c6dd-…), so the
+// preview shows genuine content — multi-line message included — rather than
+// lorem ipsum that would hide the line-break handling.
+const html = await render(
+    SupportNotificationTemplate({
+        feedbackId: '0610c6dd-8dfe-4d75-9319-2044809345ac',
+        feedbackType: 'problem',
+        wantsReply: true,
+        message:
+            "The extension, no matter which website I visit just says \"Couldn't load coupons Check your connection and try again.\" \nNothing is wrong with my connection that I'm aware of and I'm not using any sort of VPN either.",
+        expectedOutcome: undefined,
+        appLabel: 'caramel v0.1.0',
+        environment: 'production',
+        platform: 'web',
+        route: '/support',
+        userLabel: '33ce6015-1d08-4195-a96d-e80f01ddaefb',
+        posthogSessionId: '01a00045-caae-77f0-bc02-e7f836409f00',
+        posthogDistinctId: '33ce6015-1d08-4195-a96d-e80f01ddaefb',
+    }),
+)
+
+const out = process.argv[2]
+if (!out) throw new Error('usage: render-support-email-preview.mts <out.html>')
+writeFileSync(out, html, 'utf8')
+console.log(`wrote ${out} (${Buffer.byteLength(html)} bytes)`)

--- a/apps/caramel-app/src/app/api/support/route.ts
+++ b/apps/caramel-app/src/app/api/support/route.ts
@@ -13,6 +13,7 @@
 // capture a first-class `support_request_submitted` event instead of survey
 // responses. If a survey is created later, a `POSTHOG_SUPPORT_SURVEY_ID` env
 // var could route submissions to it — do NOT invent an id before one exists.
+import SupportNotificationTemplate from '@/emails/SupportNotificationTemplate'
 import { APP_ID } from '@/lib/analytics/posthogDataset'
 import { captureServerEvent } from '@/lib/analytics/posthogServer'
 import { withRoute } from '@/lib/api/withRoute'
@@ -20,6 +21,7 @@ import { auth } from '@/lib/auth/auth'
 import { sendEmail } from '@/lib/email'
 import { env } from '@/lib/env'
 import { APP_VERSION } from '@/lib/env.client'
+import { render } from '@react-email/render'
 import * as Sentry from '@sentry/nextjs'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
@@ -77,6 +79,18 @@ const SupportBodySchema = z
 
 type SupportBody = z.infer<typeof SupportBodySchema>
 
+/** The Sentry issue-search URL for an event id, or undefined when there is none.
+ *
+ * Org slug 'devino' is the real, known Sentry org (next.config.mjs). Shared by
+ * both body parts so the text and the HTML can never link to different places.
+ */
+function sentryIssueUrl(sentryEventId: string | undefined): string | undefined {
+    if (!sentryEventId) return undefined
+    return `https://devino.sentry.io/organizations/devino/issues/?query=${encodeURIComponent(
+        sentryEventId,
+    )}`
+}
+
 /** Plain-text support email body — every field an operator needs to triage. */
 function buildEmailText(input: {
     body: SupportBody
@@ -104,17 +118,46 @@ function buildEmailText(input: {
         `PostHog session: ${body.posthog_session_id ?? '(none)'}`,
         `PostHog distinct id: ${body.posthog_distinct_id ?? '(none)'}`,
     ]
-    if (body.sentry_event_id) {
+    const sentryUrl = sentryIssueUrl(body.sentry_event_id)
+    if (body.sentry_event_id && sentryUrl) {
         lines.push(`Sentry event id: ${body.sentry_event_id}`)
-        // Org slug 'devino' is the real, known Sentry org (next.config.mjs);
-        // this searches issues by the event id.
-        lines.push(
-            `Sentry: https://devino.sentry.io/organizations/devino/issues/?query=${encodeURIComponent(
-                body.sentry_event_id,
-            )}`,
-        )
+        lines.push(`Sentry: ${sentryUrl}`)
     }
     return lines.join('\n')
+}
+
+/** The HTML part — the same fields, structured, on the shared Caramel layout.
+ *
+ * Deliberately NOT given a PostHog replay link: a replay URL needs the project
+ * id, and no env in this app carries one (only the E2E test project has an id,
+ * and that is a different project). The session and distinct ids are rendered
+ * as selectable text instead — a guessed URL that 404s is worse than an id the
+ * operator can paste.
+ */
+async function buildEmailHtml(input: {
+    body: SupportBody
+    userId: string | undefined
+    environment: string
+}): Promise<string> {
+    const { body, userId, environment } = input
+    return render(
+        SupportNotificationTemplate({
+            feedbackId: body.feedback_id,
+            feedbackType: body.feedback_type,
+            wantsReply: body.wants_reply,
+            message: body.message,
+            expectedOutcome: body.expected_outcome,
+            appLabel: `${APP_ID} v${APP_VERSION}`,
+            environment,
+            platform: 'web',
+            route: body.route ?? '(unknown)',
+            userLabel: userId ?? 'anonymous',
+            posthogSessionId: body.posthog_session_id,
+            posthogDistinctId: body.posthog_distinct_id,
+            sentryEventId: body.sentry_event_id,
+            sentryUrl: sentryIssueUrl(body.sentry_event_id),
+        }),
+    )
 }
 
 export const POST = withRoute(
@@ -194,6 +237,10 @@ export const POST = withRoute(
                 await sendEmail({
                     to: supportTo,
                     subject: `[Caramel support] ${body.feedback_type} — ${body.feedback_id}`,
+                    // Both parts, from the same submission: the designed HTML
+                    // the operator reads, and the plain text as the real text
+                    // alternative (it used to be BOTH, which is the bug).
+                    html: await buildEmailHtml({ body, userId, environment }),
                     text: buildEmailText({ body, userId, environment }),
                     // replyTo = the customer, ONLY when they want a reply; never
                     // the from/sender.

--- a/apps/caramel-app/src/lib/email.ts
+++ b/apps/caramel-app/src/lib/email.ts
@@ -12,6 +12,41 @@ type EmailPayload = {
     replyTo?: string
 }
 
+/** HTML-escape every character that could change the shape of the markup. */
+const escapeHtml = (value: string) =>
+    value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+
+/**
+ * Minimal HTML for a caller that only has plain text.
+ *
+ * Sending the raw text as the HTML body — which this module used to do — is
+ * what made the support notification arrive malformed: HTML collapses newlines,
+ * so a carefully line-formatted report rendered as one unstyled run-on wall
+ * (measured on the real production message, whose `html` and `text` fields were
+ * byte-identical). It is also an injection hole, because the support message is
+ * user input: `<script>` typed into the form would have been markup in the
+ * operator's inbox, not text.
+ *
+ * So the text is escaped first and its line breaks become real <br/>, inside a
+ * readable system-font wrapper. A caller with a designed template passes `html`
+ * and never reaches this.
+ */
+export const textToHtml = (value: string) => {
+    const body = escapeHtml(value).replace(/\r?\n/g, '<br />')
+    return (
+        "<div style=\"font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto," +
+        "'Helvetica Neue',Arial,sans-serif;font-size:15px;line-height:24px;color:#1a1a2e;" +
+        'max-width:600px;margin:0 auto;padding:16px;">' +
+        body +
+        '</div>'
+    )
+}
+
 const getClient = () => {
     const apiKey = env.USESEND_API_KEY
     if (!apiKey) {
@@ -31,9 +66,9 @@ export const sendEmail = async (data: EmailPayload) => {
         from: `${fromName} <${fromEmail}>`,
         to: data.to,
         subject: data.subject,
-        // Keep the pre-existing text→html fold so text-only callers
-        // (sites/suggest) still render, but ALSO send a real text part now.
-        html: data.html || data.text || '',
+        // A text-only caller gets ESCAPED, <br/>-preserving HTML — never its
+        // raw newline-formatted text dropped into the HTML body. See textToHtml.
+        html: data.html || (data.text ? textToHtml(data.text) : ''),
         text: data.text,
         // Only set replyTo when provided — usesend treats an absent field
         // differently from an empty string.

--- a/apps/caramel-app/tests/unit/email-replyTo.test.ts
+++ b/apps/caramel-app/tests/unit/email-replyTo.test.ts
@@ -47,20 +47,58 @@ describe('sendEmail — replyTo + real text field', () => {
         expect(payload.text).toBe('a message')
     })
 
-    it('sends a real text part AND (backward-compat) folds text into html', async () => {
+    it('never sends a text-only caller’s raw text as the html body', async () => {
+        // This pin used to assert the OPPOSITE — that html === the raw text —
+        // as "backward compat". That fold is what shipped the malformed support
+        // notification: HTML collapses newlines, so the operator's mail arrived
+        // as one unstyled run-on wall (measured on the real production message,
+        // whose html and text fields were byte-identical, 586 bytes each).
         await sendEmail({
             to: 'support@unotes.net',
             subject: 'hi',
-            text: 'plain body',
+            text: 'line one\nline two',
         })
 
         const payload = sendMock.mock.calls[0]![0] as {
             html?: string
             text?: string
         }
-        expect(payload.text).toBe('plain body')
-        // sites/suggest historically had no html; the fold keeps a body.
-        expect(payload.html).toBe('plain body')
+        expect(payload.text).toBe('line one\nline two')
+        expect(payload.html).not.toBe('line one\nline two')
+        // The line break survives as markup rather than collapsing.
+        expect(payload.html).toContain('line one<br />line two')
+    })
+
+    it('escapes a text-only body so user input can never become markup', async () => {
+        // The support message is user input. Folding it into html raw made a
+        // report containing tags an injection into the operator's inbox.
+        await sendEmail({
+            to: 'support@unotes.net',
+            subject: 'hi',
+            text: 'Message:\n<script>alert(1)</script> & "quoted"',
+        })
+
+        const payload = sendMock.mock.calls[0]![0] as { html?: string }
+        expect(payload.html).not.toContain('<script>')
+        expect(payload.html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+        expect(payload.html).toContain('&amp;')
+        expect(payload.html).toContain('&quot;quoted&quot;')
+    })
+
+    it('leaves a caller-supplied html body exactly as given', async () => {
+        await sendEmail({
+            to: 'support@unotes.net',
+            subject: 'hi',
+            html: '<p>designed</p>',
+            text: 'designed',
+        })
+
+        const payload = sendMock.mock.calls[0]![0] as {
+            html?: string
+            text?: string
+        }
+        expect(payload.html).toBe('<p>designed</p>')
+        expect(payload.text).toBe('designed')
     })
 
     it('omits replyTo entirely when not provided', async () => {

--- a/apps/caramel-app/tests/unit/support-email-template.test.ts
+++ b/apps/caramel-app/tests/unit/support-email-template.test.ts
@@ -1,0 +1,113 @@
+import SupportNotificationTemplate from '@/emails/SupportNotificationTemplate'
+import { render } from '@react-email/render'
+import { describe, expect, it } from 'vitest'
+
+// The support notification is the email the owner reads every time a user
+// reports something, and until 2026-08-14 it was the plain-text body dropped
+// straight into the HTML slot: newlines collapsed, no styling, user input
+// unescaped. These pin the three properties that fixes it — it is real HTML,
+// the author's line breaks survive, and nothing a user types becomes markup.
+
+const BASE = {
+    feedbackId: '0610c6dd-8dfe-4d75-9319-2044809345ac',
+    feedbackType: 'problem',
+    wantsReply: true,
+    message: 'first line\nsecond line',
+    appLabel: 'caramel v0.1.0',
+    environment: 'production',
+    platform: 'web',
+    route: '/support',
+    userLabel: '33ce6015-1d08-4195-a96d-e80f01ddaefb',
+    posthogSessionId: '01a00045-caae-77f0-bc02-e7f836409f00',
+    posthogDistinctId: '33ce6015-1d08-4195-a96d-e80f01ddaefb',
+}
+
+const renderTemplate = (overrides: Record<string, unknown> = {}) =>
+    render(SupportNotificationTemplate({ ...BASE, ...overrides } as never))
+
+describe('support notification template', () => {
+    it('renders a styled HTML document, not the plain-text body', async () => {
+        const html = await renderTemplate()
+
+        expect(html).toContain('<table')
+        expect(html).toContain('style=')
+        // Proof it rides the SHARED EmailLayout rather than inventing a look:
+        // the layout's page background, its card border, and its logo.
+        expect(html).toContain('#fdf8f5')
+        expect(html).toContain('#f0e4db')
+        expect(html).toContain('https://grabcaramel.com/full-logo.png')
+    })
+
+    it('preserves the author’s line breaks instead of collapsing them', async () => {
+        const html = await renderTemplate({ message: 'first line\nsecond' })
+
+        expect(html).toContain('<br')
+        expect(html).toContain('first line')
+        expect(html).toContain('second')
+    })
+
+    it('escapes user input so a report can never inject markup', async () => {
+        const html = await renderTemplate({
+            message: '<script>alert("xss")</script>',
+            expectedOutcome: '<img src=x onerror=alert(1)>',
+        })
+
+        expect(html).not.toContain('<script>alert')
+        expect(html).not.toContain('<img src=x onerror')
+        expect(html).toContain('&lt;script&gt;')
+        expect(html).toContain('&lt;img')
+    })
+
+    it('shows every field an operator needs to triage', async () => {
+        const html = await renderTemplate({
+            expectedOutcome: 'coupons should load',
+        })
+
+        for (const value of [
+            BASE.feedbackId,
+            BASE.appLabel,
+            BASE.environment,
+            BASE.route,
+            BASE.userLabel,
+            BASE.posthogSessionId,
+            BASE.posthogDistinctId,
+            'first line',
+            'coupons should load',
+        ]) {
+            expect(html).toContain(value)
+        }
+    })
+
+    it('links the Sentry event when there is one, and omits the section otherwise', async () => {
+        const withSentry = await renderTemplate({
+            sentryEventId: 'abc123',
+            sentryUrl:
+                'https://devino.sentry.io/organizations/devino/issues/?query=abc123',
+        })
+        expect(withSentry).toContain(
+            'https://devino.sentry.io/organizations/devino/issues/?query=abc123',
+        )
+
+        const without = await renderTemplate()
+        expect(without).not.toContain('sentry.io')
+    })
+
+    it('tells the operator that replying reaches the customer, only when they asked for a reply', async () => {
+        // The shared layout's default footer says "do not reply" — which is the
+        // opposite of the truth here, because the route sets replyTo to the
+        // customer whenever they asked for one.
+        const wants = await renderTemplate({ wantsReply: true })
+        expect(wants).toContain('goes straight to the customer')
+        expect(wants).not.toContain('Please do not reply')
+
+        const doesNot = await renderTemplate({ wantsReply: false })
+        expect(doesNot).toContain('Please do not reply')
+    })
+
+    it('omits the expected-outcome section entirely when none was given', async () => {
+        const html = await renderTemplate({ expectedOutcome: undefined })
+
+        expect(html).not.toContain('Expected outcome')
+        expect(html).not.toContain('(none provided)')
+    })
+})

--- a/apps/caramel-app/tests/unit/support-route.test.ts
+++ b/apps/caramel-app/tests/unit/support-route.test.ts
@@ -98,6 +98,31 @@ describe('POST /api/support — support/feedback flow', () => {
         expect(sendEmailMock).toHaveBeenCalledTimes(1)
     })
 
+    it('sends BOTH a rendered html part and the plain-text part, carrying the same report', async () => {
+        // The bug this pins: the route used to pass `text` only, and email.ts
+        // dropped that raw text into the html body — so the operator's copy
+        // arrived as one unstyled run-on wall with every newline collapsed.
+        // Deleting the html argument here is the edit that reinstates it.
+        await POST(supportRequest(validBody({ message: 'line one\nline two' })))
+
+        const payload = sendEmailMock.mock.calls[0]![0] as {
+            html?: string
+            text?: string
+        }
+
+        expect(payload.html).toBeTruthy()
+        expect(payload.text).toBeTruthy()
+        expect(payload.html).not.toBe(payload.text)
+        // The html is real markup on the shared Caramel layout...
+        expect(payload.html).toContain('<table')
+        expect(payload.html).toContain('#fdf8f5')
+        expect(payload.html).toContain('<br')
+        // ...and the text part stays the plain triage dump it always was.
+        expect(payload.text).toContain('Feedback ID:')
+        expect(payload.text).toContain('line one\nline two')
+        expect(payload.text).not.toContain('<table')
+    })
+
     it('authenticated submit uses the SESSION user_id + email and IGNORES client-supplied identity', async () => {
         getSessionMock.mockResolvedValue({
             user: { id: 'user-1', email: 'real@user.com' },


### PR DESCRIPTION
## The support notification was plain text dropped into the HTML body

Owner-reported: a Caramel app email is malformed and unstyled. It is the **support notification** — the mail sent to the support inbox every time someone submits the support form.

**Confirmed on the real production message**, not inferred: message `cmssxqe8o00ktpc422z23xh39` (2026-08-14 12:40 UTC, to `aladdin@devino.ca`) came back from the UseSend API with `html` and `text` **byte-identical, 586 bytes each**.

### Root cause

`src/lib/email.ts:36` — `html: data.html || data.text || ''`. A caller that passes only `text` had its plain text used verbatim as the HTML body. HTML collapses newlines, so `buildEmailText()`'s carefully sectioned report ("Message:", "Expected outcome:", "--- context ---") rendered as one unstyled run-on paragraph in the default serif. Two callers were text-only: `api/support/route.ts` (this one) and `api/sites/suggest/route.ts`.

A second, quieter defect in the same line: the support message is **user input**, so folding it into HTML unescaped meant a report containing `<script>` or `<img onerror=…>` became markup in the operator's inbox.

Before / after, rendered from the real submission:

| Before | After |
|---|---|
| Unstyled serif wall, every line break collapsed | Branded card on the existing `EmailLayout`, structure preserved |

### The fix, at both levels

**1. A real template** — `emails/SupportNotificationTemplate.tsx`, built on the **existing** `EmailLayout`/`EmailNotice`/`text` design system the auth emails already use (same brand palette, same 580px card, same logo). Type badge, reply-wanted state, the message with its line breaks intact, expected outcome, a clickable Sentry link, and a readable context table. The route now sends the rendered HTML **and** keeps `buildEmailText()` as the real plain-text part.

**2. `email.ts` no longer folds.** A text-only caller now gets `textToHtml()` — HTML-escaped, `<br/>`-preserving, in a readable wrapper. `sites/suggest` is fixed by the same change.

Escaping is by construction: everything interpolated is a JSX text child, never `dangerouslySetInnerHTML`, so React escapes it; line breaks are real `<br/>` elements.

Two deliberate non-changes, both to avoid inventing things:
- **No PostHog replay link.** A replay URL needs the project id and no env in this app carries one (only the E2E *test* project has an id — a different project). The session/distinct ids are selectable text instead; a guessed URL that 404s is worse.
- **`EmailLayout` gained one optional `footerNote` prop.** Its default footer says "Please do not reply", which is the opposite of the truth here — the route sets `replyTo` to the customer. Default behaviour is unchanged for the other two templates.

### Tests

`tests/unit/support-email-template.test.ts` (8, new) · `tests/unit/email-replyTo.test.ts` (extended) · `tests/unit/support-route.test.ts` (+1).

Note one **existing pin asserted the bug**: `email-replyTo.test.ts` previously required `html === the raw text` as "backward compat". That expectation is inverted now, with the reason recorded.

**All 4 mutations red-proofed** — reintroduce the defect and the pin goes red: the fold returns · the wrapper stops escaping · the template renders the message as one collapsed run · the route stops sending an html part (this one initially stayed green, which is why the route pin was added).

### Verification

- Rendered from the **real** production submission and inspected in a browser at **desktop and 375px** (no overflow: 360px content in a 375px viewport).
- Mojibake seen in a first screenshot was traced to my preview server omitting a charset — served as UTF-8 the glyphs are correct, so the template needed no change. Recording it because it looked like a real defect.
- **No email was sent.** Rendered-file inspection only.

### Gates

`tsc --noEmit` · `eslint` · `prettier --check` · `knip` · **`vitest run` → 73 files, 680 passed** · husky pre-commit (lint-staged, type-check, knip ×2, prisma validate) green.
