### PR TITLE
fix(catalog): a partial store-config push stops deleting the selectors it says nothing about

### DIFF
--- a/apps/caramel-app/src/lib/catalog/applyCatalogRows.ts
+++ b/apps/caramel-app/src/lib/catalog/applyCatalogRows.ts
@@ -184,6 +184,51 @@ function pgTextArray(values: readonly string[]): Prisma.Sql {
  * `WHERE excluded.updated_at >= …` guard still prevents a concurrent write from
  * being clobbered by an older one regardless.
  */
+/**
+ * The eight extension-consumed selector columns, in the order the upsert writes them.
+ */
+const SELECTOR_COLUMNS = [
+    'show_input_xpath',
+    'dismiss_button_xpath',
+    'coupon_input_xpath',
+    'apply_button_xpath',
+    'price_container_xpath',
+    'success_indicator_xpath',
+    'error_indicator_xpath',
+    'coupon_remove_xpath',
+] as const
+
+/**
+ * `ON CONFLICT` assignments for the selector columns, where **absent means "no opinion",
+ * not "delete"**.
+ *
+ * These used to be a plain `col = excluded.col`, which made a push authoritative for every
+ * column including the ones the producer knows nothing about. The producer's served rows are
+ * SPARSE — measured 2026-08-14 over 2,132 stores: `dismiss_button_xpath` is null on 97.8% of
+ * them, `show_input_xpath` on 74.6%, `price_container_xpath` on 18.2% — so a routine sync
+ * silently DELETED values this table was serving. Eight domains lost a field that day
+ * (mikasa.com, oralb.com, plae.co, simpli-home.com, thegldshop.com, theoutnet.com,
+ * uspoloassn.com, venus.com); four of them because a freshly discovered config with fewer
+ * populated fields became the producer's served row. Nothing else writes this table, so a
+ * dropped value never came back on its own.
+ *
+ * A NULL is therefore treated as "I have no value for this field" and leaves the stored value
+ * alone. Deleting a selector is still possible, but it must be SAID rather than implied: the
+ * empty string is an explicit tombstone and clears the column. Plain COALESCE was rejected for
+ * exactly that reason — it would have made a wrong selector unremovable by any push.
+ *
+ * Column names come from the const array above, never from input, so `Prisma.raw` is safe here.
+ */
+const SELECTOR_UPSERT_ASSIGNMENTS = Prisma.raw(
+    SELECTOR_COLUMNS.map(
+        col =>
+            `${col} = CASE` +
+            ` WHEN excluded.${col} IS NULL THEN store_configs.${col}` +
+            ` WHEN excluded.${col} = '' THEN NULL` +
+            ` ELSE excluded.${col} END`,
+    ).join(', '),
+)
+
 export async function applyCatalogRows(
     payload: IngestCatalogPayload,
 ): Promise<ApplyResult> {
@@ -337,14 +382,7 @@ export async function applyCatalogRows(
                             INSERT INTO store_configs (store_name, show_input_xpath, dismiss_button_xpath, coupon_input_xpath, apply_button_xpath, price_container_xpath, success_indicator_xpath, error_indicator_xpath, coupon_remove_xpath, created_at, updated_at)
                             VALUES ${Prisma.join(tuples)}
                             ON CONFLICT (store_name) DO UPDATE SET
-                                show_input_xpath = excluded.show_input_xpath,
-                                dismiss_button_xpath = excluded.dismiss_button_xpath,
-                                coupon_input_xpath = excluded.coupon_input_xpath,
-                                apply_button_xpath = excluded.apply_button_xpath,
-                                price_container_xpath = excluded.price_container_xpath,
-                                success_indicator_xpath = excluded.success_indicator_xpath,
-                                error_indicator_xpath = excluded.error_indicator_xpath,
-                                coupon_remove_xpath = excluded.coupon_remove_xpath,
+                                ${SELECTOR_UPSERT_ASSIGNMENTS},
                                 updated_at = excluded.updated_at
                             WHERE excluded.updated_at >= store_configs.updated_at
                         `,

--- a/apps/caramel-app/tests/integration/ingest-catalog.itest.ts
+++ b/apps/caramel-app/tests/integration/ingest-catalog.itest.ts
@@ -97,6 +97,89 @@ describe('applyCatalogRows — only-if-newer (real pg :58005)', () => {
     })
 })
 
+describe('applyCatalogRows — a partial store_config never deletes a selector', () => {
+    // The producer's served rows are SPARSE (measured 2026-08-14 over 2,132 stores:
+    // dismiss_button_xpath null on 97.8%, show_input_xpath on 74.6%), and the schema
+    // explicitly allows "a producer may push a partial config (only the fields it
+    // re-derived)". The upsert used to write every column verbatim, so those absent
+    // fields DELETED what this table was serving — 8 domains lost a field that day,
+    // and nothing else writes this table, so the value never came back.
+    const store = 'itest-null-preserve.example'
+
+    it('leaves a column alone when the push omits it, and clears it only on an explicit empty string', async () => {
+        // Full config first.
+        const r1 = await applyCatalogRows({
+            coupons: [],
+            sources: [],
+            force: false,
+            storeConfigs: [
+                {
+                    store_name: store,
+                    coupon_input_xpath: 'input#code',
+                    apply_button_xpath: 'button#apply',
+                    show_input_xpath: 'a#reveal',
+                    price_container_xpath: '.total',
+                    updated_at: new Date('2026-07-14T12:00:00.000Z'),
+                },
+            ],
+        })
+        expect(r1.gated).toBe(false)
+
+        // A later, PARTIAL push: it re-derived the two required selectors and has no
+        // opinion on the rest. The omitted columns must survive.
+        const r2 = await applyCatalogRows({
+            coupons: [],
+            sources: [],
+            force: false,
+            storeConfigs: [
+                {
+                    store_name: store,
+                    coupon_input_xpath: 'input#code-v2',
+                    apply_button_xpath: 'button#apply',
+                    updated_at: new Date('2026-07-14T18:00:00.000Z'),
+                },
+            ],
+        })
+        expect(r2.gated).toBe(false)
+
+        const kept = await prisma.storeConfig.findUnique({
+            where: { storeName: store },
+        })
+        expect(kept?.couponInputXpath).toBe('input#code-v2') // re-derived → applied
+        expect(kept?.showInputXpath).toBe('a#reveal') // omitted → PRESERVED
+        expect(kept?.priceContainerXpath).toBe('.total') // omitted → PRESERVED
+
+        // Deleting is still possible, but it has to be SAID: '' is the tombstone.
+        const r3 = await applyCatalogRows({
+            coupons: [],
+            sources: [],
+            force: false,
+            storeConfigs: [
+                {
+                    store_name: store,
+                    coupon_input_xpath: 'input#code-v2',
+                    apply_button_xpath: 'button#apply',
+                    show_input_xpath: '',
+                    updated_at: new Date('2026-07-15T00:00:00.000Z'),
+                },
+            ],
+        })
+        expect(r3.gated).toBe(false)
+
+        const cleared = await prisma.storeConfig.findUnique({
+            where: { storeName: store },
+        })
+        expect(cleared?.showInputXpath).toBeNull() // explicit '' → cleared
+        expect(cleared?.priceContainerXpath).toBe('.total') // still untouched
+    })
+
+    afterEach(async () => {
+        await prisma.storeConfig.deleteMany({
+            where: { storeName: { startsWith: 'itest-' } },
+        })
+    })
+})
+
 describe('applyCatalogRows — >20% tombstone force-gate', () => {
     it('refuses a >20% tombstoning push without force, applies it with force', async () => {
         // M = before + 3 visible test coupons guarantees expiring all of them


### PR DESCRIPTION
## The bug

`applyCatalogRows` wrote every `store_configs` selector column as `col = excluded.col`. That made a push authoritative for **all eight** columns — including the ones the producer knows nothing about.

The producer's served rows are sparse. Measured 2026-08-14 across 2,132 stores:

| column | NULL/empty |
| --- | --- |
| `dismiss_button_xpath` | 97.8% |
| `show_input_xpath` | 74.6% |
| `price_container_xpath` | 18.2% |

So a routine sync silently **deleted** values this table was serving. `applyCatalogRows` is the only writer, so a dropped value never came back.

## It already fired

Diffing a 14:04 snapshot of `/api/extension/supported-stores` against the same endpoint hours later: **8 domains lost a field** (`priceContainer` x6, `showInput` x2, `dismissButton` x1) — mikasa.com, oralb.com, plae.co, simpli-home.com, thegldshop.com, theoutnet.com, uspoloassn.com, venus.com. Four of the eight were stores from that night's discovery batch: a fresh agent config with fewer populated fields became the served row and overwrote the richer older values.

It also contradicted this repo's own stated contract — `ingestSchemas.ts` says *"a producer may push a partial config (only the fields it re-derived)"*, which the upsert did not honour.

Newly urgent: caramel-coupons#78 pushes per-store within seconds of an ext-QA publish, instead of at the next 12h sync. Same bug, much shorter fuse.

## The fix

A NULL now means *"I have no value for this field"* and leaves the stored value alone. Deleting is still possible but must be **said**: the empty string is an explicit tombstone.

Plain `COALESCE` was rejected deliberately — it would have made a wrong selector unremovable by any push.

Column names come from a hardcoded const array, never from input, so `Prisma.raw` is safe.

## Proof

`tests/integration/ingest-catalog.itest.ts`, against real Postgres: a full config, then a PARTIAL push that re-derives only the two required selectors -> the omitted `showInput`/`priceContainer` survive and the re-derived one applies; then an explicit `''` -> that column clears while its neighbour stays untouched.

- integration: 4 passed
- unit (`ingest-catalog.test.ts`): 11 passed
- `tsc --noEmit`: clean

Not addressed here: the 8 fields already lost. Restoring them means re-pushing values we still hold, which is a separate, owner-visible action.