### PR TITLE
DO NOT MERGE YET — fix(ext-probe): a store we never reached stops reading as a store we cannot seed

### DIFF
--- a/apps/caramel-extension/tests/ext-probe-platform-evidence.test.mjs
+++ b/apps/caramel-extension/tests/ext-probe-platform-evidence.test.mjs
@@ -1,0 +1,405 @@
+// "No platform marker found" was one sentence covering three different worlds,
+// and the batch of 2026-08-14 shows the cost: 11 of 24 stores ended at
+// `INCONCLUSIVE_SEED` with that sentence, no cart, no apply attempt, no verdict
+// for the repair loop to act on. Three of them — kizik.com,
+// peterthomasroth.com, venus.com — are plain Shopify whose `/products.json`
+// answered `200` from the same machine minutes later, and kizik detected
+// `shopify` cleanly on a re-run. The detector was right about the document it
+// was shown and wrong about which document that was, and the report could not
+// say so.
+//
+// What is pinned here is the difference between the three worlds:
+//   - the store answered, and the answer is "not this platform"  (404)
+//   - the store refused to answer                                (403/429/…)
+//   - we were looking at the wrong page                          (non-2xx nav)
+//
+// Everything runs against a stubbed `globalThis.fetch`. No store is touched.
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+    capabilityProbeOrder,
+    CART_API_PROBES,
+    describeDocumentInPage,
+    detectPlatformInPage,
+    normalizePlatformHint,
+    probeCartApiInPage,
+    resolvePlatform,
+    SEEDABLE_PLATFORMS,
+    shouldRelookAtDocument,
+} from '../../../tools/ext-probe/seed.mjs'
+
+const originalFetch = globalThis.fetch
+afterEach(() => {
+    globalThis.fetch = originalFetch
+    document.body.innerHTML = ''
+    document.body.className = ''
+    document.head.innerHTML = ''
+    delete window.Shopify
+    delete window.BCData
+    delete window.wc_add_to_cart_params
+})
+
+/** A store that answers `answers[path-prefix]` and 404s everything else. */
+function stubEndpoints(answers) {
+    const seen = []
+    globalThis.fetch = async url => {
+        const u = String(url)
+        seen.push(u)
+        for (const [prefix, reply] of Object.entries(answers))
+            if (u.startsWith(prefix)) {
+                if (reply instanceof Error) throw reply
+                return {
+                    ok: reply.status >= 200 && reply.status < 300,
+                    status: reply.status,
+                    json: async () => {
+                        if (reply.json === undefined)
+                            throw new SyntaxError('Unexpected token <')
+                        return reply.json
+                    },
+                }
+            }
+        return { ok: false, status: 404, json: async () => ({}) }
+    }
+    return seen
+}
+
+const shopifyFeed = { status: 200, json: { products: [{ id: 1 }] } }
+
+describe('a store that serves its assets from its OWN host is still Shopify', () => {
+    it('detects the first-party /cdn/shop asset path', () => {
+        // Counted on peterthomasroth.com, 2026-08-14: 92 first-party
+        // `/cdn/shop/` tags against 4 on cdn.shopify.com. A store that drops
+        // the preconnect carries no cdn.shopify.com tag at all.
+        document.head.innerHTML =
+            '<script src="//www.example.com/cdn/shop/t/426/assets/theme.js"></script>'
+        expect(detectPlatformInPage()).toEqual({
+            platform: 'shopify',
+            signal: 'first-party /cdn/shop asset',
+        })
+    })
+
+    it('detects the shopifycloud module path the same way', () => {
+        document.head.innerHTML =
+            '<script src="//x.com/cdn/shopifycloud/shop-js/modules/v2/loader.js"></script>'
+        expect(detectPlatformInPage().platform).toBe('shopify')
+    })
+
+    it('still prefers the global when both are present', () => {
+        window.Shopify = { shop: 'x.myshopify.com' }
+        document.head.innerHTML =
+            '<script src="//x.com/cdn/shop/t/1/assets/a.js"></script>'
+        expect(detectPlatformInPage().signal).toBe('window.Shopify.shop')
+    })
+})
+
+describe('when markup finds nothing, the platform’s own endpoint is asked', () => {
+    it('names the platform whose feed answered with the shape that platform returns', async () => {
+        stubEndpoints({ '/products.json': shopifyFeed })
+        const out = await probeCartApiInPage({
+            order: SEEDABLE_PLATFORMS,
+            endpoints: CART_API_PROBES,
+        })
+
+        expect(out.platform).toBe('shopify')
+        expect(out.attempts.at(-1)).toMatchObject({
+            platform: 'shopify',
+            status: 200,
+            ok: true,
+            shape: 'products-array',
+        })
+    })
+
+    it('stops asking once one endpoint answers — the rest are never fetched', async () => {
+        const seen = stubEndpoints({ '/products.json': shopifyFeed })
+        await probeCartApiInPage({
+            order: ['shopify', 'woocommerce', 'bigcommerce'],
+            endpoints: CART_API_PROBES,
+        })
+        expect(seen).toEqual(['/products.json?limit=1'])
+    })
+
+    it('a 200 of the WRONG shape is not that platform', async () => {
+        // Measured on 5 of 167 stores (publiclands.com, wearpact.com,
+        // gamefly.com, secretsales.com, strawberrynet.com): an SPA catch-all
+        // answers 200 with HTML. A status-only check names every one of them
+        // the wrong platform and then seeds with someone else's endpoints.
+        stubEndpoints({ '/products.json': { status: 200 } })
+        const out = await probeCartApiInPage({
+            order: ['shopify'],
+            endpoints: CART_API_PROBES,
+        })
+
+        expect(out.platform).toBe('unknown')
+        expect(out.attempts[0]).toMatchObject({
+            status: 200,
+            shape: 'not-json',
+        })
+    })
+
+    it('a 200 of the wrong JSON shape is not that platform either', async () => {
+        stubEndpoints({ '/products.json': { status: 200, json: { ok: true } } })
+        const out = await probeCartApiInPage({
+            order: ['shopify'],
+            endpoints: CART_API_PROBES,
+        })
+        expect(out.attempts[0].shape).toBe('unexpected-json')
+        expect(out.platform).toBe('unknown')
+    })
+
+    it('records a network failure as an error, never as an absent endpoint', async () => {
+        stubEndpoints({ '/products.json': new TypeError('Failed to fetch') })
+        const out = await probeCartApiInPage({
+            order: ['shopify'],
+            endpoints: CART_API_PROBES,
+        })
+        expect(out.attempts[0].status).toBeNull()
+        expect(out.attempts[0].error).toMatch(/Failed to fetch/)
+    })
+
+    it('every probe keeps its own status, so the trail is readable afterwards', async () => {
+        stubEndpoints({
+            '/products.json': { status: 403 },
+            '/wp-json': { status: 404 },
+            '/api/storefront': { status: 503 },
+        })
+        const out = await probeCartApiInPage({
+            order: SEEDABLE_PLATFORMS,
+            endpoints: CART_API_PROBES,
+        })
+        expect(out.attempts.map(a => [a.platform, a.status])).toEqual([
+            ['shopify', 403],
+            ['woocommerce', 404],
+            ['bigcommerce', 503],
+        ])
+    })
+})
+
+const noMarkup = { platform: 'unknown', signal: 'no platform marker found' }
+const attemptsOf = statuses =>
+    statuses.map(([platform, status]) => ({
+        platform,
+        endpoint: CART_API_PROBES[platform].path,
+        status,
+        ok: false,
+        shape: null,
+        error: null,
+    }))
+
+describe('a blocked marker is reported differently from an absent one', () => {
+    it('ABSENT: the store answered 404 everywhere — it is not one of ours', () => {
+        const out = resolvePlatform({
+            markup: noMarkup,
+            capability: {
+                platform: 'unknown',
+                signal: 'no cart API answered',
+                attempts: attemptsOf([
+                    ['shopify', 404],
+                    ['woocommerce', 404],
+                    ['bigcommerce', 404],
+                ]),
+            },
+            hint: null,
+        })
+
+        expect(out.platform).toBe('unknown')
+        expect(out.blocked).toBe(false)
+        expect(out.signal).toContain('shopify 404')
+        expect(out.signal).not.toContain('refused')
+    })
+
+    it('BLOCKED: every endpoint refused — that is not evidence about the platform', () => {
+        const out = resolvePlatform({
+            markup: noMarkup,
+            capability: {
+                platform: 'unknown',
+                signal: 'no cart API answered',
+                attempts: attemptsOf([
+                    ['shopify', 403],
+                    ['woocommerce', 429],
+                    ['bigcommerce', 503],
+                ]),
+            },
+            hint: null,
+        })
+
+        expect(out.blocked).toBe(true)
+        expect(out.signal).toContain(
+            'NOT evidence the store is on another platform',
+        )
+    })
+
+    it('one honest 404 among refusals is enough to stop calling it blocked', () => {
+        const out = resolvePlatform({
+            markup: noMarkup,
+            capability: {
+                platform: 'unknown',
+                signal: 'no cart API answered',
+                attempts: attemptsOf([
+                    ['shopify', 403],
+                    ['woocommerce', 404],
+                    ['bigcommerce', 403],
+                ]),
+            },
+            hint: null,
+        })
+        expect(out.blocked).toBe(false)
+    })
+
+    it('no capability probe at all is not "blocked" — nothing was refused', () => {
+        const out = resolvePlatform({
+            markup: noMarkup,
+            capability: null,
+            hint: null,
+        })
+        expect(out.blocked).toBe(false)
+        expect(out.signal).toBe('no platform marker found')
+    })
+})
+
+describe('who decided, and what a hint may and may not do', () => {
+    it('markup decides and is recorded as the source', () => {
+        const out = resolvePlatform({
+            markup: { platform: 'shopify', signal: 'window.Shopify.shop' },
+            capability: null,
+            hint: null,
+        })
+        expect(out).toMatchObject({
+            platform: 'shopify',
+            source: 'markup',
+            hintAgreed: null,
+        })
+    })
+
+    it('the hint is HONOURED when markup is blind and the endpoint confirms', () => {
+        const out = resolvePlatform({
+            markup: { platform: 'unknown', signal: 'no platform marker found' },
+            capability: {
+                platform: 'woocommerce',
+                signal: 'woocommerce answered /wp-json/... with array',
+                attempts: [{ platform: 'woocommerce', status: 200, ok: true }],
+            },
+            hint: 'woocommerce',
+        })
+        expect(out).toMatchObject({
+            platform: 'woocommerce',
+            source: 'capability',
+            hint: 'woocommerce',
+            hintAgreed: true,
+        })
+    })
+
+    it('the hint asks its own endpoint FIRST and the others still follow', () => {
+        expect(capabilityProbeOrder('bigcommerce')).toEqual([
+            'bigcommerce',
+            'shopify',
+            'woocommerce',
+        ])
+        expect(capabilityProbeOrder(null)).toEqual([...SEEDABLE_PLATFORMS])
+        expect(capabilityProbeOrder('sfcc')).toEqual([...SEEDABLE_PLATFORMS])
+    })
+
+    it('a hint NEVER overrides markup — a replatformed store is seeded as it is today', () => {
+        // The hint comes from a config discovered at some point in the past.
+        // The global comes from the bundle the store is serving right now.
+        const out = resolvePlatform({
+            markup: { platform: 'bigcommerce', signal: 'window.BCData' },
+            capability: null,
+            hint: 'shopify',
+        })
+        expect(out.platform).toBe('bigcommerce')
+        expect(out.source).toBe('markup')
+        expect(out.hintAgreed).toBe(false)
+    })
+
+    it('a hint alone seeds NOTHING — with no confirming endpoint the answer stays unknown', () => {
+        const out = resolvePlatform({
+            markup: { platform: 'unknown', signal: 'no platform marker found' },
+            capability: {
+                platform: 'unknown',
+                signal: 'no cart API answered',
+                attempts: [{ platform: 'shopify', status: 404, ok: false }],
+            },
+            hint: 'shopify',
+        })
+        expect(out.platform).toBe('unknown')
+        expect(out.hintAgreed).toBe(false)
+    })
+
+    it('an unrecognised hint THROWS rather than being quietly dropped', () => {
+        // Dropped silently, the caller reads the resulting detection failure as
+        // a fact about the store.
+        expect(() => normalizePlatformHint('salesforce')).toThrow(
+            /unknown --platform-hint/,
+        )
+        expect(normalizePlatformHint(' Shopify ')).toBe('shopify')
+        expect(normalizePlatformHint(undefined)).toBeNull()
+        expect(normalizePlatformHint('')).toBeNull()
+    })
+})
+
+describe('the second look is taken on evidence, not on disappointment', () => {
+    const unknown = { platform: 'unknown', blocked: false }
+
+    it('a non-2xx navigation means we may not have been on the store', () => {
+        expect(
+            shouldRelookAtDocument({
+                navigationStatus: 403,
+                resolved: unknown,
+            }),
+        ).toBe(true)
+        expect(
+            shouldRelookAtDocument({
+                navigationStatus: 503,
+                resolved: unknown,
+            }),
+        ).toBe(true)
+    })
+
+    it('all endpoints refused means the same thing', () => {
+        expect(
+            shouldRelookAtDocument({
+                navigationStatus: 200,
+                resolved: { platform: 'unknown', blocked: true },
+            }),
+        ).toBe(true)
+    })
+
+    it('a store that simply is not ours does NOT pay for a second page load', () => {
+        // 48 of the 167 stores measured on 2026-08-14 carry no marker and no
+        // cart API at all. Reloading each of them every run buys nothing.
+        expect(
+            shouldRelookAtDocument({
+                navigationStatus: 200,
+                resolved: unknown,
+            }),
+        ).toBe(false)
+    })
+
+    it('a platform we DID name is never re-looked at', () => {
+        expect(
+            shouldRelookAtDocument({
+                navigationStatus: 403,
+                resolved: { platform: 'shopify', blocked: false },
+            }),
+        ).toBe(false)
+    })
+
+    it('an unknown navigation status is treated as "we do not know what we saw"', () => {
+        expect(
+            shouldRelookAtDocument({
+                navigationStatus: null,
+                resolved: unknown,
+            }),
+        ).toBe(true)
+    })
+})
+
+describe('the report says which document the detection ran against', () => {
+    it('carries the url, title, size and readyState', () => {
+        document.title = 'Just a moment...'
+        const out = describeDocumentInPage()
+        expect(out.title).toBe('Just a moment...')
+        expect(out.url).toBe(location.href)
+        expect(out.htmlBytes).toBeGreaterThan(0)
+        expect(typeof out.readyState).toBe('string')
+    })
+})

--- a/tools/ext-probe/README.md
+++ b/tools/ext-probe/README.md
@@ -36,6 +36,7 @@ node tools/ext-probe/probe.mjs <url> [width] [tag] [flags]
 | `--viewport WxH`     | `1920x1080`              | The viewport to measure at, in the spelling `agent_discovery` uses. Authoritative when given.                                                                                                                                                        |
 | `--width`/`--height` | `1920` / class default   | Set individually. A width alone picks the conventional height for its class (`--width 390` → 390x844), so a mobile pass is one flag.                                                                                                                 |
 | `--tag`              | `probe`                  | Same as the positional form.                                                                                                                                                                                                                         |
+| `--platform-hint`    | —                        | `shopify`/`woocommerce`/`bigcommerce`. Orders the cart-API probe so the likely endpoint is asked first, and names the platform when markup found none. Never overrides markup. An unrecognised value **throws before Chromium starts**.              |
 
 Human prose goes to **stderr**; stdout carries the JSON object and nothing else. Three artifacts always
 land in `--out-dir`: `ext-probe-<tag>-<width>.log`, `.json` and `.png`. The **report is an artifact,
@@ -120,6 +121,14 @@ the served config, the best available verdict is `AMBER_NO_INDICATORS` — never
             "cartApiOk": null, // the platform's cart endpoint answered
             "productsJsonOk": null, // the Shopify legs, set only on a Shopify run
             "cartJsOk": null,
+            "signal": null, // WHY that answer, incl. every cart-API status tried
+            "source": null, // markup | capability | null — which leg decided
+            "hint": null, // the caller's --platform-hint, echoed back
+            "hintAgreed": null, // whether the evidence agreed with it
+            "blocked": null, // every cart-API probe refused: we learned NOTHING
+            "navigationStatus": null, // HTTP status the detection ran against
+            "document": null, // {url,title,htmlBytes,readyState}, only when unknown
+            "firstLook": null, // set only when a second look was taken
         },
         "cartItemsAtArrival": null, // read BEFORE the wait window
         "config": {
@@ -247,6 +256,35 @@ them without reconstructing the theme's own `attribute_*` field names. On BigCom
 A platform with no seeder reports `INCONCLUSIVE_PLATFORM` and the run stops there. **A cart is never
 faked**: on Shopify the add's own status is the signal, and on both new platforms success is
 confirmed by re-reading the cart, so a `201` whose item never appears is not a seeded cart.
+
+### When markup finds nothing
+
+Markup detection answers the common case for free, and it used to be the ONLY leg — so
+`"no platform marker found"` was the single sentence covering a store we do not support, a store
+behind a challenge page, and a store whose markers were simply not in the document we happened to
+be shown. In the 2026-08-14 batch that sentence buried 11 of 24 stores, and three of them
+(kizik.com, peterthomasroth.com, venus.com) are plain Shopify that detected correctly on the very
+next run. A verdict the caller cannot read is not a verdict.
+
+Three legs now separate those cases:
+
+1. **The cart API is asked directly.** When markup finds nothing, each platform's own endpoint is
+   fetched — the same endpoint that platform's seeder is about to use, so a `200` is a licence to
+   seed rather than a second opinion. The JSON **shape** is checked, not just the status: 5 of the
+   167 stores measured that day answer `200` with their SPA's HTML on at least one of these paths.
+2. **Refusal is recorded as refusal.** Every attempt keeps its status, and `blocked: true` marks the
+   case where all of them were refused (401/403/407/429/451/503 or a network error) — "we learned
+   nothing", never "the store is on some other platform".
+3. **One second look, on evidence.** If the navigation was not `2xx`, or every endpoint refused, the
+   page is reloaded once and the same question asked again; `firstLook` keeps what the first attempt
+   saw. Not "retry whenever unknown" — a store we genuinely cannot seed would then pay for an extra
+   page load forever.
+
+`--platform-hint` lets the caller pass what the store's config implies. It orders the cart-API probe
+so the likely endpoint is asked first and names the platform when markup found none — but it never
+overrides markup, because a global the platform's own bundle set is the store speaking while a hint
+is our config guessing, and a store that replatformed since discovery would otherwise be seeded the
+old way.
 
 ## Store safety
 

--- a/tools/ext-probe/probe.mjs
+++ b/tools/ext-probe/probe.mjs
@@ -24,12 +24,19 @@ import { dirname, join, relative, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { chromium } from 'playwright'
 import {
+    capabilityProbeOrder,
+    CART_API_PROBES,
     countPromoInputsInPage,
     DEFAULT_PRODUCT_LIMIT,
+    describeDocumentInPage,
     detectPlatformInPage,
     MAX_REJECTED_ADDS,
+    normalizePlatformHint,
+    probeCartApiInPage,
     readCartStateInPage,
+    resolvePlatform,
     seedersByPlatform,
+    shouldRelookAtDocument,
 } from './seed.mjs'
 import {
     buildReport,
@@ -259,6 +266,10 @@ async function main() {
         throw new Error('no target url given')
     }
     const { width, height } = resolveViewport(flags, widthArg)
+    // Thrown BEFORE the browser launches: a hint the probe cannot honour is a
+    // caller bug, and swallowing it would leave that caller reading a detection
+    // failure as a fact about the store.
+    const platformHint = normalizePlatformHint(flags['platform-hint'])
     const tag = flags.tag || tagArg || 'probe'
     const extDir = resolve(process.env.EXT_DIR || flags.ext || DEFAULT_EXT_DIR)
     const waitMs = Number(process.env.PROBE_WAIT_MS || flags.wait || 30000)
@@ -359,10 +370,16 @@ async function main() {
 
         // An empty cart is not a checkout, and the extension is right not to show
         // there — so seed one first, the way the platform itself would.
-        await page.goto(target.origin, {
+        // The status is KEPT. A store that answers the probe's first
+        // navigation with a challenge, a consent wall or a 5xx serves a
+        // document carrying no platform marker, and the report used to record
+        // that as "no platform marker found" — indistinguishable from a store
+        // we genuinely do not recognise.
+        const firstNav = await page.goto(target.origin, {
             waitUntil: 'domcontentloaded',
             timeout: 60000,
         })
+        let navigationStatus = firstNav ? firstNav.status() : null
         if (!sw)
             sw = await ctx
                 .waitForEvent('serviceworker', { timeout: 15000 })
@@ -396,13 +413,72 @@ async function main() {
         // platform itself emits — detected ONCE and then passed to both the
         // seeder and the cart reader, so the two can never disagree about what
         // the store is.
-        const detected = await page.evaluate(detectPlatformInPage).catch(e => ({
-            platform: 'unknown',
-            signal: `detection failed: ${e.message}`,
-        }))
-        const platform = detected.platform
+        //
+        // `identify` is the whole ladder, kept in one place so the second look
+        // below is the SAME question asked again rather than a different one.
+        const identify = async () => {
+            const markup = await page
+                .evaluate(detectPlatformInPage)
+                .catch(e => ({
+                    platform: 'unknown',
+                    signal: `detection failed: ${e.message}`,
+                }))
+            // Markup is free and is the store's own bundle talking, so the
+            // endpoints are only asked when it found nothing.
+            let capability = null
+            if (markup.platform === 'unknown')
+                capability = await page
+                    .evaluate(probeCartApiInPage, {
+                        order: capabilityProbeOrder(platformHint),
+                        endpoints: CART_API_PROBES,
+                    })
+                    .catch(e => ({
+                        platform: 'unknown',
+                        signal: `cart API probe failed: ${e.message}`,
+                        attempts: [],
+                    }))
+            return resolvePlatform({ markup, capability, hint: platformHint })
+        }
+
+        let resolved = await identify()
+        if (shouldRelookAtDocument({ navigationStatus, resolved })) {
+            // The document we were shown may not have been the store: three
+            // stores reported `unknown` by a batch run detected `shopify` on
+            // the very next run from the same machine (2026-08-14). One reload,
+            // only on that evidence, and the outcome of both looks is recorded.
+            note(
+                `platform: first look found nothing (${resolved.signal}) — reloading once`,
+            )
+            observation.platform.firstLook = {
+                platform: resolved.platform,
+                signal: resolved.signal,
+                navigationStatus,
+            }
+            const again = await page
+                .reload({ waitUntil: 'domcontentloaded', timeout: 60000 })
+                .catch(e => {
+                    note(`  (reload failed: ${e.message})`)
+                    return null
+                })
+            if (again) navigationStatus = again.status()
+            resolved = await identify()
+        }
+
+        const platform = resolved.platform
         observation.platform.detected = platform
-        note(`platform: ${platform} (${detected.signal})`)
+        observation.platform.signal = resolved.signal
+        observation.platform.source = resolved.source
+        observation.platform.hint = resolved.hint
+        observation.platform.hintAgreed = resolved.hintAgreed
+        observation.platform.blocked = resolved.blocked
+        observation.platform.navigationStatus = navigationStatus
+        if (platform === 'unknown')
+            // What we were actually looking at, so "no marker found" can never
+            // again stand in for "we were on a challenge page".
+            observation.platform.document = await page
+                .evaluate(describeDocumentInPage)
+                .catch(() => null)
+        note(`platform: ${platform} (${resolved.signal})`)
 
         const seeder = seedersByPlatform()[platform]
         // No seeder means no cart, and no cart means no evidence — reported as
@@ -414,7 +490,7 @@ async function main() {
               })
             : {
                   ok: false,
-                  detail: `no seeder speaks for platform "${platform}" (${detected.signal})`,
+                  detail: `no seeder speaks for platform "${platform}" (${resolved.signal})`,
                   rejectedAdds: 0,
                   adds: 0,
                   productFeedOk: false,

--- a/tools/ext-probe/seed.mjs
+++ b/tools/ext-probe/seed.mjs
@@ -52,6 +52,254 @@ export function seedersByPlatform() {
 }
 
 /**
+ * The endpoint each platform publishes that answers "are you this platform?"
+ * — the SAME endpoint that platform's seeder is about to call, so a `200` here
+ * is evidence the seed can proceed rather than a second opinion about markup.
+ *
+ * Passed INTO the page function rather than read from module scope: a
+ * serialised page function cannot see this file (see the note at the top), and
+ * one table beats a copy that drifts.
+ *
+ * `expect` names the JSON shape that platform's endpoint returns. The shape
+ * check is not decoration — 5 of the 167 stores measured on 2026-08-14
+ * (publiclands.com, wearpact.com, gamefly.com, secretsales.com,
+ * strawberrynet.com) answer `200` with their SPA's HTML catch-all on at least
+ * one of these paths, and a status-only check would have named every one of
+ * them the wrong platform.
+ */
+export const CART_API_PROBES = Object.freeze({
+    shopify: { path: '/products.json?limit=1', expect: 'products-array' },
+    woocommerce: {
+        path: '/wp-json/wc/store/v1/products?per_page=1',
+        expect: 'array',
+    },
+    bigcommerce: { path: '/api/storefront/carts', expect: 'array' },
+})
+
+/**
+ * Statuses that mean "the store refused to answer", as opposed to "the store
+ * answered, and the answer is no". Collapsing the two is what made a blocked
+ * Shopify store indistinguishable from a store that is not Shopify.
+ */
+const REFUSAL_STATUSES = Object.freeze([401, 403, 407, 429, 451, 503])
+
+/**
+ * Ask each platform's own endpoint, in the given order, whether it is home.
+ *
+ * Runs only when markup detection came back `unknown`, so the common path
+ * still costs zero requests. Every attempt is REPORTED — status included —
+ * because "404, so not Shopify" and "403, so we never found out" are different
+ * facts and the report used to carry neither.
+ *
+ * @param {{order: string[], endpoints: Record<string, {path: string, expect: string}>}} options
+ * @returns {Promise<{platform: string, signal: string, attempts: Array<object>}>}
+ */
+export async function probeCartApiInPage(options) {
+    const order = (options && options.order) || []
+    const endpoints = (options && options.endpoints) || {}
+    const attempts = []
+    for (const platform of order) {
+        const spec = endpoints[platform]
+        if (!spec) continue
+        const attempt = {
+            platform,
+            endpoint: spec.path,
+            status: null,
+            ok: false,
+            shape: null,
+            error: null,
+        }
+        attempts.push(attempt)
+        try {
+            const res = await fetch(spec.path, {
+                headers: { accept: 'application/json' },
+            })
+            attempt.status = res.status
+            if (!res.ok) continue
+            let body = null
+            try {
+                body = await res.json()
+            } catch {
+                // Not a parse bug on our side: a store whose SPA answers every
+                // path with HTML lands here, and "the endpoint served
+                // something that is not this platform's JSON" is the finding.
+                attempt.shape = 'not-json'
+                continue
+            }
+            const matches =
+                spec.expect === 'array'
+                    ? Array.isArray(body)
+                    : !!body &&
+                      typeof body === 'object' &&
+                      Array.isArray(body.products)
+            attempt.shape = matches ? spec.expect : 'unexpected-json'
+            if (!matches) continue
+            attempt.ok = true
+            return {
+                platform,
+                signal: `${platform} answered ${spec.path} with ${spec.expect}`,
+                attempts,
+            }
+        } catch (e) {
+            attempt.error = String(e).slice(0, 80)
+        }
+    }
+    return { platform: 'unknown', signal: 'no cart API answered', attempts }
+}
+
+/**
+ * What document did we actually look at? Recorded whenever the platform comes
+ * back unknown.
+ *
+ * A store that served a challenge page, a consent wall or an error page to the
+ * probe's first navigation carries none of a platform's markers, and the old
+ * report said only "no platform marker found" — the same sentence a genuinely
+ * unrecognised store produces. These four fields separate them: a challenge
+ * page is small, differently titled, and served under a non-2xx status.
+ */
+export function describeDocumentInPage() {
+    return {
+        url: location.href,
+        title: String(document.title || '').slice(0, 120),
+        htmlBytes: document.documentElement
+            ? document.documentElement.outerHTML.length
+            : 0,
+        readyState: document.readyState,
+    }
+}
+
+/**
+ * The order to ask the platforms in. A caller's hint goes first — it is the
+ * store's own config talking, and asking the likely endpoint first costs the
+ * unlikely ones nothing.
+ *
+ * @param {string|null} hint
+ * @returns {string[]}
+ */
+export function capabilityProbeOrder(hint) {
+    const rest = SEEDABLE_PLATFORMS.filter(p => p !== hint)
+    return hint && SEEDABLE_PLATFORMS.includes(hint) ? [hint, ...rest] : rest
+}
+
+/**
+ * A caller-supplied platform hint, or `null`. Anything else THROWS: a hint the
+ * probe silently drops is worse than no hint, because the caller then reads a
+ * detection failure as a property of the store.
+ *
+ * @param {unknown} value
+ * @returns {string|null}
+ */
+export function normalizePlatformHint(value) {
+    if (value === undefined || value === null || value === '') return null
+    const hint = String(value).trim().toLowerCase()
+    if (!SEEDABLE_PLATFORMS.includes(hint))
+        throw new Error(
+            `unknown --platform-hint "${value}" — the seeder speaks ${SEEDABLE_PLATFORMS.join('/')}`,
+        )
+    return hint
+}
+
+/**
+ * Decide the platform from the evidence gathered, and say who decided.
+ *
+ * Node-side and pure: the page functions above collect facts, this turns them
+ * into one answer, and keeping the two apart is what makes the answer testable
+ * without a browser.
+ *
+ * Markup outranks the hint on purpose. A global the platform's own bundle set
+ * is the store speaking; a hint is our config guessing, and a store that
+ * replatformed since discovery would otherwise be seeded the old way.
+ *
+ * @param {{markup: object, capability: object|null, hint: string|null}} evidence
+ * @returns {{platform: string, signal: string, source: string|null, hint: string|null, hintAgreed: boolean|null, blocked: boolean}}
+ */
+export function resolvePlatform(evidence) {
+    const markup = (evidence && evidence.markup) || {
+        platform: 'unknown',
+        signal: 'no markup detection ran',
+    }
+    const capability = (evidence && evidence.capability) || null
+    const hint = (evidence && evidence.hint) || null
+    const attempts = (capability && capability.attempts) || []
+    // Every attempt refused, and there was at least one: we did not learn that
+    // the store is on some other platform, we learned nothing.
+    const blocked =
+        attempts.length > 0 &&
+        attempts.every(
+            a =>
+                a.status === null ||
+                REFUSAL_STATUSES.includes(a.status) ||
+                a.ok === undefined,
+        ) &&
+        !attempts.some(a => a.ok)
+
+    if (SEEDABLE_PLATFORMS.includes(markup.platform))
+        return {
+            platform: markup.platform,
+            signal: markup.signal,
+            source: 'markup',
+            hint,
+            hintAgreed: hint ? hint === markup.platform : null,
+            blocked: false,
+        }
+
+    if (capability && SEEDABLE_PLATFORMS.includes(capability.platform))
+        return {
+            platform: capability.platform,
+            signal: `${markup.signal}; ${capability.signal}`,
+            source: 'capability',
+            hint,
+            hintAgreed: hint ? hint === capability.platform : null,
+            blocked: false,
+        }
+
+    const trail = attempts
+        .map(a => `${a.platform} ${a.error || a.shape || a.status}`)
+        .join(', ')
+    return {
+        platform: 'unknown',
+        signal: [
+            markup.signal,
+            trail && `cart API: ${trail}`,
+            blocked &&
+                'every endpoint refused — this is NOT evidence the store is on another platform',
+        ]
+            .filter(Boolean)
+            .join('; '),
+        source: null,
+        hint,
+        hintAgreed: hint ? false : null,
+        blocked,
+    }
+}
+
+/**
+ * Should the probe look at the document a second time before abandoning?
+ *
+ * Only when the evidence says we may have been looking at the wrong page —
+ * a navigation the store did not answer 2xx, or a set of cart-API probes that
+ * were all refused. Measured (2026-08-14): kizik.com, peterthomasroth.com and
+ * venus.com were each reported `unknown` by a batch run and each detected
+ * `shopify` on the very next run from the same machine, with `Shopify.shop`
+ * present at `domcontentloaded` — the detector was right about the document it
+ * was shown, and wrong about which document that was.
+ *
+ * Deliberately NOT "retry whenever unknown": a store we genuinely cannot seed
+ * would then pay for a second page load on every run forever.
+ *
+ * @param {{navigationStatus: number|null, resolved: object}} state
+ * @returns {boolean}
+ */
+export function shouldRelookAtDocument(state) {
+    const resolved = (state && state.resolved) || {}
+    if (resolved.platform !== 'unknown') return false
+    const status = state ? state.navigationStatus : null
+    if (status === null || status === undefined) return true
+    if (status < 200 || status >= 300) return true
+    return !!resolved.blocked
+}
+
+/**
  * Name the e-commerce platform from markup the platform itself emits — never
  * from the hostname. A per-store list would rot the day a store replatformed,
  * and would be wrong for the 2,700th store the moment it was written.
@@ -103,6 +351,19 @@ export function detectPlatformInPage() {
             () =>
                 has(
                     'script[src*="cdn.shopify.com"], link[href*="cdn.shopify.com"]',
+                ),
+        ],
+        // Shopify serves theme and platform assets from the STORE's own host
+        // now, not only from cdn.shopify.com. Counted on 2026-08-14:
+        // peterthomasroth.com carries 92 first-party `/cdn/shop/` tags against
+        // 4 on cdn.shopify.com, so a store that drops the preconnect is
+        // invisible to the marker above while still being plain Shopify.
+        [
+            'shopify',
+            'first-party /cdn/shop asset',
+            () =>
+                has(
+                    'script[src*="/cdn/shop"], link[href*="/cdn/shop"], script[src*="/cdn/shopifycloud"], link[href*="/cdn/shopifycloud"]',
                 ),
         ],
         [

--- a/tools/ext-probe/verdict.mjs
+++ b/tools/ext-probe/verdict.mjs
@@ -128,6 +128,28 @@ export function emptyObservation() {
             // Shopify stay comparable field-for-field.
             productsJsonOk: null,
             cartJsOk: null,
+            // WHY the answer above is the answer. `unknown` used to arrive with
+            // one sentence — "no platform marker found" — that a blocked store,
+            // a challenge page and a genuinely unrecognised platform all
+            // produced, which is why 11 of 24 stores in the 2026-08-14 batch
+            // were unreadable. These carry the difference.
+            signal: null,
+            // 'markup' | 'capability' | null — which leg decided.
+            source: null,
+            // The caller's platform hint and whether the evidence agreed with
+            // it. A hint never decides on its own; see resolvePlatform.
+            hint: null,
+            hintAgreed: null,
+            // Every cart-API probe refused (401/403/429/503/network). We did
+            // not learn the store is on another platform; we learned nothing.
+            blocked: null,
+            // The HTTP status of the navigation the detection ran against.
+            navigationStatus: null,
+            // The document we were actually looking at, recorded only when the
+            // platform came back unknown.
+            document: null,
+            // Present only when a second look was taken: what the first one saw.
+            firstLook: null,
         },
         // Read BEFORE the wait window. See probe.mjs for why that ordering is
         // load-bearing rather than incidental.


### PR DESCRIPTION
## ⛔ MERGE-HELD

A 50-store discovery batch is running and reads this probe per store. Do not merge until the team lead releases it — merging mid-batch changes the artifact under measurement.

## What was wrong

`INCONCLUSIVE_SEED` with `no seeder speaks for platform "unknown" (no platform marker found)` was the terminal state for **11 of the 24 stores** in the 2026-08-14 ext-QA batch. No cart → no apply attempt → no GREEN/RED → the repair loop never fires. The seeder was the binding constraint on the whole ext-QA investment.

That one sentence was covering three different worlds, and the report could not tell them apart:

| world | what it means | what the report said |
| --- | --- | --- |
| the store answered, and it is not a platform we seed | genuine coverage gap | `no platform marker found` |
| the store refused to answer (WAF / 403 / 429) | we learned **nothing** | `no platform marker found` |
| we were looking at a challenge page, not the store | detector was right, document was wrong | `no platform marker found` |

**The third world is real and measurable.** `kizik.com`, `peterthomasroth.com` and `venus.com` were each reported `unknown` by the batch. All three are plain Shopify: 6 markers each in the served HTML, `Shopify.shop` present at `domcontentloaded` in a real Chromium, and `/products.json` answering `200` from the same machine. Re-running the probe on `kizik.com` unchanged detected `platform: shopify (window.Shopify.shop)`, seeded a cart, and advanced the verdict to `INCONCLUSIVE_CONFIG_STALE`.

Two supporting facts also came out of the measurement:

- `observation.platform.productFeedOk` / `cartApiOk` are `false` on every `unknown` store **because nothing set them** — no seeder ran. They looked like evidence of blocked endpoints and carried none.
- `page.goto`'s HTTP status was discarded, so a store answering the first navigation with `403` was indistinguishable from one answering `200`.

## What changed

**1. The cart API is asked directly when markup finds nothing.** Each platform's own endpoint — the same one that platform's seeder is about to call — so a `200` is a licence to seed, not a second opinion. Costs zero requests on the common path (markup still decides first).

The JSON **shape** is checked, not just the status: 5 of 167 stores measured (`publiclands.com`, `wearpact.com`, `gamefly.com`, `secretsales.com`, `strawberrynet.com`) answer `200` with their SPA's HTML catch-all on at least one of these paths, and a status-only check names every one of them the wrong platform.

**2. Refusal is recorded as refusal.** Every attempt keeps its status; `blocked: true` marks "all of them refused" (401/403/407/429/451/503 or a network error). One honest `404` among refusals is enough to stop calling it blocked.

**3. One second look, on evidence.** Non-2xx navigation, or every endpoint refused → reload once and ask again; `firstLook` keeps what the first attempt saw. Deliberately *not* "retry whenever unknown" — 48 of the 167 stores carry no marker and no cart API at all, and they must not pay for an extra page load forever.

**4. `--platform-hint`.** Orders the cart-API probe and names the platform when markup was blind. It **never** overrides markup: a global the platform's bundle set is the store speaking, a hint is our config guessing, and a store that replatformed since discovery would otherwise be seeded the old way. An unrecognised value throws before Chromium starts (`PROBE_ERROR`, exit 70) rather than being dropped.

**5. First-party Shopify assets are a marker.** Shopify serves theme assets from the store's own host now — 92 first-party `/cdn/shop/` tags on `peterthomasroth.com` against 4 on `cdn.shopify.com`. A store that drops the preconnect was invisible to the old marker.

New report fields under `observation.platform`: `signal`, `source`, `hint`, `hintAgreed`, `blocked`, `navigationStatus`, `document`, `firstLook`. Additive only — `ext-probe/1` stands.

## Live proof

Two stores, run with this build (neither is in the running batch's target list):

```
13deals.com  navStatus 403  blocked true  firstLook taken
  signal: no platform marker found; cart API: shopify 403, woocommerce 403, bigcommerce 403;
          every endpoint refused — this is NOT evidence the store is on another platform
  document: {"url":"https://www.13deals.com/store/","title":"Just a moment...","htmlBytes":27299}

miansai.com  navStatus 403  blocked true  firstLook taken
  document: {"url":"https://www.miansai.com/","title":"Attention Required! | Cloudflare","htmlBytes":4253}
```

Both previously read as "a platform we do not support". They are stores the probe never reached. And `kizik.com` under the same build: `platform: shopify (window.Shopify.shop)`, `source: markup`, `navigationStatus: 200`, seeded, verdict `INCONCLUSIVE_CONFIG_STALE`.

## Gates

| gate | result |
| --- | --- |
| `vitest run` (full) | 868/871 passed. The 3 failures are the known load-flakes — `popup-settings-icon.test.tsx`, `popup-settings-view.test.tsx`, `source-is-text.test.mjs` — **all pass in isolation** (8/8 and 3/3) |
| `ext-probe-platform-evidence.test.mjs` (new) | 25/25 |
| `ext-probe-seed-platforms.test.mjs` | 23/23 |
| `test:guards` | 57/57 |
| `build` | clean, 793.61 kB |
| `test:parity` | 71/71 |
| `oxlint` / `prettier` | clean |

## Coverage gap, measured and NOT fixed here

Across 167 stores (117 previously probed + tonight's 50), **79 are seedable today** (69 Shopify, 8 BigCommerce, 2 WooCommerce, API-confirmed). The largest named gap is **Salesforce B2C Commerce / Demandware — 13 stores** (`boxlunch`, `coach`, `exofficio`, `gnc`, `hallmark`, `kiehls`, `netgear`, `vince`, `paulaschoice`, `us.pandora.net`, `weber`, `lanebryant`, `phase-eight`), more than WooCommerce and comparable to BigCommerce, both of which already have seeders.

**No SFCC seeder ships in this PR, on purpose — it is not provable yet.** Reconnaissance (read-only except two anonymous cart adds on non-batch stores):

- The controller base **is** uniformly discoverable from homepage markup: `Sites-<id>-Site/<locale>` on 5/5 stores tested.
- Product ids are **not**: only 1 of 5 carries `data-pid` on the homepage; the rest need the SFRA search grid.
- `Cart-AddProduct` answers `500` with a CSRF token in the JSON error body, and **replaying that token still 500s** — from a bare HTTP session *and* from a real browser on the store's own session with its cookies (`vince.com`, `hallmark.com`). `CSRF-Generate` also 500s.

Conclusion: the token SFRA accepts is one minted into a rendered **product** page, so a working seeder must navigate to `Product-Show?pid=…` and read the token plus the variant pid off that form — a page navigation per store, which is a design decision worth the owner's call rather than a guess shipped into 13 live stores.

## Companion

`DevinoSolutions/caramel-coupons` → `feat/ext-qa-platform-hint` (also merge-held) passes `--platform-hint` from the config's own endpoints.
