### PR TITLE
fix(ext-probe): default to a loadable build instead of the pre-WXT path

### DIFF
--- a/apps/caramel-extension/tests/ext-probe-default-ext-dir.test.mjs
+++ b/apps/caramel-extension/tests/ext-probe-default-ext-dir.test.mjs
@@ -1,0 +1,113 @@
+// The probe's default extension directory must be a build it can actually load.
+//
+// The refusal suite next door (ext-probe-extension-required.test.mjs) pins the
+// other half: a probe that cannot load an extension never produces a verdict.
+// Both halves were true at once and that was the whole defect — the default
+// pointed at `apps/caramel-extension`, which the WXT migration left without a
+// manifest, so the gate fired correctly on every run nobody had set EXT_DIR
+// for. Measured 2026-08-19: ten discovery runs in one six-hour window took no
+// extension QA at all, and their configs were the best of the batch.
+//
+// Fake repo roots in a temp dir, never this checkout's own `.output`: that
+// directory is gitignored, so a suite that asserted against it would pass on a
+// developer's machine and be vacuous in CI.
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+    extBuildOutputs,
+    extensionLoadProblem,
+    legacyExtDir,
+    resolveDefaultExtDir,
+} from '../../../tools/ext-probe/ext-dir.mjs'
+
+function fakeRepo() {
+    return mkdtempSync(join(tmpdir(), 'ext-dir-root-'))
+}
+
+function build(
+    root,
+    name,
+    manifest = { manifest_version: 3, version: '9.9.9' },
+) {
+    const dir = join(root, 'apps', 'caramel-extension', '.output', name)
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, 'manifest.json'), JSON.stringify(manifest), 'utf8')
+    return dir
+}
+
+describe('the default extension directory prefers a loadable build', () => {
+    it('resolves to the production build when one exists', () => {
+        const root = fakeRepo()
+        const prod = build(root, 'chrome-mv3')
+
+        expect(resolveDefaultExtDir(root)).toBe(prod)
+        expect(extensionLoadProblem(resolveDefaultExtDir(root))).toBeNull()
+    })
+
+    it('prefers production over dev when both exist', () => {
+        // Not cosmetic: the dev build points at dev backends and carries the
+        // dev env stamp, so measuring it answers a question ext-QA never
+        // asked. A developer who ran `pnpm build:dev` last must still get the
+        // shopper's build by default.
+        const root = fakeRepo()
+        const prod = build(root, 'chrome-mv3')
+        const dev = build(root, 'chrome-mv3-dev')
+
+        expect(resolveDefaultExtDir(root)).toBe(prod)
+        expect(resolveDefaultExtDir(root)).not.toBe(dev)
+    })
+
+    it('falls back to the dev build when it is the only one built', () => {
+        const root = fakeRepo()
+        const dev = build(root, 'chrome-mv3-dev')
+
+        expect(resolveDefaultExtDir(root)).toBe(dev)
+    })
+
+    it('skips a build Chromium could not load and takes the next one', () => {
+        // The default is chosen by the same predicate as the launch gate, so a
+        // half-written production build cannot shadow a working dev build and
+        // turn into exit 71.
+        const root = fakeRepo()
+        build(root, 'chrome-mv3', { manifest_version: 3, name: 'no version' })
+        const dev = build(root, 'chrome-mv3-dev')
+
+        expect(resolveDefaultExtDir(root)).toBe(dev)
+    })
+
+    it('still yields an UNLOADABLE path when the checkout holds no build', () => {
+        // The refusal is not weakened: with nothing built, the default must
+        // remain something `assertLoadableExtension` rejects. Silently landing
+        // on a directory that merely exists is the empty-browser bug.
+        const root = fakeRepo()
+
+        const resolved = resolveDefaultExtDir(root)
+        expect(resolved).toBe(legacyExtDir(root))
+        expect(extensionLoadProblem(resolved)).toMatch(/no manifest\.json/)
+    })
+
+    it('names the broken build rather than an unbuilt directory', () => {
+        const root = fakeRepo()
+        const prod = build(root, 'chrome-mv3', { manifest_version: 3 })
+
+        const resolved = resolveDefaultExtDir(root)
+        expect(resolved).toBe(prod)
+        expect(extensionLoadProblem(resolved)).toMatch(/no version/i)
+    })
+
+    it('offers only chrome builds — Chromium cannot load the others', () => {
+        const root = fakeRepo()
+        build(root, 'firefox-mv3')
+        build(root, 'safari-mv2')
+
+        expect(extBuildOutputs(root).every(d => d.includes('chrome-mv3'))).toBe(
+            true,
+        )
+        // ...and a checkout holding ONLY those builds still refuses, instead
+        // of launching Chromium at an extension it cannot install.
+        const resolved = resolveDefaultExtDir(root)
+        expect(extensionLoadProblem(resolved)).not.toBeNull()
+    })
+})

--- a/tools/ext-probe/README.md
+++ b/tools/ext-probe/README.md
@@ -10,12 +10,13 @@ the vocabulary.
 
 ## Layout
 
-| File           | Role                                                                                                                                                         |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `probe.mjs`    | The driver. Launches Chromium, seeds a cart, watches the run, emits the report. Needs a browser.                                                             |
-| `verdict.mjs`  | The judgement. Pure — no browser, no filesystem. This is what the unit tests exercise.                                                                       |
-| `seed.mjs`     | The functions that run **inside** the page — platform detection, the per-platform seeders, the cart reader. Self-contained so Playwright can serialise them. |
-| `viewport.mjs` | Which viewport to measure at. Its own module because it is a policy, not a detail — see below.                                                               |
+| File           | Role                                                                                                                                                             |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `probe.mjs`    | The driver. Launches Chromium, seeds a cart, watches the run, emits the report. Needs a browser.                                                                 |
+| `verdict.mjs`  | The judgement. Pure — no browser, no filesystem. This is what the unit tests exercise.                                                                           |
+| `seed.mjs`     | The functions that run **inside** the page — platform detection, the per-platform seeders, the cart reader. Self-contained so Playwright can serialise them.     |
+| `viewport.mjs` | Which viewport to measure at. Its own module because it is a policy, not a detail — see below.                                                                   |
+| `ext-dir.mjs`  | Where a build lands and which one loads by default. The single owner of WXT's output layout for the probe; browser-free, so the default is pinned by unit tests. |
 
 ## Usage
 
@@ -23,20 +24,20 @@ the vocabulary.
 node tools/ext-probe/probe.mjs <url> [width] [tag] [flags]
 ```
 
-| Flag / env           | Default                  | Meaning                                                                                                                                                                                                                                              |
-| -------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `EXT_DIR`            | `apps/caramel-extension` | Which build to load. **Set it** — the WXT build lands in `apps/caramel-extension/.output/chrome-mv3`, and the default path no longer holds a manifest. A directory without a loadable `manifest.json` exits `71` before Chromium starts (see below). |
-| `PROBE_WAIT_MS`      | `30000`                  | How long a shopper waits before we call it a no-show.                                                                                                                                                                                                |
-| `PROBE_ALL_LOGS`     | unset                    | `1` keeps every console line, not just the Caramel-shaped ones.                                                                                                                                                                                      |
-| `--out <path>`       | stdout                   | Write the JSON report to a file instead of stdout. The report is persisted to `--out-dir` regardless.                                                                                                                                                |
-| `--out-dir <path>`   | `.ext-probe/`            | Where the full log, the JSON report, the screenshot and the disposable profile live.                                                                                                                                                                 |
-| `--expect-config`    | —                        | JSON file holding the config under test; enables the staleness compare.                                                                                                                                                                              |
-| `--good-code`        | —                        | A code expected to work — supplies GREEN evidence (6).                                                                                                                                                                                               |
-| `--invalid-code`     | —                        | A deliberately invalid code — the negative control, GREEN evidence (7).                                                                                                                                                                              |
-| `--viewport WxH`     | `1920x1080`              | The viewport to measure at, in the spelling `agent_discovery` uses. Authoritative when given.                                                                                                                                                        |
-| `--width`/`--height` | `1920` / class default   | Set individually. A width alone picks the conventional height for its class (`--width 390` → 390x844), so a mobile pass is one flag.                                                                                                                 |
-| `--tag`              | `probe`                  | Same as the positional form.                                                                                                                                                                                                                         |
-| `--platform-hint`    | —                        | `shopify`/`woocommerce`/`bigcommerce`. Orders the cart-API probe so the likely endpoint is asked first, and names the platform when markup found none. Never overrides markup. An unrecognised value **throws before Chromium starts**.              |
+| Flag / env           | Default                | Meaning                                                                                                                                                                                                                                                                            |
+| -------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `EXT_DIR`            | first loadable build   | Which build to load; always wins when set. The default prefers `apps/caramel-extension/.output/chrome-mv3` (production — what a shopper gets), then `.output/chrome-mv3-dev`; with neither built it stays unloadable on purpose and exits `71` before Chromium starts (see below). |
+| `PROBE_WAIT_MS`      | `30000`                | How long a shopper waits before we call it a no-show.                                                                                                                                                                                                                              |
+| `PROBE_ALL_LOGS`     | unset                  | `1` keeps every console line, not just the Caramel-shaped ones.                                                                                                                                                                                                                    |
+| `--out <path>`       | stdout                 | Write the JSON report to a file instead of stdout. The report is persisted to `--out-dir` regardless.                                                                                                                                                                              |
+| `--out-dir <path>`   | `.ext-probe/`          | Where the full log, the JSON report, the screenshot and the disposable profile live.                                                                                                                                                                                               |
+| `--expect-config`    | —                      | JSON file holding the config under test; enables the staleness compare.                                                                                                                                                                                                            |
+| `--good-code`        | —                      | A code expected to work — supplies GREEN evidence (6).                                                                                                                                                                                                                             |
+| `--invalid-code`     | —                      | A deliberately invalid code — the negative control, GREEN evidence (7).                                                                                                                                                                                                            |
+| `--viewport WxH`     | `1920x1080`            | The viewport to measure at, in the spelling `agent_discovery` uses. Authoritative when given.                                                                                                                                                                                      |
+| `--width`/`--height` | `1920` / class default | Set individually. A width alone picks the conventional height for its class (`--width 390` → 390x844), so a mobile pass is one flag.                                                                                                                                               |
+| `--tag`              | `probe`                | Same as the positional form.                                                                                                                                                                                                                                                       |
+| `--platform-hint`    | —                      | `shopify`/`woocommerce`/`bigcommerce`. Orders the cart-API probe so the likely endpoint is asked first, and names the platform when markup found none. Never overrides markup. An unrecognised value **throws before Chromium starts**.                                            |
 
 Human prose goes to **stderr**; stdout carries the JSON object and nothing else. Three artifacts always
 land in `--out-dir`: `ext-probe-<tag>-<width>.log`, `.json` and `.png`. The **report is an artifact,
@@ -82,6 +83,12 @@ migration moved the build to `.output/chrome-mv3`: days of ext-QA verdicts were 
 empty browser, and the only tell in the whole report was `vnull` in the log header. **A probe that
 cannot load the extension must never produce a verdict**, so the check runs before Chromium is
 launched and the report carries no observation at all.
+
+The gate then produced the opposite failure, because the default still pointed at the pre-WXT path
+while the code knew where a build lands well enough to NAME it in the refusal: every caller that did
+not set `EXT_DIR` got `71` and no verdict — ten discovery runs in one six-hour window on 2026-08-19,
+whose configs were the best of that batch. The default now prefers a loadable build (`ext-dir.mjs`,
+production first) and the refusal is untouched: a checkout with nothing built still exits `71`.
 
 Verdicts are evaluated **first match wins**, in the order listed in `VERDICTS`. `INCONCLUSIVE_SEED`
 is checked before everything else on purpose: an empty cart is not a checkout, so the extension

--- a/tools/ext-probe/ext-dir.mjs
+++ b/tools/ext-probe/ext-dir.mjs
@@ -1,0 +1,87 @@
+// Where a build actually lands, and which one the probe loads when nobody says.
+//
+// Browser-free on purpose (like verdict.mjs): which directory holds a loadable
+// extension is a fact about the checkout, not about a run, so it can be pinned
+// without launching Chromium.
+//
+// This module is the ONE owner of WXT's output layout for the probe. The probe
+// used to default at `apps/caramel-extension` — the pre-WXT layout, which has
+// held no manifest since the migration — while knowing perfectly well where a
+// build lands: it carried those paths already, but only to make the refusal
+// message name a real directory instead of shrugging. So it refused to default
+// to the very build it was naming, and every caller that did not set EXT_DIR
+// got exit 71 and no verdict at all. Measured 2026-08-19: ten discovery runs in
+// one six-hour window took no extension QA whatsoever, and the configs that
+// went unmeasured were the best of the batch.
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * WXT's chrome build outputs, best first.
+ *
+ * Production before dev, always. The probe exists to measure what a real
+ * shopper gets: the dev build points at dev backends and carries a different
+ * env stamp (`verbose:!0`, the tell the served-from-api suite reads), so
+ * loading it would answer a question ext-QA is not asking. It stays a
+ * candidate only because a checkout that has `pnpm build:dev`'d and nothing
+ * else still measures the extension rather than an empty browser.
+ *
+ * Chrome only: the probe launches Playwright's Chromium, so `.output/firefox-*`
+ * and `.output/safari-*` are deliberately absent — Chromium cannot load them,
+ * and listing them would turn a refusal into a launch failure.
+ */
+export function extBuildOutputs(repoRoot) {
+    const output = join(repoRoot, 'apps', 'caramel-extension', '.output')
+    return [join(output, 'chrome-mv3'), join(output, 'chrome-mv3-dev')]
+}
+
+/**
+ * The pre-WXT layout. Last resort as a default, and the path the refusal names
+ * when the checkout holds nothing loadable at all — an operator recognises it,
+ * and "no manifest.json in apps/caramel-extension" is the message that made
+ * this whole class of failure legible in the first place.
+ */
+export function legacyExtDir(repoRoot) {
+    return join(repoRoot, 'apps', 'caramel-extension')
+}
+
+/**
+ * Why Chromium could not load `dir` as an unpacked extension, or null when it
+ * can. Kept here so the default RESOLUTION and the launch-time REFUSAL apply
+ * one predicate: a default chosen by a laxer rule than the gate that follows
+ * it would hand the gate a directory it is about to reject.
+ */
+export function extensionLoadProblem(dir) {
+    const manifestPath = join(dir, 'manifest.json')
+    if (!existsSync(manifestPath)) return `no manifest.json in ${dir}`
+    // A manifest Chromium cannot parse loads exactly as well as no manifest at
+    // all, and produces the same empty browser.
+    try {
+        const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+        if (!manifest.version)
+            return `${manifestPath} carries no version — Chromium refuses a manifest without one`
+    } catch (e) {
+        return `${manifestPath} is not parseable JSON: ${e.message}`
+    }
+    return null
+}
+
+/**
+ * The directory the probe loads when no EXT_DIR / --ext was given.
+ *
+ * Prefers a build it can actually load, in the order above. When none is
+ * loadable it still returns a path — refusing is the caller's job
+ * (`assertLoadableExtension`), and this must never silently succeed. It picks
+ * the most informative one: a candidate that HAS a manifest explains why that
+ * build is unusable (unparseable, versionless), which beats reporting the
+ * absence of a manifest somewhere the operator never built.
+ */
+export function resolveDefaultExtDir(repoRoot) {
+    const candidates = [...extBuildOutputs(repoRoot), legacyExtDir(repoRoot)]
+    const loadable = candidates.find(dir => extensionLoadProblem(dir) === null)
+    if (loadable) return loadable
+    const present = candidates.find(dir =>
+        existsSync(join(dir, 'manifest.json')),
+    )
+    return present || legacyExtDir(repoRoot)
+}

--- a/tools/ext-probe/probe.mjs
+++ b/tools/ext-probe/probe.mjs
@@ -24,6 +24,11 @@ import { dirname, join, relative, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { chromium } from 'playwright'
 import {
+    extBuildOutputs,
+    extensionLoadProblem,
+    resolveDefaultExtDir,
+} from './ext-dir.mjs'
+import {
     capabilityProbeOrder,
     CART_API_PROBES,
     countPromoInputsInPage,
@@ -52,13 +57,12 @@ import { resolveViewport } from './viewport.mjs'
 // anywhere else, which made the scratch version Windows-only.
 const HERE = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = resolve(HERE, '..', '..')
-const DEFAULT_EXT_DIR = join(REPO_ROOT, 'apps', 'caramel-extension')
-// Where a build actually lands. Only used to make the "you pointed me at a
-// directory with no manifest" message name a real path instead of a shrug.
-const BUILD_OUTPUT_HINTS = [
-    join(REPO_ROOT, 'apps', 'caramel-extension', '.output', 'chrome-mv3'),
-    join(REPO_ROOT, 'apps', 'caramel-extension', '.output', 'chrome-mv3-dev'),
-]
+// Where a build actually lands — and, since the default now prefers one, where
+// this probe loads from when nobody passes EXT_DIR. The layout itself lives in
+// ext-dir.mjs so it has exactly one owner (see the note there: knowing the
+// paths well enough to NAME them in an error while refusing to default to them
+// cost ten discovery runs their extension QA).
+const BUILD_OUTPUT_HINTS = extBuildOutputs(REPO_ROOT)
 
 // The extension's own cache key for the supported-domain list (store-detect.js).
 // Cleared before the run so the domain list is always fetched fresh: a verdict
@@ -157,26 +161,19 @@ class NoExtensionError extends Error {
  * thing — the prompt never appeared, no coupons were fetched, nothing was
  * submitted — which is indistinguishable from a genuinely broken store config.
  * That is exactly what happened after the WXT migration moved the build to
- * `.output/chrome-mv3` and left `apps/caramel-extension` (this file's default)
- * without a manifest: days of ext-QA verdicts were measurements of an empty
- * browser, and the single tell was `vnull` in the log header.
+ * `.output/chrome-mv3` and left `apps/caramel-extension` (this file's default
+ * until 2026-08-19) without a manifest: days of ext-QA verdicts were
+ * measurements of an empty browser, and the single tell was `vnull` in the log
+ * header.
+ *
+ * The gate is unchanged by the default now preferring a real build (ext-dir.mjs):
+ * a default is a guess, and a guess that turns out to be unloadable must still
+ * stop the run here rather than launch an empty browser.
  */
 function assertLoadableExtension(extDir) {
-    const manifestPath = join(extDir, 'manifest.json')
-    let problem = null
-    if (!existsSync(manifestPath)) {
-        problem = `no manifest.json in ${extDir}`
-    } else {
-        // A manifest Chromium cannot parse loads exactly as well as no
-        // manifest at all, and produces the same empty browser.
-        try {
-            const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
-            if (!manifest.version)
-                problem = `${manifestPath} carries no version — Chromium refuses a manifest without one`
-        } catch (e) {
-            problem = `${manifestPath} is not parseable JSON: ${e.message}`
-        }
-    }
+    // The same predicate the default resolution uses, so a default can never be
+    // chosen by a laxer rule than the gate standing immediately behind it.
+    const problem = extensionLoadProblem(extDir)
     if (!problem) return
     const built = BUILD_OUTPUT_HINTS.filter(dir =>
         existsSync(join(dir, 'manifest.json')),
@@ -185,7 +182,7 @@ function assertLoadableExtension(extDir) {
         [
             `${problem} — Chromium would have launched with NO extension,`,
             'and every verdict from that run would have been a measurement of an empty browser.',
-            'The WXT build lands in apps/caramel-extension/.output/chrome-mv3; point EXT_DIR (or --ext) at it.',
+            'The WXT build lands in apps/caramel-extension/.output/chrome-mv3, which is the default when it exists; build it, or point EXT_DIR (or --ext) at one.',
             built.length
                 ? `Loadable build(s) found here now: ${built.join(', ')}`
                 : 'No built extension found either — run `pnpm --filter caramel-extension build` first.',
@@ -271,7 +268,11 @@ async function main() {
     // failure as a fact about the store.
     const platformHint = normalizePlatformHint(flags['platform-hint'])
     const tag = flags.tag || tagArg || 'probe'
-    const extDir = resolve(process.env.EXT_DIR || flags.ext || DEFAULT_EXT_DIR)
+    // EXT_DIR (or --ext) always wins: it is the operator's override, and the
+    // default is only a best guess at which build is worth measuring.
+    const extDir = resolve(
+        process.env.EXT_DIR || flags.ext || resolveDefaultExtDir(REPO_ROOT),
+    )
     const waitMs = Number(process.env.PROBE_WAIT_MS || flags.wait || 30000)
     // The auto-apply flow only STARTS once the prompt renders (autoApply
     // defaults on) and then runs under its own wall-clock budget. Reading the


### PR DESCRIPTION
## The defect

`DEFAULT_EXT_DIR` resolved to `apps/caramel-extension` — the pre-WXT layout, which has held no `manifest.json` since the migration. `assertLoadableExtension` therefore refused, **correctly**, with `PROBE_NO_EXTENSION` / exit `71`, on every run where nobody set `EXT_DIR`.

The probe already knew where a build lands: it carried `BUILD_OUTPUT_HINTS` purely so the refusal message could name a real directory. It named the build it declined to default to.

Measured consequence: 10 discovery runs in one 6-hour window took no extension QA at all, and those configs were the best of the batch (agent-rated 85–100, persisted at 60–70 because "no evidence" correctly means "not proven working"). The penalty was right; the diagnosis was not.

## The fix

New leaf module `tools/ext-probe/ext-dir.mjs` — the **one** owner of WXT's output layout for the probe, browser-free like `verdict.mjs` so the default is pinned by unit tests instead of by launching Chromium.

Resolution order, best first:

1. `apps/caramel-extension/.output/chrome-mv3` — **production**. The probe measures what a real shopper gets; the dev build points at dev backends and carries the dev env stamp (`verbose:!0`, the tell `ext-probe-served-from-api` reads), so loading it answers a question ext-QA never asked.
2. `.output/chrome-mv3-dev` — only so a checkout that has `build:dev`'d and nothing else still measures the extension rather than an empty browser.
3. `apps/caramel-extension` — the historic default, last, and the path the refusal names when nothing is built.

Chrome only: the probe launches Playwright's Chromium, so `.output/firefox-*` / `.output/safari-*` are deliberately absent — listing them would turn a clean refusal into a launch failure.

Properties kept:

- **`EXT_DIR` / `--ext` still win** over any default — that override is in use as a stopgap right now.
- **The refusal is untouched.** A candidate is chosen by the *same* predicate the gate applies (`extensionLoadProblem`, extracted from `assertLoadableExtension` verbatim), so a default can never be picked by a laxer rule than the gate behind it. With nothing built, the default stays a path that fails the gate: still `71`, still with the hint.
- A build whose manifest is unparseable or versionless is **skipped**, not defaulted to — and when nothing is loadable, the returned path prefers a candidate that at least HAS a manifest, so the refusal explains why *that build* is unusable rather than reporting an absence somewhere nobody built.

## Proof

**Real resolution on the machine running discovery** (`C:\...\Github\caramel`, the checkout `ext_qa.py` shells out to):

```
resolved  : ...\apps\caramel-extension\.output\chrome-mv3
problem   : null
manifest  : Caramel - Trusted Honey Alternative 1.4.1 mv3
```

Against a checkout with nothing built it resolves to `apps/caramel-extension` and `extensionLoadProblem` returns `no manifest.json in …` — i.e. still exit `71`.

**The real probe, `EXT_DIR` unset**, against a deliberately unreachable URL:

```
ext-probe: Caramel - Trusted Honey Alternative v1.4.1 sha256:abe3ab2c…
ext-probe: …\apps\caramel-extension\.output\chrome-mv3
PROBE_EXIT=70   (PROBE_ERROR — the unreachable URL, not PROBE_NO_EXTENSION)
```

**A real store verdict, `EXT_DIR` unset** — the thing nobody had proven: `https://www.allbirds.com/cart` → seeded 1 item, prompt rendered at 4409ms, verdict `RED_NOT_DETECTED` (exit `20`) from build 1.4.1. A store-level verdict, which is what `71` had been replacing.

**Red-proof** of `tests/ext-probe-default-ext-dir.test.mjs` (7 pins, fake repo roots in tmp — never this checkout's gitignored `.output`, which would make the suite vacuous in CI):

- Restoring the pre-fix default (`return legacyExtDir(repoRoot)`) → **5 of 7 red**. The 2 that stay green are exactly the two pinning that the refusal is preserved, which the pre-fix code also did.
- Flipping the order to dev-first → **1 red**, `prefers production over dev when both exist`.

**Gates:** `vitest run` in `caramel-extension` 894/894 across 92 files (incl. the 7 new + the 5 existing refusal pins); root `prettier --check` clean; `oxlint` exit 0; `eslint` 0 errors; `type-check` clean; full husky pre-commit green.

## Reported, not changed

`.output/chrome-mv3` also appears in `apps/caramel-extension/scripts/{smoke-package,test-guards,test-extension,parity-harness}.mjs`, that package's `test:smoke` script, and the two extension workflows. Each of those names *its own required build target* (several deliberately want the dev stamp and build it if missing) — a different question from "which build should the probe measure", so they are left alone rather than folded into a shared resolver.