### PR TITLE
feat(support): support emails deep-link to the feedback event in PostHog

### DIFF
--- a/apps/caramel-app/.env.example
+++ b/apps/caramel-app/.env.example
@@ -96,6 +96,11 @@ NEXT_PUBLIC_POSTHOG_KEY=
 # shared E2E test-project capture pair (required when dataset is 'e2e').
 NEXT_PUBLIC_POSTHOG_E2E_TEST_PROJECT_HOST=
 NEXT_PUBLIC_POSTHOG_E2E_TEST_PROJECT_CAPTURE_TOKEN=
+# Browser URL of this deploy's PostHog project UI, PROJECT ID INCLUDED
+# (e.g. https://posthog.example.com/project/123). Powers the "open in PostHog"
+# deep link in support emails; unset → the email carries no link. Real value
+# lives only in the deploy env.
+POSTHOG_PROJECT_UI_URL=
 # App version stamp — auto-injected by next.config.mjs from package.json.
 # Documented here for completeness; do NOT set it by hand.
 # NEXT_PUBLIC_APP_VERSION=

--- a/apps/caramel-app/emails/SupportNotificationTemplate.tsx
+++ b/apps/caramel-app/emails/SupportNotificationTemplate.tsx
@@ -28,6 +28,8 @@ export interface SupportNotificationProps {
     userLabel: string
     posthogSessionId?: string
     posthogDistinctId?: string
+    /** Deep link to THIS submission's support_request_submitted event. */
+    posthogUrl?: string
     sentryEventId?: string
     sentryUrl?: string
 }
@@ -110,6 +112,7 @@ export default function SupportNotificationTemplate(
         userLabel,
         posthogSessionId,
         posthogDistinctId,
+        posthogUrl,
         sentryEventId,
         sentryUrl,
     } = props
@@ -187,6 +190,17 @@ export default function SupportNotificationTemplate(
                 <>
                     <p style={sectionLabel}>Expected outcome</p>
                     <div style={panel}>{renderMessage(expectedOutcome)}</div>
+                </>
+            ) : null}
+
+            {posthogUrl ? (
+                <>
+                    <p style={sectionLabel}>Analytics</p>
+                    <p style={{ ...text.body, margin: '0 0 24px' }}>
+                        <a href={posthogUrl} style={text.link}>
+                            Open this feedback event in PostHog
+                        </a>
+                    </p>
                 </>
             ) : null}
 

--- a/apps/caramel-app/src/app/api/support/route.ts
+++ b/apps/caramel-app/src/app/api/support/route.ts
@@ -15,6 +15,7 @@
 // var could route submissions to it — do NOT invent an id before one exists.
 import SupportNotificationTemplate from '@/emails/SupportNotificationTemplate'
 import { APP_ID } from '@/lib/analytics/posthogDataset'
+import { posthogSupportEventUrl } from '@/lib/analytics/posthogLinks'
 import { captureServerEvent } from '@/lib/analytics/posthogServer'
 import { withRoute } from '@/lib/api/withRoute'
 import { auth } from '@/lib/auth/auth'
@@ -118,6 +119,15 @@ function buildEmailText(input: {
         `PostHog session: ${body.posthog_session_id ?? '(none)'}`,
         `PostHog distinct id: ${body.posthog_distinct_id ?? '(none)'}`,
     ]
+    // Same builder as the HTML part, so the two bodies can never link to
+    // different places; absent when no project UI URL is configured.
+    const posthogUrl = posthogSupportEventUrl(
+        body.feedback_id,
+        env.POSTHOG_PROJECT_UI_URL,
+    )
+    if (posthogUrl) {
+        lines.push(`PostHog event: ${posthogUrl}`)
+    }
     const sentryUrl = sentryIssueUrl(body.sentry_event_id)
     if (body.sentry_event_id && sentryUrl) {
         lines.push(`Sentry event id: ${body.sentry_event_id}`)
@@ -128,11 +138,11 @@ function buildEmailText(input: {
 
 /** The HTML part — the same fields, structured, on the shared Caramel layout.
  *
- * Deliberately NOT given a PostHog replay link: a replay URL needs the project
- * id, and no env in this app carries one (only the E2E test project has an id,
- * and that is a different project). The session and distinct ids are rendered
- * as selectable text instead — a guessed URL that 404s is worse than an id the
- * operator can paste.
+ * The PostHog link is built (never guessed) from POSTHOG_PROJECT_UI_URL — the
+ * env that finally carries a project id — and points at the submission's own
+ * `support_request_submitted` event. Session-REPLAY links are still deliberately
+ * absent: a replay may not exist for an anonymous submitter, and a URL that
+ * 404s is worse than the ids rendered as selectable text.
  */
 async function buildEmailHtml(input: {
     body: SupportBody
@@ -154,6 +164,10 @@ async function buildEmailHtml(input: {
             userLabel: userId ?? 'anonymous',
             posthogSessionId: body.posthog_session_id,
             posthogDistinctId: body.posthog_distinct_id,
+            posthogUrl: posthogSupportEventUrl(
+                body.feedback_id,
+                env.POSTHOG_PROJECT_UI_URL,
+            ),
             sentryEventId: body.sentry_event_id,
             sentryUrl: sentryIssueUrl(body.sentry_event_id),
         }),

--- a/apps/caramel-app/src/lib/analytics/posthogLinks.ts
+++ b/apps/caramel-app/src/lib/analytics/posthogLinks.ts
@@ -1,0 +1,53 @@
+// Operator-facing PostHog deep links.
+//
+// The support email carries a feedback_id and, until now, no way to jump to
+// the matching `support_request_submitted` event — the template deliberately
+// refused to guess a URL because no env carried the project id (a link that
+// 404s is worse than an id the operator can paste). POSTHOG_PROJECT_UI_URL
+// (env.ts) closes that gap: it names the browser UI of THIS deploy's PostHog
+// project, so the link below is constructed, never guessed.
+//
+// The `#q=` payload is PostHog's activity-explorer query fragment. This exact
+// shape (DataTableNode → EventsQuery, `exact` operator on the event property)
+// was proven against the live self-hosted instance on 2026-08-19: navigating
+// it renders the explorer with the `feedback_id = …` filter chip applied and
+// exactly the one matching event row. Change the shape only by re-proving it
+// in a browser first.
+
+/**
+ * Deep link to the activity explorer filtered to ONE support submission's
+ * `support_request_submitted` event, or undefined when no project UI URL is
+ * configured (the email then simply carries no link).
+ *
+ * @param feedbackId the submission's client-generated correlation id
+ * @param projectUiUrl env.POSTHOG_PROJECT_UI_URL — e.g.
+ *   "https://posthog.example.com/project/123" (trailing slashes tolerated)
+ */
+export function posthogSupportEventUrl(
+    feedbackId: string,
+    projectUiUrl: string | undefined,
+): string | undefined {
+    if (!projectUiUrl) return undefined
+    const query = {
+        kind: 'DataTableNode',
+        full: true,
+        source: {
+            kind: 'EventsQuery',
+            select: ['*', 'event', 'person', 'timestamp'],
+            event: 'support_request_submitted',
+            properties: [
+                {
+                    key: 'feedback_id',
+                    value: [feedbackId],
+                    operator: 'exact',
+                    type: 'event',
+                },
+            ],
+            // The explorer defaults to a 24h window; a support email may be
+            // triaged days later, so widen the window past any realistic lag.
+            after: '-90d',
+        },
+    }
+    const base = projectUiUrl.replace(/\/+$/, '')
+    return `${base}/activity/explore#q=${encodeURIComponent(JSON.stringify(query))}`
+}

--- a/apps/caramel-app/src/lib/env.ts
+++ b/apps/caramel-app/src/lib/env.ts
@@ -101,6 +101,15 @@ const serverObjectSchema = z.object({
     POSTHOG_DATASET: z
         .enum(['production', 'e2e', 'disabled'])
         .default('disabled'),
+    // Browser URL of THIS deploy's PostHog project UI, project id included
+    // (e.g. "https://posthog.example.com/project/123"). Used ONLY to build the
+    // operator-facing deep link in support emails (the support_request_submitted
+    // event filtered by feedback_id — src/lib/analytics/posthogLinks.ts).
+    // Distinct from NEXT_PUBLIC_POSTHOG_HOST, which is the ingestion endpoint
+    // and carries no project id — the reason the email previously had no link.
+    // Unset → support emails simply carry no PostHog link. The real value lives
+    // in the deploy env, not in this public repo.
+    POSTHOG_PROJECT_UI_URL: z.string().optional(),
 })
 
 const serverSchema = serverObjectSchema.refine(

--- a/apps/caramel-app/tests/unit/posthog-links.test.ts
+++ b/apps/caramel-app/tests/unit/posthog-links.test.ts
@@ -1,0 +1,58 @@
+import { posthogSupportEventUrl } from '@/lib/analytics/posthogLinks'
+import { describe, expect, it } from 'vitest'
+
+// Pins for the support email's PostHog deep link. The `#q=` fragment shape
+// (DataTableNode → EventsQuery with an `exact` feedback_id property filter)
+// was PROVEN against the live self-hosted explorer on 2026-08-19 — navigating
+// it renders the filter chip and exactly the one matching event. These tests
+// freeze that shape so a refactor cannot silently degrade the link into one
+// that loads an unfiltered (or broken) explorer.
+
+const FEEDBACK_ID = '1b0a369b-7eab-4a27-91ee-3ebef9ea5ea1'
+const BASE = 'https://posthog.example.com/project/123'
+
+function decodeQ(url: string): Record<string, unknown> {
+    const fragment = url.split('#q=')[1]
+    expect(fragment).toBeTruthy()
+    return JSON.parse(decodeURIComponent(fragment!)) as Record<string, unknown>
+}
+
+describe('posthogSupportEventUrl', () => {
+    it('no configured project UI URL → undefined (the email carries no link)', () => {
+        expect(posthogSupportEventUrl(FEEDBACK_ID, undefined)).toBeUndefined()
+        expect(posthogSupportEventUrl(FEEDBACK_ID, '')).toBeUndefined()
+    })
+
+    it('builds the proven activity-explorer URL: base + /activity/explore + #q=', () => {
+        const url = posthogSupportEventUrl(FEEDBACK_ID, BASE)!
+        expect(url.startsWith(`${BASE}/activity/explore#q=`)).toBe(true)
+    })
+
+    it('the #q= payload is the proven query shape, filtered EXACTLY on this feedback_id', () => {
+        const q = decodeQ(posthogSupportEventUrl(FEEDBACK_ID, BASE)!)
+        expect(q).toMatchObject({
+            kind: 'DataTableNode',
+            source: {
+                kind: 'EventsQuery',
+                event: 'support_request_submitted',
+                properties: [
+                    {
+                        key: 'feedback_id',
+                        value: [FEEDBACK_ID],
+                        operator: 'exact',
+                        type: 'event',
+                    },
+                ],
+            },
+        })
+        // The window must outlive triage lag — the explorer default (24h)
+        // would show an empty table for a report opened days later.
+        expect((q.source as { after: string }).after).toBe('-90d')
+    })
+
+    it('tolerates trailing slashes on the configured base without doubling them', () => {
+        const url = posthogSupportEventUrl(FEEDBACK_ID, `${BASE}//`)!
+        expect(url.startsWith(`${BASE}/activity/explore#q=`)).toBe(true)
+        expect(url).not.toContain('//activity')
+    })
+})

--- a/apps/caramel-app/tests/unit/support-route.test.ts
+++ b/apps/caramel-app/tests/unit/support-route.test.ts
@@ -129,6 +129,61 @@ describe('POST /api/support — support/feedback flow', () => {
         expect(parseRecipientList('')).toEqual([])
     })
 
+    it('no POSTHOG_PROJECT_UI_URL configured → NEITHER part carries a PostHog link', async () => {
+        // A guessed URL that 404s is worse than no link — absence must be
+        // graceful, not a broken href.
+        await POST(supportRequest(validBody()))
+
+        const payload = sendEmailMock.mock.calls[0]![0] as {
+            html: string
+            text: string
+        }
+        expect(payload.text).not.toContain('PostHog event:')
+        expect(payload.html).not.toContain('activity/explore')
+        expect(payload.html).not.toContain('Open this feedback event')
+    })
+
+    it('POSTHOG_PROJECT_UI_URL configured → BOTH parts carry the SAME deep link to THIS feedback event', async () => {
+        // env is parsed at module load, so re-evaluate the route against the
+        // stubbed process.env; the hoisted mocks (shared instances) still
+        // intercept the fresh module graph.
+        vi.stubEnv(
+            'POSTHOG_PROJECT_UI_URL',
+            'https://posthog.example.com/project/123',
+        )
+        vi.resetModules()
+        try {
+            const { POST: postWithLink } = await import(
+                '@/app/api/support/route'
+            )
+            const res = await postWithLink(supportRequest(validBody()))
+            expect(res.status).toBe(200)
+
+            const payload = sendEmailMock.mock.calls[0]![0] as {
+                html: string
+                text: string
+            }
+            const textUrl = payload.text
+                .split('PostHog event: ')[1]
+                ?.split('\n')[0]
+            expect(textUrl).toBeTruthy()
+            // The link targets the configured project's activity explorer,
+            // filtered on THIS submission's feedback_id.
+            expect(
+                textUrl!.startsWith(
+                    'https://posthog.example.com/project/123/activity/explore#q=',
+                ),
+            ).toBe(true)
+            expect(textUrl).toContain(FEEDBACK_ID)
+            // The html href is the IDENTICAL url — the two bodies can never
+            // point an operator at different places.
+            expect(payload.html).toContain(`href="${textUrl}"`)
+        } finally {
+            vi.unstubAllEnvs()
+            vi.resetModules()
+        }
+    })
+
     it('sends BOTH a rendered html part and the plain-text part, carrying the same report', async () => {
         // The bug this pins: the route used to pass `text` only, and email.ts
         // dropped that raw text into the html body — so the operator's copy


### PR DESCRIPTION
Support emails now carry an "Open this feedback event in PostHog" deep link (both the HTML and plain-text parts, always the identical URL), pointing at the activity explorer filtered on the submission's feedback_id.

- New optional env POSTHOG_PROJECT_UI_URL (browser UI URL of the deploy's PostHog project, project id included). Unset → the email simply carries no link; the real value lives only in the deploy env (public repo).
- The #q= query shape was proven against the live self-hosted explorer before being hardcoded (renders the feedback_id filter chip + exactly the one matching event row).
- src/lib/analytics/posthogLinks.ts is the one home for the URL; the route feeds both body parts from it so they can never point at different places.
- Pins: tests/unit/posthog-links.test.ts (shape, exact filter, -90d window, trailing-slash tolerance, unset → undefined) + support-route.test.ts (unset env → NEITHER part links; set env → BOTH parts carry the SAME url containing the feedback_id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)