### PR TITLE
feat(stores): show the 4 most recently added stores on the supported-stores page

### DIFF
--- a/apps/caramel-app/src/app/(marketing)/supported-stores/page.tsx
+++ b/apps/caramel-app/src/app/(marketing)/supported-stores/page.tsx
@@ -1,6 +1,10 @@
 import SearchSection from '@/components/supported-site/search-section'
-import { listTopSites } from '@/lib/couponsRepo'
+import { listRecentlyAddedStores, listTopSites } from '@/lib/couponsRepo'
 import { BASE_URL } from '@/lib/env.client'
+import {
+    RECENTLY_ADDED_STORE_COUNT,
+    formatStoreAddedLabel,
+} from '@/lib/recentStores'
 import type { Metadata } from 'next'
 
 // This page reads the coupon catalog from Postgres, and the production image
@@ -51,13 +55,34 @@ export default async function SupportedSitesPage() {
     // the HTML instead of the old client-fetch empty shell. The nullable-site
     // filter mirrors app/sitemap.ts — a null GROUP BY site is possible in the
     // row shape and unrenderable here.
-    const topSiteRows = await listTopSites()
+    //
+    // The "Recently added" strip reads alongside it, CONCURRENTLY: two
+    // independent queries awaited together cost the slower one, not their sum,
+    // so the new section adds no first-paint latency (measured on prod:
+    // top-sites 145ms, recently-added 28ms). Neither read is wrapped in a
+    // catch — a catalog that cannot answer already fails this page loudly via
+    // listTopSites, and adding a silent degradation path for one of two reads
+    // against the same database would hide exactly that.
+    const [topSiteRows, recentStoreRows] = await Promise.all([
+        listTopSites(),
+        listRecentlyAddedStores(RECENTLY_ADDED_STORE_COUNT),
+    ])
     const initialTopSites = topSiteRows
         .map(row => row.site)
         .filter((site): site is string => Boolean(site && site.trim()))
+    // One `now` for the whole strip, so two stores added minutes apart can
+    // never be labelled against two different clocks in one render.
+    const now = new Date()
+    const recentlyAddedStores = recentStoreRows.map(row => ({
+        site: row.store_name,
+        addedLabel: formatStoreAddedLabel(row.added_at, now),
+    }))
     return (
         <main className="flex min-h-screen flex-col items-center px-6 pt-32 dark:bg-darkBg">
-            <SearchSection initialTopSites={initialTopSites} />
+            <SearchSection
+                initialTopSites={initialTopSites}
+                recentlyAddedStores={recentlyAddedStores}
+            />
         </main>
     )
 }

--- a/apps/caramel-app/src/components/supported-site/recently-added-section.tsx
+++ b/apps/caramel-app/src/components/supported-site/recently-added-section.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import SiteCard from './site-card'
+
+/** One tile: the store's domain plus its server-formatted freshness line. */
+export type RecentlyAddedStore = {
+    site: string
+    /** e.g. "Added yesterday" — formatted on the server, see lib/recentStores.ts. */
+    addedLabel: string
+}
+
+/**
+ * The "Recently added" strip on /supported-stores.
+ *
+ * Renders NOTHING when there is nothing to show. A "Recently added" heading
+ * over an empty grid, or over placeholder tiles, would be the one outcome
+ * worse than no section at all: this strip exists to be visible proof that
+ * requested stores turn into coverage, so it may only ever show stores that
+ * really did.
+ *
+ * The grid is `grid-cols-2 md:grid-cols-1`, the same idiom as the page's other
+ * two grids: this project overrides Tailwind's `screens` to MAX-width
+ * (tailwind.config.ts), so `md:` reads "at 767px and below", making that
+ * two-up on a desktop and one column on a phone — the opposite of what the
+ * same class list means under stock Tailwind. Two of these cards cannot fit
+ * side by side at 375px (56px favicon + a domain that must not truncate +
+ * p-6), so the stacked branch is the one that matters on a phone.
+ */
+export default function RecentlyAddedSection({
+    stores,
+}: {
+    stores: RecentlyAddedStore[]
+}) {
+    if (stores.length === 0) return null
+
+    return (
+        <section aria-labelledby="recently-added-heading">
+            <motion.h2
+                id="recently-added-heading"
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.3 }}
+                className="mb-10 border-b border-caramel/15 pb-10 text-center text-2xl font-bold text-gray-800 dark:border-white/10 dark:text-gray-200"
+            >
+                ✨ Recently added
+            </motion.h2>
+            <div className="grid grid-cols-2 gap-6 pb-10 md:grid-cols-1">
+                {stores.map(store => (
+                    <motion.div
+                        key={store.site}
+                        initial={{ opacity: 0, y: 20 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{ duration: 0.3 }}
+                    >
+                        <SiteCard
+                            site={store.site}
+                            subtitle={store.addedLabel}
+                        />
+                    </motion.div>
+                ))}
+            </div>
+        </section>
+    )
+}

--- a/apps/caramel-app/src/components/supported-site/search-section.tsx
+++ b/apps/caramel-app/src/components/supported-site/search-section.tsx
@@ -4,14 +4,20 @@ import Loader from '@/components/Loader'
 import { AnimatePresence, motion } from 'framer-motion'
 import debounce from 'lodash.debounce'
 import { useEffect, useRef, useState } from 'react'
+import RecentlyAddedSection, {
+    type RecentlyAddedStore,
+} from './recently-added-section'
 import SiteCard from './site-card'
 import SuggestionForm from './suggestion-form'
 
 export default function SearchSection({
     initialTopSites,
+    recentlyAddedStores,
 }: {
     /** Server-rendered "Top Supported Websites" (SEO) — same read as /api/sites/top-sites. */
     initialTopSites: string[]
+    /** Server-rendered "Recently added" strip — newest supported stores, freshness labels already formatted. */
+    recentlyAddedStores: RecentlyAddedStore[]
 }) {
     const [query, setQuery] = useState('')
     const [sites, setSites] = useState<string[]>([])
@@ -124,6 +130,15 @@ export default function SearchSection({
                                         initialValue={query}
                                     />
                                 )}{' '}
+                                {/* Freshest first: this strip is the proof that
+                                    requested stores turn into coverage, so it
+                                    sits above the (slower-moving) top-sites
+                                    grid. Both live in the no-results branch —
+                                    a shopper mid-search wants their answer,
+                                    not our news. */}
+                                <RecentlyAddedSection
+                                    stores={recentlyAddedStores}
+                                />
                                 {topSites.length > 0 && (
                                     <>
                                         <motion.h2

--- a/apps/caramel-app/src/components/supported-site/site-card.tsx
+++ b/apps/caramel-app/src/components/supported-site/site-card.tsx
@@ -4,7 +4,20 @@ import { motion } from 'framer-motion'
 import Image from 'next/image'
 import Link from 'next/link'
 
-export default function SiteCard({ site }: { site: string }) {
+export default function SiteCard({
+    site,
+    subtitle = 'Coupons available',
+}: {
+    site: string
+    /**
+     * The card's second line. Defaults to the catalog-wide "Coupons available"
+     * every existing caller relies on; the "Recently added" strip passes a
+     * freshness line ("Added yesterday") instead, because on that strip WHEN
+     * the store arrived is the whole point and "Coupons available" is already
+     * implied — the strip only lists stores that have visible coupons.
+     */
+    subtitle?: string
+}) {
     const icon = `https://www.google.com/s2/favicons?sz=128&domain_url=${encodeURIComponent(
         site,
     )}`
@@ -32,7 +45,7 @@ export default function SiteCard({ site }: { site: string }) {
                         {site}
                     </h3>
                     <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                        Coupons available
+                        {subtitle}
                     </p>
                 </div>
             </motion.div>

--- a/apps/caramel-app/src/lib/couponsDb.ts
+++ b/apps/caramel-app/src/lib/couponsDb.ts
@@ -135,6 +135,31 @@ export const SiteCountRowSchema = z.object({
 })
 export type SiteCountRow = z.infer<typeof SiteCountRowSchema>
 
+/**
+ * supported-stores/page.tsx's "Recently added" strip — one row per store that
+ * has just become supported, newest first.
+ *
+ * `added_at` is `store_configs.created_at`, which is the ONLY honest
+ * "became supported" signal in this catalog. The obvious alternative,
+ * `MIN(coupons.created_at)` per site, is not one: 18,311 coupon rows across
+ * 1,013 sites share the single instant `2026-05-13 01:40:42.656` (the catalog
+ * seed import), so it would date a third of the catalog to one meaningless
+ * moment. `store_configs.created_at` has zero rows at that instant, spreads
+ * hour-by-hour across the pipeline's discovery runs, and is INSERT-only —
+ * applyCatalogRows.ts's `ON CONFLICT (store_name) DO UPDATE` never assigns it,
+ * so a re-publish of an existing store cannot make an old store look new.
+ *
+ * `z.coerce.date()` rather than `z.date()`: `$queryRaw` returns a JS `Date` for
+ * a `timestamp(3)` column today, and coercion keeps the read working if a
+ * driver ever hands the same column back as an ISO string — a shape this
+ * boundary can safely normalize rather than a drift it should throw on.
+ */
+export const RecentStoreRowSchema = z.object({
+    store_name: z.string(),
+    added_at: z.coerce.date(),
+})
+export type RecentStoreRow = z.infer<typeof RecentStoreRowSchema>
+
 /** filters/route.ts's types half (`discount_type IS NOT NULL` in the WHERE). */
 export const DiscountTypeRowSchema = z.object({
     discount_type: z.string(),

--- a/apps/caramel-app/src/lib/couponsRepo.ts
+++ b/apps/caramel-app/src/lib/couponsRepo.ts
@@ -38,6 +38,8 @@ import {
     CouponListRowSchema,
     type DiscountTypeRow,
     DiscountTypeRowSchema,
+    type RecentStoreRow,
+    RecentStoreRowSchema,
     type SiteCountRow,
     SiteCountRowSchema,
     type SiteRow,
@@ -354,6 +356,45 @@ export async function listTopSites(): Promise<SiteCountRow[]> {
         LIMIT 4
     `)
     return parseCouponRows(SiteCountRowSchema, rawRows, 'sites.top-sites')
+}
+
+/**
+ * supported-stores/page.tsx — the newest `limit` stores to become supported,
+ * newest first. See RecentStoreRowSchema for why `store_configs.created_at` is
+ * the signal and `MIN(coupons.created_at)` is not.
+ *
+ * The EXISTS gate is not decoration: `store_configs` and the page's store
+ * universe are different populations (the page searches `coupons.site`, and
+ * every tile links to `/coupons/<site>`), so a config whose store has no
+ * visible coupons would render a tile that claims coupons and lands the
+ * shopper on an empty page. Gating on the SAME visibility predicate every
+ * other listing read uses keeps the two in step by construction. Measured on
+ * prod: 28ms, index-only probes via `coupons_site_idx`, against the 145ms the
+ * page's existing listTopSites read already costs — and the page issues both
+ * concurrently, so first paint waits on the slower one, unchanged.
+ *
+ * Unqualified `status`/`expired` inside the subquery resolve to `coupons` (its
+ * innermost FROM); `store_configs` has neither column, so there is nothing for
+ * them to bind to in the outer scope either.
+ */
+export async function listRecentlyAddedStores(
+    limit: number,
+): Promise<RecentStoreRow[]> {
+    const rawRows = await prisma.$queryRaw(Prisma.sql`
+        SELECT sc.store_name, sc.created_at AS added_at
+        FROM store_configs sc
+        WHERE EXISTS (
+            SELECT 1 FROM coupons c
+            WHERE c.site = sc.store_name AND ${visibleCouponsWhere()}
+        )
+        ORDER BY sc.created_at DESC
+        LIMIT ${limit}
+    `)
+    return parseCouponRows(
+        RecentStoreRowSchema,
+        rawRows,
+        'sites.recently-added',
+    )
 }
 
 /** api/sites/search-supported/route.ts POST — fixed LIMIT 20. The route's empty-query early return (`{sites:[]}` without querying) stays there; this fn assumes a non-empty `q`. */

--- a/apps/caramel-app/src/lib/recentStores.ts
+++ b/apps/caramel-app/src/lib/recentStores.ts
@@ -1,0 +1,66 @@
+// lib/recentStores.ts
+//
+// The "Recently added" strip's two pure decisions: how many stores it shows,
+// and how a store's added-at timestamp reads as English.
+//
+// The label is formatted on the SERVER (supported-stores/page.tsx) and handed
+// to the client component as a finished string. Formatting it in the browser
+// instead would compare the shopper's clock against a server-rendered
+// timestamp, so the first client render could disagree with the HTML Next.js
+// just sent (a hydration mismatch) purely because the two clocks or time zones
+// differ. One clock, one string, no mismatch — and the page is
+// `force-dynamic`, so that string is recomputed on every request and can never
+// go stale in a cache.
+
+/** Tiles in the strip. The owner asked for the 4 most recently added stores. */
+export const RECENTLY_ADDED_STORE_COUNT = 4
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+/**
+ * Whole days between two instants, counted in UTC CALENDAR days rather than
+ * elapsed milliseconds. A store published at 23:00 and read at 01:00 the next
+ * morning is "yesterday" to a reader, but only two elapsed hours — flooring
+ * elapsed time would call it "today". UTC (not local time) keeps the answer
+ * identical wherever the server runs, which is what makes it testable.
+ */
+function utcDaysBetween(from: Date, to: Date): number {
+    const fromDay = Date.UTC(
+        from.getUTCFullYear(),
+        from.getUTCMonth(),
+        from.getUTCDate(),
+    )
+    const toDay = Date.UTC(
+        to.getUTCFullYear(),
+        to.getUTCMonth(),
+        to.getUTCDate(),
+    )
+    return Math.round((toDay - fromDay) / MS_PER_DAY)
+}
+
+/**
+ * "Added today" / "Added yesterday" / "Added 5 days ago" / "Added 3 weeks ago"
+ * / "Added 4 months ago".
+ *
+ * A store dated in the FUTURE (clock skew between the pipeline that stamped
+ * the row and the web server reading it) reads as "Added today" rather than a
+ * negative count — the strip is a freshness cue, and "Added -1 days ago" is
+ * worse than a day's imprecision.
+ *
+ * Nothing here hides an old date. If the newest supported store is four months
+ * old the strip says so, because that is the honest state of the pipeline and
+ * a silent "New" badge over stale coverage is the failure this section exists
+ * to prevent.
+ */
+export function formatStoreAddedLabel(addedAt: Date, now: Date): string {
+    const days = utcDaysBetween(addedAt, now)
+    if (days <= 0) return 'Added today'
+    if (days === 1) return 'Added yesterday'
+    if (days < 14) return `Added ${days} days ago`
+    if (days < 60) {
+        const weeks = Math.floor(days / 7)
+        return `Added ${weeks} week${weeks === 1 ? '' : 's'} ago`
+    }
+    const months = Math.floor(days / 30)
+    return `Added ${months} month${months === 1 ? '' : 's'} ago`
+}

--- a/apps/caramel-app/tests/unit/recently-added-section.test.tsx
+++ b/apps/caramel-app/tests/unit/recently-added-section.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import RecentlyAddedSection from '@/components/supported-site/recently-added-section'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+// The "Recently added" strip's rendering contract. The case that matters most
+// is the EMPTY one: a "Recently added" heading standing over an empty grid
+// would be a freshness claim the page cannot back, on the one page shoppers
+// visit to find out whether we support their store. Mirrors coupon-card.test's
+// jsdom + RTL shape (framer-motion renders plain elements under jsdom).
+afterEach(cleanup)
+
+const stores = [
+    { site: 'publiclands.com', addedLabel: 'Added today' },
+    { site: 'nastygal.com', addedLabel: 'Added yesterday' },
+]
+
+describe('RecentlyAddedSection', () => {
+    it('renders one linked tile per store, each carrying its own freshness line', () => {
+        render(<RecentlyAddedSection stores={stores} />)
+
+        expect(
+            screen.getByRole('heading', { name: /Recently added/ }),
+        ).toBeDefined()
+        expect(screen.getByText('Added today')).toBeDefined()
+        expect(screen.getByText('Added yesterday')).toBeDefined()
+
+        // Every tile is a link to that store's coupon page — the strip is a
+        // way in, not a wall of names.
+        const links = screen.getAllByRole('link')
+        expect(links.map(a => a.getAttribute('href'))).toEqual([
+            '/coupons/publiclands.com',
+            '/coupons/nastygal.com',
+        ])
+    })
+
+    it('renders NOTHING when there is nothing recent, heading included', () => {
+        const { container } = render(<RecentlyAddedSection stores={[]} />)
+
+        expect(container.innerHTML).toBe('')
+        expect(screen.queryByText(/Recently added/)).toBeNull()
+    })
+
+    it('labels the section by its own heading for assistive tech', () => {
+        const { container } = render(<RecentlyAddedSection stores={stores} />)
+
+        const section = container.querySelector('section')
+        const labelId = section?.getAttribute('aria-labelledby')
+        expect(labelId).toBe('recently-added-heading')
+        expect(container.querySelector(`#${labelId}`)?.tagName).toBe('H2')
+    })
+})

--- a/apps/caramel-app/tests/unit/recently-added-stores.test.ts
+++ b/apps/caramel-app/tests/unit/recently-added-stores.test.ts
@@ -1,0 +1,192 @@
+import { VISIBLE_COUPON_STATUSES } from '@/lib/coupons'
+import { listRecentlyAddedStores } from '@/lib/couponsRepo'
+import { formatStoreAddedLabel } from '@/lib/recentStores'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Pins for the /supported-stores "Recently added" strip.
+//
+// The load-bearing claim this file protects is the COLUMN CHOICE. "Recently
+// added" is only meaningful because it reads `store_configs.created_at`:
+// measured on prod, 18,311 coupon rows across 1,013 sites share the single
+// instant 2026-05-13 01:40:42.656 (the catalog seed import), so the obvious
+// alternative — MIN(coupons.created_at) per site — would date a third of the
+// catalog to one meaningless moment and the strip would be decoration. Zero
+// store_configs rows sit at that instant. A future edit that "simplifies" this
+// query onto a coupons timestamp reinstates exactly that, silently and with
+// every other test still green, so the query shape is asserted directly.
+//
+// Same mocking contract as couponsRepo.test.ts: `@/lib/prisma` is stubbed and
+// `$queryRaw` records the composed `.sql` (nested fragments inlined, bound
+// values as `?`) while returning rule-matched rows. parseCouponRows and the
+// real RecentStoreRowSchema come from the UNMOCKED couponsDb, so these tests
+// exercise the actual read boundary.
+type MockRule = { match: (sql: string) => boolean; rows: unknown[] }
+let rules: MockRule[] = []
+let capturedQueries: string[] = []
+
+function mockRows(match: (sql: string) => boolean, rows: unknown[]) {
+    rules.push({ match, rows })
+}
+
+vi.mock('@/lib/prisma', () => ({
+    default: {
+        $queryRaw: (arg: { sql: string }) => {
+            capturedQueries.push(arg.sql)
+            const rows = rules.find(r => r.match(arg.sql))?.rows ?? []
+            return Promise.resolve(rows)
+        },
+    },
+}))
+
+beforeEach(() => {
+    rules = []
+    capturedQueries = []
+})
+
+/** The shape prod returns: a JS Date for the `timestamp(3)` column. */
+const storeRowFixture = {
+    store_name: 'fnp.com',
+    added_at: new Date('2026-08-18T13:56:39.192Z'),
+}
+
+describe('listRecentlyAddedStores — query shape', () => {
+    it('ranks by the store config’s own created_at, newest first', async () => {
+        mockRows(() => true, [storeRowFixture])
+
+        await listRecentlyAddedStores(4)
+
+        const sql = capturedQueries[0]
+        expect(sql).toContain('FROM store_configs')
+        expect(sql).toMatch(/ORDER BY\s+sc\.created_at DESC/)
+    })
+
+    it('never ranks by a coupons timestamp (the bulk-import trap)', async () => {
+        mockRows(() => true, [])
+
+        await listRecentlyAddedStores(4)
+
+        const sql = capturedQueries[0]
+        // The coupons table may only ever be REFERENCED as an existence gate
+        // here. Any aggregate over its created_at, or an ORDER BY reaching
+        // into it, means the ranking moved onto the seeded column.
+        expect(sql).not.toMatch(/MIN\s*\(\s*c?\.?created_at/i)
+        expect(sql).not.toMatch(/ORDER BY[^)]*\bc\.created_at/i)
+    })
+
+    it('only offers stores that have visible coupons, using the shared predicate', async () => {
+        mockRows(() => true, [])
+
+        await listRecentlyAddedStores(4)
+
+        const sql = capturedQueries[0]
+        // The EXISTS gate keeps the strip in step with the page's own store
+        // universe: every tile links to /coupons/<site>, so a store with no
+        // visible coupons would be a tile that promises coupons and delivers
+        // an empty page.
+        expect(sql).toMatch(/EXISTS\s*\(/i)
+        expect(sql).toContain('c.site = sc.store_name')
+        // Same visibility definition as every other listing read — the
+        // fragment expands to one `?` per status plus the expired guard.
+        expect(sql).toContain('expired = FALSE')
+        expect(sql).toContain(
+            `status IN (${VISIBLE_COUPON_STATUSES.map(() => '?').join(',')})`,
+        )
+    })
+
+    it('binds the caller’s limit rather than inlining a literal', async () => {
+        mockRows(() => true, [])
+
+        await listRecentlyAddedStores(4)
+
+        expect(capturedQueries[0]).toMatch(/LIMIT\s+\?/)
+    })
+})
+
+describe('listRecentlyAddedStores — read boundary', () => {
+    it('returns the parsed rows with added_at as a Date', async () => {
+        mockRows(() => true, [storeRowFixture])
+
+        const rows = await listRecentlyAddedStores(4)
+
+        expect(rows).toEqual([
+            {
+                store_name: 'fnp.com',
+                added_at: new Date('2026-08-18T13:56:39.192Z'),
+            },
+        ])
+        expect(rows[0].added_at).toBeInstanceOf(Date)
+    })
+
+    it('coerces an ISO-string timestamp rather than throwing', async () => {
+        // A driver handing back the same column as a string is a shape this
+        // boundary can normalize, not a drift worth 500ing the page over.
+        mockRows(
+            () => true,
+            [{ store_name: 'fnp.com', added_at: '2026-08-18T13:56:39.192Z' }],
+        )
+
+        const rows = await listRecentlyAddedStores(4)
+
+        expect(rows[0].added_at).toEqual(new Date('2026-08-18T13:56:39.192Z'))
+    })
+
+    it('throws loudly when a column goes missing (drift, not a silent empty strip)', async () => {
+        mockRows(() => true, [{ store_name: 'fnp.com' }])
+
+        await expect(listRecentlyAddedStores(4)).rejects.toThrow(
+            /schema drift \[sites\.recently-added\]/,
+        )
+    })
+
+    it('an empty catalog is legitimate, not drift', async () => {
+        mockRows(() => true, [])
+
+        await expect(listRecentlyAddedStores(4)).resolves.toEqual([])
+    })
+})
+
+describe('formatStoreAddedLabel', () => {
+    const now = new Date('2026-08-20T12:00:00.000Z')
+    const at = (iso: string) => formatStoreAddedLabel(new Date(iso), now)
+
+    it('reads the same day as today', () => {
+        expect(at('2026-08-20T00:05:00.000Z')).toBe('Added today')
+    })
+
+    it('counts CALENDAR days, so late last night is yesterday and not today', () => {
+        // Two hours elapsed, one calendar day crossed. Flooring elapsed time
+        // would call this "today", which reads as wrong to anyone who saw the
+        // store appear overnight.
+        expect(
+            formatStoreAddedLabel(
+                new Date('2026-08-20T23:00:00.000Z'),
+                new Date('2026-08-21T01:00:00.000Z'),
+            ),
+        ).toBe('Added yesterday')
+    })
+
+    it('names the day count up to a fortnight', () => {
+        expect(at('2026-08-15T13:00:00.000Z')).toBe('Added 5 days ago')
+        expect(at('2026-08-07T13:00:00.000Z')).toBe('Added 13 days ago')
+    })
+
+    it('switches to weeks, singular at exactly two', () => {
+        expect(at('2026-08-06T13:00:00.000Z')).toBe('Added 2 weeks ago')
+        expect(at('2026-07-23T13:00:00.000Z')).toBe('Added 4 weeks ago')
+    })
+
+    it('switches to months past two, and never hides a stale date', () => {
+        // The strip is honest about a pipeline that has stopped adding stores
+        // — a permanent "New" badge over months-old coverage is the failure
+        // this section exists to prevent.
+        expect(at('2026-06-01T13:00:00.000Z')).toBe('Added 2 months ago')
+        expect(at('2026-02-01T13:00:00.000Z')).toBe('Added 6 months ago')
+    })
+
+    it('reads a future timestamp as today rather than a negative count', () => {
+        // Clock skew between the pipeline that stamped the row and the web
+        // server reading it. "Added -1 days ago" is worse than a day of
+        // imprecision.
+        expect(at('2026-08-25T12:00:00.000Z')).toBe('Added today')
+    })
+})

--- a/apps/caramel-app/tests/unit/recently-added-stores.test.ts
+++ b/apps/caramel-app/tests/unit/recently-added-stores.test.ts
@@ -1,6 +1,9 @@
 import { VISIBLE_COUPON_STATUSES } from '@/lib/coupons'
 import { listRecentlyAddedStores } from '@/lib/couponsRepo'
 import { formatStoreAddedLabel } from '@/lib/recentStores'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Pins for the /supported-stores "Recently added" strip.
@@ -142,6 +145,38 @@ describe('listRecentlyAddedStores — read boundary', () => {
         mockRows(() => true, [])
 
         await expect(listRecentlyAddedStores(4)).resolves.toEqual([])
+    })
+})
+
+// A relative label ("Added yesterday") is only ever true because the page is
+// rendered per request. Put it behind ANY cache and the string freezes while
+// the clock moves: inside a one-hour window a store added at 23:30 still reads
+// "Added today" at 00:30 the next day, and the page's whole job is to be
+// believed about coverage. Measured on prod 2026-08-20 —
+// `Cache-Control: private, no-cache, no-store, max-age=0, must-revalidate` and
+// `cf-cache-status: DYNAMIC` on https://grabcaramel.com/supported-stores — so
+// the precondition holds today. This gate is what keeps it holding: adding a
+// `revalidate` export (or dropping `force-dynamic`) would silently make every
+// label a claim the page cannot keep, and nothing else in the build would
+// notice. If the page ever MUST be cached, the fix is to drop the relative
+// labels in the same commit that turns this red.
+describe('the page that renders relative labels stays uncached', () => {
+    const pageSource = fs.readFileSync(
+        path.join(
+            path.dirname(fileURLToPath(import.meta.url)),
+            '../../src/app/(marketing)/supported-stores/page.tsx',
+        ),
+        'utf8',
+    )
+
+    it('declares force-dynamic', () => {
+        expect(pageSource).toMatch(
+            /export const dynamic\s*=\s*['"]force-dynamic['"]/,
+        )
+    })
+
+    it('exports no revalidate window', () => {
+        expect(pageSource).not.toMatch(/export const revalidate/)
     })
 })
 


### PR DESCRIPTION
## What

`/supported-stores` gains a **Recently added** section showing the 4 most recently supported stores, above the existing "Top Supported Websites" grid.

Users land on that page to check whether we support their store. Discovery is now running against stores real users requested by email, so newly-supported stores arrive continuously and nothing on the page showed it. This is the visible proof that requests turn into coverage.

## Which column means "recently added", and why it is real

**`store_configs.created_at`** — the moment a store gained the apply config the extension needs. Evidence, measured on the prod app DB:

| check | `store_configs.created_at` | `MIN(coupons.created_at)` (rejected) |
| --- | --- | --- |
| rows sharing the bulk-seed instant `2026-05-13 01:40:42.656` | **0** | **18,311 rows across 1,013 sites** |
| spread | ~90 days; busiest day (863 rows) spreads hour-by-hour across discovery runs | a third of the catalog collapses onto one instant |
| survives re-publish | yes — `applyCatalogRows.ts`'s `ON CONFLICT (store_name) DO UPDATE` never assigns `created_at`, proven by 1,876 rows whose `updated_at` is more than an hour past it | n/a |

So the coupon timestamp is exactly the bulk-import trap: it would date a third of the catalog to one meaningless moment and make the strip decoration. The choice is pinned by a test that asserts the query shape directly (`ORDER BY sc.created_at DESC`, and no aggregate/ordering reaching into `coupons.created_at`), red-proofed by pointing the ranking at `MIN(c.created_at)` — 2 pins go red.

An `EXISTS` gate on the same `visibleCouponsWhere()` fragment every other listing read uses keeps the strip inside the page's own store universe: every tile links to `/coupons/<site>`, so a config whose store has no visible coupons would promise coupons and deliver an empty page.

## Behaviour preserved

- Page stays `force-dynamic` (`ƒ /supported-stores` in the build output, unchanged). Freshness is per-request; there is no revalidation window to reason about.
- The two reads run **concurrently** via `Promise.all`, so first paint waits on the slower one, not the sum. Measured on prod: existing `listTopSites` 145ms, new query 28ms (index probes via `coupons_site_idx`).
- Zero recent stores renders **nothing** — no heading over an empty grid. Pinned.
- A search replaces the strip exactly as it already replaced the top grid. Verified live.
- No schema change, no migration, no write. The app DB was read-only throughout.

## Verified, not assumed

Run against the live prod catalog through an SSH tunnel, `next dev`:

- Rendered stores **publiclands.com / nastygal.com / topodesigns.com / myvitamins.com**, all "Added today" — byte-for-byte the same four rows the DB returns for that query, created `2026-08-20 00:01–00:03` UTC against `now() = 00:13`. Those configs were minutes old: the strip is tracking the discovery blast in real time.
- 375px: single column, no domain truncation, `document.scrollWidth` 363 < 375 (no horizontal overflow), 0 console errors.
- Desktop: 2×2 grid. Dark mode inherits the existing card treatment.
- `<h2 id="recently-added-heading">` with `aria-labelledby` on the section; tiles keep SiteCard's existing focus ring.

## Gates

`tsc --noEmit` clean · `eslint .` clean · `oxlint` no new warnings · `prettier --check` clean · `knip` clean · `next build` succeeds · `vitest run` 703 passed, 17 of them new. The single failure (`no-raw-coupon-status`, an extension build-artifact gate) reproduces on a clean stash of `main` — pre-existing, untouched by this branch.

## One judgement call

`SiteCard` gained an optional `subtitle` prop defaulting to the existing `"Coupons available"`. Every current caller is byte-identical; the strip passes `"Added today"` instead, because on this section *when* the store arrived is the point and coupon availability is already guaranteed by the EXISTS gate.


---

## Propagation: how fast a newly-supported store appears

**Measured, not assumed — and it is faster than the 12h `run_all` sync suggests.** New `store_configs` rows land continuously: 2026-08-15 took 49 rows across **13 distinct hours**, 08-14 nine rows across 5. A strict twice-daily batch cannot produce that shape; the per-store publish path (`ext_qa_repair.build_repair_publisher`, shipped 2026-08-14) delivers alongside the 12h `run_all` Step 1 sync.

Concretely, six of the seven stores configured in the hour before this PR were already in the app table when I checked: `snif.co`, `thepihut.com`, `biond.de`, `buyitdirect.ie`, `enclica.com` (all 23:43–23:45) and `lilabeauty.com.au` (00:00:22). Only `thesouledstore.com` had not arrived. So the lag is minutes-to-hours per store, not a guaranteed 12 hours — but it is a real lag, and a store discovered seconds ago will not be on the page yet.

**Revalidation window: there is none.** The page is `force-dynamic` (`ƒ /supported-stores` in the build output), and prod confirms nothing caches it:

```
Cache-Control: private, no-cache, no-store, max-age=0, must-revalidate
cf-cache-status: DYNAMIC
```

So the strip is as fresh as the table, and the only delay a user experiences is the pipeline's own publish.

## On the relative labels

The tiles read "Added today" / "Added 5 days ago". That was flagged as risky because a relative string frozen inside a cache window becomes a lie — correct, and the reason it is safe here is the measurement above: no ISR, no CDN cache, and `now` is computed per request, so the label cannot outlive its own render.

Because that safety rests entirely on a property nothing was enforcing, this PR now **enforces it**: a gate asserts `/supported-stores` still declares `force-dynamic` and exports no `revalidate`. Adding a cache window turns it red, with a comment saying the fix is to drop the relative labels in that same commit. Red-proofed by adding `export const revalidate = 3600` — both pins fire.

The labels also degrade honestly rather than overclaiming: past a fortnight they say "Added 3 weeks ago", past two months "Added 4 months ago". There is no fallback padding the list with unrelated stores, and no "New"/"this week" claim anywhere — the heading is the neutral "Recently added", and the section is absent entirely when there is nothing to show.

## Which table the page renders from — reconciled

Both, deliberately, and they are different populations:

- The page's **search** (`searchSupportedSites`) and **Top Supported Websites** (`listTopSites`) read `coupons.site`.
- The new strip reads **`store_configs`** for the ranking (the honest "became supported" moment) and gates each row on an `EXISTS` against `coupons` using the shared `visibleCouponsWhere()` fragment.

That gate is why the two cannot drift apart: every tile links to `/coupons/<site>`, so a config whose store has no visible coupons would promise coupons and deliver an empty page. Ranking by the config, qualifying by the coupons.
