### PR TITLE
fix(ci): extension checks fall back to apps/caramel-extension when repo vars are unavailable (fork PRs)

### DIFF
--- a/.github/workflows/checks-extension.yml
+++ b/.github/workflows/checks-extension.yml
@@ -6,7 +6,9 @@ on:
   pull_request:
 
 env:
-  WORKING_DIRECTORY: ${{ vars.WORKING_DIRECTORY }}
+  # Fork PRs never receive repository `vars`, so this must fall back to the real
+  # package directory — not the workspace root, where every `pnpm run` 404s.
+  WORKING_DIRECTORY: ${{ vars.WORKING_DIRECTORY || 'apps/caramel-extension' }}
 
 jobs:
   lint_and_build:
@@ -14,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ${{ env.WORKING_DIRECTORY || github.workspace }}
+        working-directory: ${{ env.WORKING_DIRECTORY }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

`checks-extension.yml` resolved its job working directory from a **repository variable**:

```yaml
env:
  WORKING_DIRECTORY: ${{ vars.WORKING_DIRECTORY }}
...
    defaults:
      run:
        working-directory: ${{ env.WORKING_DIRECTORY || github.workspace }}
```

GitHub does **not** expose repository `vars` (or secrets) to workflows triggered by pull requests from forks. On a fork PR `vars.WORKING_DIRECTORY` is empty, the `||` falls through to `github.workspace`, and the whole `checks` job runs at the **monorepo root** instead of `apps/caramel-extension`. The root `package.json` has no `knip` / `size` / `test:parity` / `type-check` scripts, so those steps die with `ERR_PNPM_NO_SCRIPT`.

Same-repo PRs and pushes never saw it, because there the var resolves to `apps/caramel-extension`.

First observed on #208 (fork PR from `SusieeTheLinuxUser/caramel`), where `pnpm run knip` failed with `ERR_PNPM_NO_SCRIPT`.

## Fix

Make the fallback the **real package directory** rather than the workspace root, with a comment explaining why:

```yaml
env:
  # Fork PRs never receive repository `vars`, so this must fall back to the real
  # package directory — not the workspace root, where every `pnpm run` 404s.
  WORKING_DIRECTORY: ${{ vars.WORKING_DIRECTORY || 'apps/caramel-extension' }}
```

…and the job's `defaults.run.working-directory` simply uses `${{ env.WORKING_DIRECTORY }}` (the `|| github.workspace` escape hatch was the bug). The repository variable still wins where it is available, so nothing changes for same-repo runs.

## Scope

- Only `.github/workflows/checks-extension.yml` is touched. It is the only PR-triggered workflow that reads `vars.WORKING_DIRECTORY`.
- `release-extension.yml` also reads the var, but it is not triggered by fork PRs and already fails loudly with an explicit `::error::` when the variable is unset — left as is.
- No test pins workflow content (`tests/unit/repo-integrity.test.ts` covers root files / manifests, not `.github/`).
- `pnpm exec prettier --check .github/workflows/` is clean.