### PR TITLE
fix(ext): 1.4.1 — permission dead-state gets a fixable prompt; popup loader centred

### DIFF
--- a/apps/caramel-extension/.size-limit.js
+++ b/apps/caramel-extension/.size-limit.js
@@ -54,7 +54,14 @@ module.exports = [
         // Safari has no launchWebAuthFlow, so this is the only in-popup
         // sign-in it has). Real behaviour, measured 8.71 kB. This is the raise
         // the header sanctions: a whole flow arrived, not prose.
-        limit: '9.6 KB',
+        // 2026-08-19, raised 9.6 -> 11 kB: permission-state.js joined this
+        // group (it is popup-realm logic — see the GROUPS note in
+        // measure-size.mjs). It is the missing-host-permission machinery: the
+        // promise/callback bridge over the two permissions APIs, the
+        // every-website match pattern per runtime, the reachability probe that
+        // tells "the browser refused us" apart from "you are offline", and the
+        // gesture-safe request. Measured 10.04 kB.
+        limit: '11 KB',
         brotli: false,
     },
     {
@@ -65,7 +72,11 @@ module.exports = [
         // profile, unsupported, load-error), toast, banner, and caramel-ui's
         // sources. Vendor react/react-dom are deliberately NOT weighed — see
         // measure-size.mjs — so growth here is always OUR code growing.
-        limit: '30 KB',
+        // 2026-08-19, raised 30 -> 33.5 kB: a seventh view (PermissionView,
+        // the browser-refused-us state that used to render as a connection
+        // error) plus the AllSitesBanner component for the narrow-grant
+        // install. Measured 30.39 kB — two real surfaces, not prose.
+        limit: '33.5 KB',
         brotli: false,
     },
     {

--- a/apps/caramel-extension/background.js
+++ b/apps/caramel-extension/background.js
@@ -280,6 +280,29 @@ export function initBackground() {
 
     currentBrowser.tabs.onUpdated.addListener(_caramelOnTabUpdated)
 
+    // The user granted us host access (permission-state.js requestAllSites, or
+    // the browser's own permissions UI). The popup does not need telling — it
+    // re-derives permission state on every open — so this records the fact and
+    // nothing else. It exists because Firefox's permission doorhanger can tear
+    // the popup down while the prompt is open, which kills the continuation
+    // that would otherwise have been the only trace that the grant landed.
+    // Guarded: `permissions` is absent in some runtimes, and a missing
+    // listener must not take the worker's registration turn down with it.
+    if (currentBrowser.permissions?.onAdded?.addListener) {
+        currentBrowser.permissions.onAdded.addListener(permissions => {
+            const origins = permissions?.origins ?? []
+            if (CARAMEL_ENV.verbose)
+                console.log('Caramel: permissions granted', origins)
+            try {
+                currentBrowser.storage.local.set({
+                    caramel_all_sites_granted_at: Date.now(),
+                })
+            } catch (err) {
+                logError('permissionsOnAdded', err)
+            }
+        })
+    }
+
     currentBrowser.runtime.onMessage.addListener(
         (message, sender, sendResponse) => {
             if (!message || typeof message.action !== 'string') return

--- a/apps/caramel-extension/caramel-base.js
+++ b/apps/caramel-extension/caramel-base.js
@@ -70,6 +70,23 @@ export function initCaramelBase() {
     }
 }
 
+/* Which runtime this build is actually executing in. Safari is identified by
+ * the scheme of its OWN extension origin, not by the user agent and not at
+ * build time: the Safari artifact IS the chrome-mv3 build put through
+ * safari-web-extension-converter (see release-extension.yml publish_safari), so
+ * every build-time stamp in it still reads "chrome".
+ *
+ * Lives here rather than in popup-core.js (its home until 2026-08-19) because
+ * it reads nothing but `currentBrowser`, and two modules now need it —
+ * popup-core's signInStrategy() and permission-state's origin pattern. Leaving
+ * it in popup-core would have made permission-state import popup-core while
+ * popup-core imports permission-state; a cycle whose reads all happen at call
+ * time would work, but the leaf that owns `currentBrowser` is the honest home. */
+export function isSafariExtensionRuntime() {
+    const url = currentBrowser.runtime?.getURL?.('')
+    return typeof url === 'string' && url.startsWith('safari-web-extension://')
+}
+
 /* --------------------------------------------------  tiny helpers */
 // sleep/log/recordTiming/logError were guarded `var`s
 // (`if (typeof sleep === 'undefined') { var sleep = … }`) so a re-injected

--- a/apps/caramel-extension/entrypoints/popup/App.tsx
+++ b/apps/caramel-extension/entrypoints/popup/App.tsx
@@ -9,6 +9,7 @@ import { ToastProvider } from './components/toast'
 import type { AppApi, ResolvedState } from './types'
 import { CouponsView } from './views/CouponsView'
 import { LoadErrorView } from './views/LoadErrorView'
+import { PermissionView } from './views/PermissionView'
 import { ProfileCard } from './views/ProfileCard'
 import { SettingsView } from './views/SettingsView'
 import { SignInView } from './views/SignInView'
@@ -89,12 +90,16 @@ export function App() {
 
     // Vanilla contract: the gear is hidden by default, shown by every view
     // that wires it (coupons/unsupported/profile/settings), hidden again by
-    // the sign-in prompt, and never wired by renderLoadError.
+    // the sign-in prompt, and never wired by renderLoadError. `permission` is
+    // the same kind of dead end as loadError — nothing behind the gear helps
+    // an extension the browser is refusing — so it hides it too.
     const gearVisible =
         booted &&
         overlay !== 'signin' &&
         (overlay === 'settings' ||
-            (resolved !== null && resolved.view !== 'loadError'))
+            (resolved !== null &&
+                resolved.view !== 'loadError' &&
+                resolved.view !== 'permission'))
 
     const domain =
         resolved &&
@@ -190,6 +195,8 @@ export function App() {
                             />
                         ) : resolved?.view === 'profile' ? (
                             <ProfileCard user={resolved.user} api={api} />
+                        ) : resolved?.view === 'permission' ? (
+                            <PermissionView api={api} />
                         ) : resolved?.view === 'loadError' ? (
                             <LoadErrorView onRetry={refresh} />
                         ) : null}

--- a/apps/caramel-extension/entrypoints/popup/components/AllSitesBanner.tsx
+++ b/apps/caramel-extension/entrypoints/popup/components/AllSitesBanner.tsx
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+    requestAllSites,
+    resolveAllSitesGranted,
+} from '../../../permission-state.js'
+import type { AllSitesGranted, AppApi } from '../types'
+
+/**
+ * The half-working install, which has no symptom of its own: the API is
+ * reachable through an old narrow host grant, so coupons load and the popup
+ * looks healthy, while the content script is dead on every store and
+ * auto-apply silently never runs. Firefox auto-updates from <=1.0.3 kept
+ * exactly four old host grants and produce this state on their own.
+ *
+ * Resolves its OWN state after mount rather than taking it from
+ * resolvePopupState(). That is deliberate: this is an advisory strip above
+ * content that already loaded, and the popup's boot must never wait on a
+ * permissions API answering. A runtime whose `contains()` never calls back
+ * would otherwise hold the spinner up over a perfectly good coupon list.
+ *
+ * Renders on an explicit `false` ONLY. `null` means the runtime would not tell
+ * us whether the grant exists, and warning a working install about a
+ * permission it already has is worse than staying quiet.
+ */
+export function AllSitesBanner({ api }: { api: AppApi }) {
+    const [granted, setGranted] = useState<AllSitesGranted>(null)
+
+    // Re-read rather than assume: the prompt's own answer says what the USER
+    // clicked, and `contains()` says what the browser actually recorded —
+    // Safari can hand back something narrower than it was asked for.
+    const recheck = useCallback(() => {
+        let alive = true
+        void resolveAllSitesGranted().then((value: AllSitesGranted) => {
+            if (alive) setGranted(value)
+        })
+        return () => {
+            alive = false
+        }
+    }, [])
+
+    useEffect(() => recheck(), [recheck])
+
+    if (granted !== false) return null
+    return (
+        <div className="all-sites-banner">
+            <p>Caramel can&apos;t run on every store yet.</p>
+            <button
+                type="button"
+                id="allSitesEnableBtn"
+                className="all-sites-banner-btn"
+                onClick={() =>
+                    requestAllSites(() => {
+                        recheck()
+                        // The rest of the popup was resolved without the grant;
+                        // re-run it now that stores are reachable.
+                        api.refresh()
+                    })
+                }
+            >
+                Enable
+            </button>
+        </div>
+    )
+}

--- a/apps/caramel-extension/entrypoints/popup/types.ts
+++ b/apps/caramel-extension/entrypoints/popup/types.ts
@@ -30,6 +30,17 @@ export interface CouponsPage {
     hasMore?: boolean
 }
 
+/**
+ * Whether the browser holds the every-website host grant, as
+ * permission-state.js resolves it. `null` means the runtime could not tell us
+ * — it is NOT `false`, and only an explicit `false` may show the banner: a
+ * false alarm on a working install is worse than saying nothing.
+ *
+ * Deliberately NOT part of ResolvedState: it is resolved by AllSitesBanner
+ * after mount, so the popup's boot never waits on a permissions API answering.
+ */
+export type AllSitesGranted = boolean | null
+
 export type ResolvedState =
     | {
           view: 'coupons'
@@ -40,6 +51,10 @@ export type ResolvedState =
       }
     | { view: 'unsupported'; user: PopupUser | null; domain?: string }
     | { view: 'profile'; user: PopupUser }
+    /** The browser refused our requests outright — the host grant is missing,
+     *  and the connection copy of `loadError` would send the user hunting for
+     *  a network fault that does not exist. */
+    | { view: 'permission' }
     | { view: 'loadError' }
 
 /** Navigation the App hands every view. */

--- a/apps/caramel-extension/entrypoints/popup/views/CouponsView.tsx
+++ b/apps/caramel-extension/entrypoints/popup/views/CouponsView.tsx
@@ -8,6 +8,7 @@ import {
     signOutAndRevoke,
 } from '../../../popup-core.js'
 import { caramelCopyText } from '../../../UI-helpers.js'
+import { AllSitesBanner } from '../components/AllSitesBanner'
 import { CouponCard } from '../components/CouponCard'
 import { SavingsBanner } from '../components/SavingsBanner'
 import { useToast } from '../components/toast'
@@ -399,6 +400,8 @@ export function CouponsView({
                     </button>
                 )}
             </div>
+
+            <AllSitesBanner api={api} />
 
             <SavingsBanner />
 

--- a/apps/caramel-extension/entrypoints/popup/views/PermissionView.tsx
+++ b/apps/caramel-extension/entrypoints/popup/views/PermissionView.tsx
@@ -1,0 +1,69 @@
+import { Button } from 'caramel-ui'
+import { isSafariExtensionRuntime } from '../../../caramel-base.js'
+import { requestAllSites } from '../../../permission-state.js'
+import type { AppApi } from '../types'
+
+/**
+ * The browser refused our requests: the every-website host grant is missing,
+ * so the background fetch never left the machine and LoadErrorView used to
+ * paint "Check your connection and try again" over a perfectly good
+ * connection. Two real cohorts land here — Firefox auto-updates from <=1.0.3,
+ * which silently kept only the four old narrow host grants, and fresh installs
+ * where the grant is left unchecked.
+ *
+ * Modelled on LoadErrorView: same `.no-coupons-view` shell, same illustration
+ * disc, same single caramel-ui action. The difference is that this one is
+ * FIXABLE from inside the popup, so the button asks for the grant instead of
+ * retrying a request that cannot succeed.
+ */
+export function PermissionView({ api }: { api: AppApi }) {
+    // Safari's request() may hand back a narrower grant than it was asked for
+    // (or nothing at all) — the every-website state really lives behind its
+    // own menus, so it gets the manual route spelled out under the button
+    // rather than a prompt that can silently do nothing.
+    const safari = isSafariExtensionRuntime()
+
+    return (
+        <div className="no-coupons-view fade-in-up">
+            <div className="empty-illu" aria-hidden="true">
+                <svg
+                    width="28"
+                    height="28"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="#ea6925"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                >
+                    <rect x="4" y="10.5" width="16" height="10" rx="2" />
+                    <path d="M8 10.5V7a4 4 0 0 1 8 0" />
+                    <path d="M12 14.5v2" />
+                </svg>
+            </div>
+            <h3>Enable Caramel to get started</h3>
+            <p>
+                Your browser has site access turned off for Caramel, so it
+                can&apos;t reach our coupons or run on the stores you visit. One
+                click turns it back on.
+            </p>
+            <div className="no-coupons-actions">
+                <Button
+                    variant="primary"
+                    onClick={() => requestAllSites(api.refresh)}
+                >
+                    Enable Caramel
+                </Button>
+            </div>
+            {safari && (
+                <p className="permission-manual-note">
+                    If nothing happens, set it yourself: on Mac, click the
+                    Caramel button in the toolbar and choose{' '}
+                    <strong>Always Allow on Every Website</strong>. On iPhone or
+                    iPad, tap <strong>AA</strong> in the address bar, choose
+                    Caramel, then <strong>Always Allow</strong>.
+                </p>
+            )}
+        </div>
+    )
+}

--- a/apps/caramel-extension/entrypoints/popup/views/UnsupportedView.tsx
+++ b/apps/caramel-extension/entrypoints/popup/views/UnsupportedView.tsx
@@ -4,6 +4,7 @@ import {
     caramelUrl,
     signOutAndRevoke,
 } from '../../../popup-core.js'
+import { AllSitesBanner } from '../components/AllSitesBanner'
 import type { AppApi, PopupUser } from '../types'
 
 /**
@@ -81,6 +82,8 @@ export function UnsupportedView({
 
             <h3>{heading}</h3>
             <p>{body}</p>
+
+            <AllSitesBanner api={api} />
 
             <div className="no-coupons-actions">
                 {!coveredButDry && (

--- a/apps/caramel-extension/eslint.config.cjs
+++ b/apps/caramel-extension/eslint.config.cjs
@@ -10,12 +10,19 @@ module.exports = [
         // `pnpm --filter caramel-app generate:coupon-constants`.
         // Build outputs (old build: dist*/; WXT: .output/, .wxt/) are
         // artifacts, never sources — the parity harness owns their contents.
+        // .size-cache/ joined them 2026-08-19: it holds the MINIFIED bundles
+        // `pnpm size` writes for size-limit to weigh, and linting them is
+        // meaningless (two of them fail to even parse, since minifiers reuse
+        // identifiers across the concatenated files). Left unignored, whether
+        // `pnpm lint` passed depended on whether `pnpm size` had been run
+        // first — a gate that answers differently by invocation order.
         ignores: [
             'coupon-constants.generated.js',
             'dist/**',
             'dist-*/**',
             '.output/**',
             '.wxt/**',
+            '.size-cache/**',
         ],
     },
     {

--- a/apps/caramel-extension/package.json
+++ b/apps/caramel-extension/package.json
@@ -1,6 +1,6 @@
 {
     "name": "caramel-extension",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "description": "Caramel browser extension",
     "private": true,
     "scripts": {

--- a/apps/caramel-extension/permission-state.js
+++ b/apps/caramel-extension/permission-state.js
@@ -1,0 +1,176 @@
+// owns: the every-website host-permission grant — reading whether we have it,
+// and asking the browser for it from a user gesture.
+//
+// Why this module exists (measured in real Firefox, 2026-08-18): with the
+// `https://*/*` grant missing, the background fetch to the API fails (the
+// server sends no CORS headers to an origin it was never asked to trust) and
+// the popup painted LoadErrorView — "Couldn't load coupons — check your
+// connection and try again". The connection was fine. The extension simply had
+// no permission to use it, and the copy sent users hunting for a network fault
+// that did not exist. Two real cohorts land here: Firefox auto-updates from
+// <=1.0.3, which silently kept only the four old narrow host grants, and fresh
+// installs where the user leaves the box unchecked.
+//
+// The extension had ZERO `permissions.*` usage before this module.
+
+import { isSafariExtensionRuntime } from './caramel-base.js'
+import { CARAMEL_BASE_URL } from './caramel-env.js'
+
+/**
+ * The permissions API as PROMISES, or null where the runtime has none.
+ *
+ * Firefox and Safari expose a promise-style `browser.permissions`; Chrome and
+ * Edge expose a callback-style `chrome.permissions`. The distinction is not
+ * cosmetic here: caramel-base's bootstrap resolves `currentBrowser` to
+ * `chrome` FIRST when both globals exist, which on Firefox is the
+ * callback-shaped object — so reading the API off `currentBrowser` and calling
+ * `.then` on the result would silently do nothing on the one browser this
+ * whole module was written for. Prefer `browser` explicitly, wrap `chrome`.
+ */
+function getPermissionsApi() {
+    const promiseStyle = globalThis.browser?.permissions
+    if (promiseStyle && typeof promiseStyle.contains === 'function') {
+        return {
+            contains: perms => promiseStyle.contains(perms),
+            request: perms => promiseStyle.request(perms),
+        }
+    }
+
+    const callbackStyle = globalThis.chrome?.permissions
+    if (callbackStyle && typeof callbackStyle.contains === 'function') {
+        const wrap = method => perms =>
+            new Promise((resolve, reject) => {
+                try {
+                    callbackStyle[method](perms, result => {
+                        const err = globalThis.chrome?.runtime?.lastError
+                        if (err) reject(new Error(err.message || String(err)))
+                        else resolve(result)
+                    })
+                } catch (e) {
+                    reject(e)
+                }
+            })
+        return { contains: wrap('contains'), request: wrap('request') }
+    }
+
+    return null
+}
+
+// The match pattern that MEANS "every website" to this runtime.
+//
+// Safari only treats <all_urls> (or *://*/*) as the every-website grant —
+// handed https://*/* it records a narrower permission and the "Always Allow on
+// Every Website" state never turns on. Chrome, Edge and Firefox take
+// https://*/*, which is exactly what the manifest's host_permissions asks for,
+// so contains() compares like against like.
+//
+// Line comments rather than a block: the patterns themselves contain `*/`,
+// which would close a /* */ comment mid-sentence.
+export function allSitesOriginPattern() {
+    return isSafariExtensionRuntime() ? '<all_urls>' : 'https://*/*'
+}
+
+/**
+ * Does the browser hold the every-website grant? `true` / `false`, or `null`
+ * when the runtime cannot tell us (no permissions API, a throw, an answer that
+ * is not a boolean). `null` is not `false`: the banner keys on an explicit
+ * `false`, because telling a working install it has no permission is worse
+ * than saying nothing.
+ *
+ * Carries NO timeout on purpose. Its one caller is a React effect on a banner
+ * that starts hidden, so a callback-style API that never calls back simply
+ * leaves this pending and shows no banner — which is already the right answer
+ * for a runtime that cannot tell us. A deadline here would buy nothing and
+ * cost a live timer on every mount.
+ */
+export function resolveAllSitesGranted() {
+    const api = getPermissionsApi()
+    if (!api) return Promise.resolve(null)
+    return api
+        .contains({ origins: [allSitesOriginPattern()] })
+        .then(has => (typeof has === 'boolean' ? has : null))
+        .catch(() => null)
+}
+
+/**
+ * Can an extension page reach our own API at all? Returns 'ok' for ANY
+ * response (a 404, a 429 and a 500 all prove the request was allowed to
+ * leave), 'blocked' for the `TypeError` a missing host permission produces,
+ * and 'err' for anything else.
+ *
+ * Deliberately NOT branched on the error message: "NetworkError when
+ * attempting to fetch resource" (Firefox) and "Failed to fetch" (Chromium) are
+ * the same fact spelled two ways, and Safari spells it a third. The TYPE is
+ * the contract — `fetch` rejects with `TypeError` and nothing else for a
+ * request the browser refused to make.
+ */
+async function probeApiReachable() {
+    try {
+        await fetch(
+            new URL(
+                'api/extension/supported-stores',
+                `${CARAMEL_BASE_URL}/`,
+            ).toString(),
+            { method: 'GET' },
+        )
+        return 'ok'
+    } catch (e) {
+        return e instanceof TypeError ? 'blocked' : 'err'
+    }
+}
+
+/**
+ * Why the popup could not load coupons, when it could not:
+ *
+ *   'granted'          — the request left the machine; permissions are not it
+ *   'needs_permission' — the browser refused the request outright
+ *   'network'          — a real transport failure; the connection copy is right
+ *   'unknown'          — the runtime has no permissions API, so there is
+ *                        nothing this popup could offer to fix
+ *
+ * The PROBE decides on its own, and `contains()` is deliberately NOT consulted
+ * here. Chrome's `contains()` answers about the effective grant, which our
+ * manifest's overlapping `content_scripts` patterns muddy, so it is not
+ * trustworthy enough to bury a working install behind a permission prompt —
+ * and a narrow-but-working grant leads to the same view as a healthy one
+ * anyway, so asking would only be work that changes no answer.
+ *
+ * Only called when the coupon fetch has already FAILED, so its extra request
+ * costs a user nothing on the path they actually walk — see the success-path
+ * note in popup-core.js resolvePopupState().
+ */
+export async function resolvePermissionState() {
+    // A false gate is worse than no gate, and a permission view whose button
+    // cannot request anything is a dead end: with nothing to ask and nothing
+    // to offer, say so and let the caller render the failure it already had.
+    if (!getPermissionsApi()) return 'unknown'
+
+    const probe = await probeApiReachable()
+    if (probe === 'blocked') return 'needs_permission'
+    if (probe === 'err') return 'network'
+    return 'granted'
+}
+
+/**
+ * Ask for the every-website grant. MUST be called straight out of a click:
+ * all four browsers reject `permissions.request()` that is not attributable to
+ * a user gesture, and an `await` before it ends the gesture. Everything above
+ * the request here is synchronous by construction — no await, no microtask.
+ *
+ * `onGranted` may never run on Firefox: its permission doorhanger can tear the
+ * popup down while the prompt is open, taking this continuation with it. That
+ * is fine and deliberate — the popup re-derives permission state on every
+ * open, so the next open shows the truth either way.
+ */
+export function requestAllSites(onGranted) {
+    const api = getPermissionsApi()
+    if (!api) return
+    api.request({ origins: [allSitesOriginPattern()] })
+        .then(granted => {
+            if (granted) onGranted()
+        })
+        .catch(() => {
+            // A refused or dismissed prompt is an ANSWER, not a fault: the
+            // view stays exactly as it was and the user can ask again.
+        })
+}

--- a/apps/caramel-extension/popup-core.js
+++ b/apps/caramel-extension/popup-core.js
@@ -18,10 +18,18 @@ import {
     caramelSetSettings,
     caramelSyncSavings,
     currentBrowser,
+    isSafariExtensionRuntime,
     log,
 } from './caramel-base.js'
 import { CARAMEL_ENV } from './caramel-env.js'
 import { fetchCouponsPage } from './coupon-fetch.js'
+import { resolvePermissionState } from './permission-state.js'
+
+// isSafariExtensionRuntime moved to caramel-base.js (2026-08-19) so
+// permission-state.js could read it without importing this module back. It is
+// re-exported here because signInStrategy() below is its other caller and the
+// Safari OAuth pins address it through this module.
+export { isSafariExtensionRuntime }
 
 // Base URL from the build-time environment stamp (caramel-env.js, the first
 // module the popup realm evaluates). This used to call a shared
@@ -150,12 +158,26 @@ async function getActiveTabDomainRecord() {
  * The decision flow that was initPopup(), returning WHAT to render instead of
  * painting it — React owns the painting (and the 400ms anti-flicker floor the
  * old DOMContentLoaded bootstrap kept). Resolves to one of:
- *   {view:'coupons', coupons, user, domain, page} — page = the full envelope
+ *   {view:'coupons', coupons, user, domain, page}
  *   {view:'unsupported', user, domain}            — domain undefined = no tab
  *   {view:'profile', user}
+ *   {view:'permission'}
  *   {view:'loadError'}
  * `onSessionInvalid` is handed to validateStoredSession — the React app
  * passes its re-resolve so a dead session repaints logged-out.
+ *
+ * Host permission (2026-08-19), on the FAILURE path only. When the fetch
+ * fails, "the network is down" and "the browser refused to make the request"
+ * are indistinguishable from here, and the second one was being reported as
+ * the first — resolvePermissionState() probes and says which, and only an
+ * explicit 'needs_permission' takes over the view. Its extra request is paid
+ * on a path that is already broken.
+ *
+ * The SUCCESS path deliberately asks nothing. A successful fetch already
+ * proves the extension can reach the API, so the probe's answer is known in
+ * advance; and the remaining question — is the grant NARROW, leaving the
+ * content script dead on every store? — is asked by AllSitesBanner after it
+ * mounts, not here. Boot must never wait on a permissions API answering.
  */
 export async function resolvePopupState(onSessionInvalid) {
     // The service worker can reply undefined on a cold start / error; never let
@@ -202,7 +224,7 @@ export async function resolvePopupState(onSessionInvalid) {
             try {
                 page = await fetchCouponsPage(domain, '', '', 1)
             } catch {
-                return { view: 'loadError' }
+                return await failedToLoad()
             }
             const coupons = page.coupons
 
@@ -216,8 +238,20 @@ export async function resolvePopupState(onSessionInvalid) {
         if (token) return { view: 'profile', user }
         return { view: 'unsupported', user: null, domain: undefined }
     } catch {
-        return { view: 'loadError' }
+        return await failedToLoad()
     }
+}
+
+/* The two ways resolvePopupState() gives up, and the one question worth asking
+ * before it does: did the browser refuse the request? Only an explicit
+ * 'needs_permission' takes the view — 'network', 'unknown' and the two grant
+ * answers all keep the honest connection error, because sending someone to a
+ * permission prompt that is already granted is a dead end with no retry. */
+async function failedToLoad() {
+    const permission = await resolvePermissionState()
+    return permission === 'needs_permission'
+        ? { view: 'permission' }
+        : { view: 'loadError' }
 }
 
 /* Validates the stored session token against GET /api/extension/me. The
@@ -597,16 +631,6 @@ const SAFARI_OAUTH_PENDING_KEYS = [
     'pendingOauthExpiresAt',
     'pendingOauthProvider',
 ]
-
-/* Which sign-in route this runtime can actually take. Safari is identified by
- * the scheme of its OWN extension origin, not by the user agent and not at
- * build time: the Safari artifact IS the chrome-mv3 build put through
- * safari-web-extension-converter (see release-extension.yml publish_safari), so
- * every build-time stamp in it still reads "chrome". */
-export function isSafariExtensionRuntime() {
-    const url = currentBrowser.runtime?.getURL?.('')
-    return typeof url === 'string' && url.startsWith('safari-web-extension://')
-}
 
 /**
  * 'identity'    — Chrome/Edge: launchWebAuthFlow, in-popup, unchanged.

--- a/apps/caramel-extension/public/assets/styles.css
+++ b/apps/caramel-extension/public/assets/styles.css
@@ -31,22 +31,35 @@ body {
     background: var(--cm-bg);
 }
 
-/* --- Loading skeleton ---
-   Light ghost bars INSIDE the card footprint (replaces the old dark scrim +
-   pulsing logo overlay): a header bar ghost + 3 coupon-ticket ghost rows with
-   a subtle background-position shimmer. popup.js keeps the same contract —
-   sets display:none on #loading-container once the real fetch resolves. */
+/* --- Loading overlay ---
+   The full-bleed scrim the popup shows until BOTH the 400ms anti-flicker floor
+   and the real coupon resolve have landed (App.tsx). It holds ONE child: the
+   caramel-ui Spinner, a fixed 28px box.
+
+   The centering is load-bearing, not decoration (reported on Firefox
+   2026-08-18, present in every browser). This was a column flex container with
+   no alignment at all, so the spinner sat at the flex line's start — jammed
+   into the top-left corner of an otherwise empty 420px panel, which reads as a
+   broken popup rather than a loading one. `flex-direction: column` and the
+   14px `gap` came from the multi-child skeleton this overlay used to hold and
+   mean nothing to a single centered child; they are gone with it. */
 .loading-container {
     position: absolute;
     inset: 0;
     z-index: 999;
     display: flex;
-    flex-direction: column;
-    gap: 14px;
+    align-items: center;
+    justify-content: center;
     padding: 24px 20px;
     box-sizing: border-box;
     background: var(--cm-bg);
 }
+
+/* --- Coupon-list skeleton ---
+   The ghost row CouponsView paints in the infinite-scroll footer while the
+   next page is in flight. The header-bar ghost rule that used to sit here died
+   with the boot skeleton above — nothing had rendered it since (2026-08-19),
+   and tests/popup-permission-gate.test.tsx asserts its selector is gone. */
 .skeleton {
     background: linear-gradient(
         90deg,
@@ -57,11 +70,6 @@ body {
     background-size: 200% 100%;
     animation: skeletonShimmer 1.4s var(--cm-ease-in-out) infinite;
     border-radius: var(--cm-radius-md);
-}
-.skeleton-header {
-    height: 36px;
-    width: 60%;
-    margin: 0 auto 6px;
 }
 .skeleton-ticket {
     height: 84px;
@@ -848,6 +856,56 @@ body {
     font-size: 13px;
     line-height: 1.5;
     color: var(--cm-text-secondary);
+}
+
+/* --- Missing-every-website-grant banner -------------------------
+   One slim row, shown ONLY when the browser told us the grant is absent
+   (AllSitesBanner). It sits above content that loaded fine, so it stays
+   deliberately quiet: a tinted strip, not an error. */
+.all-sites-banner {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 12px;
+    padding: 9px 10px;
+    border-radius: 10px;
+    background: var(--cm-brand-soft);
+    border: 1px solid var(--cm-brand-soft-4);
+    text-align: left;
+}
+.all-sites-banner p {
+    /* Beats `.no-coupons-view p`, which would add an 18px bottom margin and
+       centre the text inside a row that is neither. */
+    margin: 0;
+    flex: 1;
+    font-size: 12px;
+    line-height: 1.4;
+    color: var(--cm-text-secondary);
+}
+.all-sites-banner-btn {
+    flex: none;
+    padding: 6px 12px;
+    border: none;
+    border-radius: 8px;
+    background: var(--cm-brand);
+    color: var(--cm-on-brand);
+    font-size: 12px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: background var(--cm-dur-fast) var(--cm-ease);
+}
+.all-sites-banner-btn:hover {
+    background: var(--cm-brand-strong);
+}
+
+/* The Safari fallback instructions under the permission view's button — the
+   every-website grant lives behind Safari's own menus, so the copy has to name
+   them. Quieter than `.no-coupons-view p` and with no trailing margin. */
+.permission-manual-note {
+    margin: 14px 0 0;
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--cm-text-muted-2);
 }
 
 /* Stacked full-width actions read far cleaner than a wrapped icon+button row. */

--- a/apps/caramel-extension/scripts/measure-size.mjs
+++ b/apps/caramel-extension/scripts/measure-size.mjs
@@ -71,8 +71,11 @@ export const GROUPS = {
         'inject.js',
     ],
     // popup.js became popup-core.js in P2: the logic module keeps its own
-    // budget, and the React views/shell get theirs below.
-    popup: ['popup-core.js'],
+    // budget, and the React views/shell get theirs below. permission-state.js
+    // is popup-realm logic too (popup-core imports it; the views call its
+    // request helper), so it is weighed here rather than escaping the ratchet
+    // by being a new file.
+    popup: ['popup-core.js', 'permission-state.js'],
     // The popup's OWN React code (P2): everything TSX/TS under the popup
     // entrypoint plus caramel-ui's sources, which ship in the same chunk.
     // Deliberately NOT the built chunk: react/react-dom are a fixed vendor

--- a/apps/caramel-extension/scripts/parity-expected-diffs.json
+++ b/apps/caramel-extension/scripts/parity-expected-diffs.json
@@ -73,6 +73,34 @@
             "added": "2026-08-13"
         },
         {
+            "browser": "chrome",
+            "path": "/version",
+            "reason": "1.4.0 -> 1.4.1 (package.json is the single version authority): the missing-host-permission gate and the top-left loader fix. The goldens are frozen 1.3.1 snapshots relabelled 1.4.0 and cannot follow a release without being re-frozen",
+            "retiredBy": "golden-rebaseline(1.4.1)",
+            "added": "2026-08-19"
+        },
+        {
+            "browser": "chrome",
+            "path": "/optional_host_permissions",
+            "reason": "runtime-requestable every-website grant, added 2026-08-19 so permission-state.js requestAllSites() can ask for it from a click (see the wxt.config.ts note); a no-op on Chrome, declared for all browsers to keep one code path",
+            "retiredBy": "golden-rebaseline(1.4.1)",
+            "added": "2026-08-19"
+        },
+        {
+            "browser": "firefox",
+            "path": "/version",
+            "reason": "1.4.0 -> 1.4.1 (package.json is the single version authority): the missing-host-permission gate and the top-left loader fix. The goldens are frozen 1.3.1 snapshots relabelled 1.4.0 and cannot follow a release without being re-frozen",
+            "retiredBy": "golden-rebaseline(1.4.1)",
+            "added": "2026-08-19"
+        },
+        {
+            "browser": "firefox",
+            "path": "/optional_host_permissions",
+            "reason": "runtime-requestable every-website grant, added 2026-08-19 so permission-state.js requestAllSites() can ask for it from a click; the Gecko contract is that request() may only name origins the manifest listed as optional, and the Firefox <=1.0.3 upgrade cohort is exactly who needs to ask",
+            "retiredBy": "golden-rebaseline(1.4.1)",
+            "added": "2026-08-19"
+        },
+        {
             "browser": "firefox",
             "path": "/background/scripts",
             "reason": "the env stamp is BUNDLED into background.js instead of a separate manifest entry — the stamp-first guarantee moves from manifest order into the module graph (P1 pins it there)",

--- a/apps/caramel-extension/tests/popup-loader.test.tsx
+++ b/apps/caramel-extension/tests/popup-loader.test.tsx
@@ -73,6 +73,15 @@ let chromeStub: any
 beforeAll(() => {
     initCouponConstants()
     chromeStub = installChromeStub()
+
+    // See the same note in tests/popup.test.tsx: a failed coupon fetch now
+    // asks permission-state.js why before it paints (2026-08-19). Both halves
+    // are stubbed healthy so this pin keeps owning the loader LIFECYCLE and
+    // nothing else — and so the probe never reaches the real network, which
+    // would make the rejecting-transport case depend on the machine's
+    // connectivity rather than on the transport under test.
+    chromeStub.permissions.contains = (_perms: unknown, cb: any) => cb(true)
+    globalThis.fetch = () => Promise.resolve(new Response('{}'))
 })
 
 beforeEach(() => {

--- a/apps/caramel-extension/tests/popup-permission-gate.test.tsx
+++ b/apps/caramel-extension/tests/popup-permission-gate.test.tsx
@@ -1,0 +1,317 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { initCaramelBase } from '../caramel-base.js'
+import { initCouponConstants } from '../coupon-constants.generated.js'
+import { App } from '../entrypoints/popup/App'
+import { allSitesOriginPattern } from '../permission-state.js'
+
+/**
+ * The missing-host-permission gate (2026-08-18/19).
+ *
+ * Measured in real Firefox: with the `https://*` + `/*` grant absent, the
+ * background fetch to the API fails (the server sends no CORS headers to an
+ * origin it was never asked to trust) and the popup painted LoadErrorView —
+ * "Couldn't load coupons — check your connection and try again". The
+ * connection was fine; the browser had refused the request. Two cohorts land
+ * there: Firefox auto-updates from <=1.0.3, which silently kept only four old
+ * narrow host grants, and fresh installs with the box left unchecked.
+ *
+ * What these pins own is the DISCRIMINATION, in both directions. A permission
+ * prompt shown to someone who is merely offline is a dead end with no retry,
+ * which is why "the offline case keeps the connection copy" is pinned as hard
+ * as the new view is. The half-working install (API reachable on a narrow
+ * grant, content script dead on every store) has no symptom of its own, so the
+ * banner is pinned too.
+ */
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+/** Permissive chrome stub — the same Proxy harness popup-loader.test.tsx uses.
+ *  NOTE the trap it carries for this suite: anything not explicitly set is
+ *  auto-created as a callable returning undefined, so an unset
+ *  `permissions.contains` LOOKS like a working API and then never calls its
+ *  callback. Every test below therefore arms permissions explicitly — an
+ *  omission would silently exercise a branch nobody meant to test. */
+function installChromeStub() {
+    const cache = new WeakMap()
+    const wrap = (target: any): any => {
+        if (cache.has(target)) return cache.get(target)
+        const proxy = new Proxy(target, {
+            get(obj: any, prop) {
+                if (prop === 'then' || typeof prop === 'symbol')
+                    return undefined
+                if (!(prop in obj)) obj[prop] = wrap(function () {})
+                return obj[prop]
+            },
+            apply: () => undefined,
+        })
+        cache.set(target, proxy)
+        return proxy
+    }
+    const stub = wrap(function chromeStubRoot() {})
+    for (const area of ['sync', 'local', 'session']) {
+        stub.storage[area].get = (_keys: unknown, cb: any) => {
+            if (typeof cb === 'function') cb({})
+        }
+        stub.storage[area].set = (_items: unknown, cb: any) => {
+            if (typeof cb === 'function') cb()
+        }
+        stub.storage[area].remove = (_keys: unknown, cb: any) => {
+            if (typeof cb === 'function') cb()
+        }
+    }
+    stub.runtime.lastError = undefined
+    ;(globalThis as any).chrome = stub
+    ;(globalThis as any).browser = undefined
+    ;(window as any).chrome = stub
+    ;(window as any).browser = undefined
+    initCaramelBase()
+    return stub
+}
+
+let chromeStub: any
+
+/** Coupon transport: `null` answer = the fetch throws (the LoadError path). */
+function armTransport(answer: unknown) {
+    chromeStub.runtime.sendMessage = (message: any, cb: any) => {
+        if (message?.action === 'getActiveTabDomainRecord') {
+            cb({ url: 'https://example.com/cart' })
+        } else if (message?.action === 'fetchCoupons') {
+            cb(answer)
+        } else {
+            cb(undefined)
+        }
+    }
+}
+
+/** Arms permissions.contains/request. `granted` is what contains() answers;
+ *  `requestAnswer` is what the prompt resolves to. Returns the recorded calls. */
+function armPermissions(granted: boolean, requestAnswer = false) {
+    const containsCalls: unknown[] = []
+    const requestCalls: unknown[] = []
+    chromeStub.permissions.contains = (perms: unknown, cb: any) => {
+        containsCalls.push(perms)
+        cb(granted)
+    }
+    chromeStub.permissions.request = (perms: unknown, cb: any) => {
+        requestCalls.push(perms)
+        cb(requestAnswer)
+    }
+    return { containsCalls, requestCalls }
+}
+
+/** The popup-context probe permission-state.js runs when the fetch failed. */
+function armProbe(outcome: 'ok' | 'blocked' | 'err') {
+    const fetchMock = vi.fn(() => {
+        if (outcome === 'ok') return Promise.resolve(new Response('{}'))
+        // A missing host permission makes fetch reject with a TypeError; the
+        // MESSAGE differs per engine ("NetworkError when attempting to fetch
+        // resource" vs "Failed to fetch"), which is exactly why the type is
+        // what the module reads.
+        return Promise.reject(
+            outcome === 'blocked'
+                ? new TypeError(
+                      'NetworkError when attempting to fetch resource',
+                  )
+                : new Error('boom'),
+        )
+    })
+    ;(globalThis as any).fetch = fetchMock
+    return fetchMock
+}
+
+const permissionHeading = () =>
+    screen.queryByText('Enable Caramel to get started')
+const connectionHeading = () => screen.queryByText("Couldn't load coupons")
+const banner = () => screen.queryByText("Caramel can't run on every store yet.")
+
+beforeAll(() => {
+    initCouponConstants()
+    chromeStub = installChromeStub()
+})
+
+beforeEach(() => {
+    // getURL decides isSafariExtensionRuntime(); reset it so one Safari test
+    // cannot leak its runtime into the rest of the file.
+    chromeStub.runtime.getURL = () => 'chrome-extension://caramel/'
+    delete (globalThis as any).fetch
+})
+
+describe('a coupon fetch the BROWSER refused is not a connection problem', () => {
+    it('shows the permission view when the fetch fails, the probe is refused with a TypeError, and the grant is absent', async () => {
+        armTransport({ error: 'HTTP 500' })
+        armPermissions(false)
+        armProbe('blocked')
+
+        render(<App />)
+
+        await waitFor(() => expect(permissionHeading()).toBeInTheDocument())
+        // The measured symptom this replaces: connection copy over a working
+        // connection. It must be GONE, not merely joined.
+        expect(connectionHeading()).not.toBeInTheDocument()
+        expect(
+            screen.getByRole('button', { name: 'Enable Caramel' }),
+        ).toBeInTheDocument()
+    })
+
+    it('keeps the connection copy when the fetch fails for a reason that is NOT a refusal (offline, backend down)', async () => {
+        armTransport({ error: 'HTTP 500' })
+        armPermissions(false)
+        armProbe('err')
+
+        render(<App />)
+
+        await waitFor(() => expect(connectionHeading()).toBeInTheDocument())
+        // Sending someone who is offline to a permission prompt is a dead end:
+        // the grant is already theirs to give and giving it changes nothing.
+        expect(permissionHeading()).not.toBeInTheDocument()
+    })
+
+    it('keeps the connection copy when the probe itself succeeds — the request left the machine, so permissions are not the fault', async () => {
+        armTransport({ error: 'HTTP 500' })
+        armPermissions(true)
+        armProbe('ok')
+
+        render(<App />)
+
+        await waitFor(() => expect(connectionHeading()).toBeInTheDocument())
+        expect(permissionHeading()).not.toBeInTheDocument()
+    })
+
+    it('hides the settings gear on the permission view, exactly as it does on the load error', async () => {
+        armTransport({ error: 'HTTP 500' })
+        armPermissions(false)
+        armProbe('blocked')
+
+        render(<App />)
+
+        await waitFor(() => expect(permissionHeading()).toBeInTheDocument())
+        expect(
+            screen.queryByRole('button', { name: 'Open settings' }),
+        ).not.toBeInTheDocument()
+    })
+})
+
+describe('the half-working install: coupons load, but the content script is dead on every store', () => {
+    it('renders no banner when the browser confirms the every-website grant', async () => {
+        armTransport({ coupons: [{ code: 'SAVE10', status: 'valid' }] })
+        armPermissions(true)
+
+        render(<App />)
+
+        await waitFor(() =>
+            expect(screen.getByText(/Coupons for/)).toBeInTheDocument(),
+        )
+        expect(banner()).not.toBeInTheDocument()
+        // The happy path must not spend a probe request: the successful coupon
+        // fetch already proves the extension can reach the API, and
+        // /api/extension/supported-stores is DB-backed and rate-limited.
+        expect((globalThis as any).fetch).toBeUndefined()
+    })
+
+    it('renders the banner when coupons load on a NARROW grant, and its button asks for every website', async () => {
+        armTransport({ coupons: [{ code: 'SAVE10', status: 'valid' }] })
+        const { requestCalls } = armPermissions(false)
+
+        render(<App />)
+
+        await waitFor(() => expect(banner()).toBeInTheDocument())
+
+        fireEvent.click(screen.getByRole('button', { name: 'Enable' }))
+        // Asserted WITHOUT awaiting: permissions.request() must be reached
+        // inside the click's own call stack. Every browser rejects a request
+        // that is not attributable to a user gesture, and a single `await`
+        // ahead of it ends the gesture — so "it was called by the time the
+        // click returned" is the property, not "it was called eventually".
+        expect(requestCalls).toEqual([{ origins: ['https://*/*'] }])
+    })
+
+    it('re-resolves the popup when the grant is actually given, so the banner goes away without reopening', async () => {
+        armTransport({ coupons: [{ code: 'SAVE10', status: 'valid' }] })
+        // contains() says no, and the prompt says yes — the state the popup
+        // must not be left holding.
+        const granted = { value: false }
+        chromeStub.permissions.contains = (_perms: unknown, cb: any) =>
+            cb(granted.value)
+        chromeStub.permissions.request = (_perms: unknown, cb: any) => {
+            granted.value = true
+            cb(true)
+        }
+
+        render(<App />)
+        await waitFor(() => expect(banner()).toBeInTheDocument())
+
+        fireEvent.click(screen.getByRole('button', { name: 'Enable' }))
+
+        await waitFor(() => expect(banner()).not.toBeInTheDocument())
+        expect(screen.getByText(/Coupons for/)).toBeInTheDocument()
+    })
+})
+
+describe('Safari asks for a different pattern and can refuse the prompt outright', () => {
+    it('asks for <all_urls>, the only pattern Safari counts as every website, and spells out the manual route', async () => {
+        chromeStub.runtime.getURL = () => 'safari-web-extension://caramel/'
+        expect(allSitesOriginPattern()).toBe('<all_urls>')
+
+        armTransport({ error: 'HTTP 500' })
+        const { requestCalls } = armPermissions(false)
+        armProbe('blocked')
+
+        render(<App />)
+        await waitFor(() => expect(permissionHeading()).toBeInTheDocument())
+
+        // Safari's request() can hand back a narrower grant than it was asked
+        // for, or nothing at all, so the view carries the menus that always
+        // work alongside the button.
+        expect(
+            screen.getByText(/Always Allow on Every Website/),
+        ).toBeInTheDocument()
+
+        fireEvent.click(screen.getByRole('button', { name: 'Enable Caramel' }))
+        expect(requestCalls).toEqual([{ origins: ['<all_urls>'] }])
+    })
+
+    it('does not show the manual Safari route on a Chromium runtime', async () => {
+        armTransport({ error: 'HTTP 500' })
+        armPermissions(false)
+        armProbe('blocked')
+
+        render(<App />)
+        await waitFor(() => expect(permissionHeading()).toBeInTheDocument())
+        expect(
+            screen.queryByText(/Always Allow on Every Website/),
+        ).not.toBeInTheDocument()
+    })
+})
+
+describe('the loading overlay centres its spinner', () => {
+    /* jsdom does no layout, so the rendered position cannot be measured here.
+       The defect was purely declarative — a column flex container with no
+       alignment, which parks its single 28px child at the flex line's start,
+       i.e. the top-left corner of an empty 420px panel — so the source is
+       pinned instead (house style for layout that a unit runner cannot see). */
+    const css = readFileSync(join(ROOT, 'public/assets/styles.css'), 'utf8')
+    const loadingBlock = css.slice(
+        css.indexOf('.loading-container {'),
+        css.indexOf('}', css.indexOf('.loading-container {')),
+    )
+
+    it('centres on both axes', () => {
+        expect(loadingBlock).toContain('align-items: center')
+        expect(loadingBlock).toContain('justify-content: center')
+    })
+
+    it('no longer carries the column/gap left over from the multi-child skeleton', () => {
+        expect(loadingBlock).not.toContain('flex-direction: column')
+        expect(loadingBlock).not.toContain('gap:')
+    })
+
+    it('has no orphan .skeleton-header rule, and keeps the .skeleton rules CouponsView still renders', () => {
+        expect(css).not.toContain('.skeleton-header')
+        expect(css).toContain('.skeleton {')
+        expect(css).toContain('.skeleton-ticket {')
+    })
+})

--- a/apps/caramel-extension/tests/popup.test.tsx
+++ b/apps/caramel-extension/tests/popup.test.tsx
@@ -71,6 +71,18 @@ beforeAll(() => {
     initCouponConstants()
     const chromeStub = installChromeStub()
 
+    // A failed coupon fetch now asks WHY before it paints (permission-state.js,
+    // 2026-08-19): a browser that refused the request gets the permission view
+    // instead of connection copy. Both halves of that question are stubbed
+    // here so this pin keeps testing what it was written for — a healthy
+    // permission state, i.e. a genuine outage:
+    //   contains() answers, so the popup does not sit out its bounded wait;
+    //   fetch() RESOLVES, so the probe reads 'ok' rather than reaching for the
+    //   real network — an unstubbed jsdom fetch would make this suite's verdict
+    //   depend on whether the machine running it can see grabcaramel.com.
+    chromeStub.permissions.contains = (_perms: unknown, cb: any) => cb(true)
+    globalThis.fetch = () => Promise.resolve(new Response('{}'))
+
     chromeStub.runtime.sendMessage = (message: any, cb: any) => {
         if (message?.action === 'getActiveTabDomainRecord') {
             cb({ url: 'https://example.com/cart' })

--- a/apps/caramel-extension/wxt.config.ts
+++ b/apps/caramel-extension/wxt.config.ts
@@ -121,6 +121,20 @@ export default defineConfig({
                 ? ['tabs', 'activeTab', 'storage', 'alarms']
                 : ['tabs', 'activeTab', 'storage', 'identity', 'alarms'],
         host_permissions: ['https://*/*'],
+        // Declared for EVERY browser (2026-08-19). `host_permissions` above is
+        // what we ask for at install; this is what may be asked for AGAIN at
+        // runtime, which is what permission-state.js's requestAllSites() does
+        // for the population that ended up without it — Firefox auto-updates
+        // from <=1.0.3 kept only four old narrow host grants, and fresh
+        // installs can leave the box unchecked. The Gecko/WebExtensions
+        // contract is that request() may only name origins the manifest listed
+        // as optional, so spelling it out removes any question of whether the
+        // prompt can be raised at all. A legal no-op on Chrome/Edge, which
+        // already allow requesting a declared host_permission; listing it
+        // there too keeps one code path across all four browsers.
+        // `<all_urls>` rides along because that is the only pattern Safari
+        // accepts as "every website".
+        optional_host_permissions: ['https://*/*', '<all_urls>'],
         web_accessible_resources: [
             {
                 // popup.html is WXT's name for the popup page (was


### PR DESCRIPTION
Two user-facing extension bugs, shipped as 1.4.1.

**Permission dead-state (the trav1295 1-star / support-ticket bug).** With the every-website host grant missing (Firefox auto-updates from <=1.0.3 silently keep only the four old narrow grants; fresh installs can leave the box unchecked), the background fetch is refused by the browser and the popup painted "Couldn't load coupons — check your connection" over a perfectly good connection. The popup now probes reachability on failure (TypeError = blocked, everything else stays the network copy), renders a PermissionView whose button calls permissions.request synchronously from the click, and a working-but-narrow grant gets an advisory AllSitesBanner instead of a false error. background.js listens on permissions.onAdded so a grant made from the doorhanger heals the install even if Firefox tears the popup down. optional_host_permissions added for all browsers; Safari uses the <all_urls> spelling it requires.

**Loader off-centre.** .loading-container had no centering; the spinner sat top-left. Now flex-centred both axes; the one truly dead skeleton rule removed (skeleton/skeleton-ticket are live in CouponsView and pinned as such).

**Verified in real browsers (beyond the 887-test suite + 79/79 parity):**
- Real Firefox, broken-upgrade profile: zero-grant popup shows PermissionView (never the connection copy); legacy 4-grant state loads coupons AND shows the banner; full grant = clean popup; spinner measured dead-centre of the 420px container mid-boot.
- Real Firefox grant E2E: verified-zero grants -> click Enable Caramel -> real addon-webext-permissions doorhanger accepted -> grant recorded as https://*/* -> popup leaves the permission state.
- Real Chrome: fresh install loads coupons (no gate misfire); site access "On click" + store tab active shows PermissionView; banner appears on the idle view; test extension uninstalled after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)